### PR TITLE
Use Docker for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 # No need to commit databases
 *.sqlite3
 
+# Javascript stuff
+node_modules
+reqs/static/js/bundle.js
+
+# Data
+*.csv
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,11 @@
-language: python
-sudo: false
-python: 3.5
-before_install:
-- nvm install node
-install:
-- pip install -r requirements_dev.txt
-- npm install
+language: generic
+sudo: required
+services:
+- docker
 script:
-- py.test
-- flake8
-- wget https://github.com/ombegov/policy-v2/raw/master/assets/Phase1_CombinedQA_AllPhase1_Nov21.csv
-- iconv -f Windows-1252 -t utf-8 Phase1_CombinedQA_AllPhase1_Nov21.csv > data.csv
-- python manage.py migrate
-- python manage.py import_reqs data.csv
-- webpack
+- make reqs/static/js/bundle.js
+- make pytest
+- make integration_tests
 deploy:
   edge: true
   provider: cloudfoundry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.5.2
+
+WORKDIR /code
+ENV PYTHONUNBUFFERED="1"
+EXPOSE 8000
+
+COPY ["requirements.txt", "requirements_dev.txt", "/code/"]
+
+RUN pip install -r requirements.txt
+
+COPY ["Makefile", "manage.py", "/code/"]
+COPY ["omb_eregs", "/code/omb_eregs"]
+COPY ["reqs", "/code/reqs"]
+COPY ["devops", "/code/devops"]
+
+ARG DEBUG=""
+RUN [ -z $DEBUG ] || pip install -r requirements_dev.txt
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,69 @@
+.PHONY: prod
+prod: reqs/static/js/bundle.js requirements.txt
+	docker-compose -f devops/prod-compose.yml up
+
+.PHONY: dev
+dev: reqs/static/js/bundle.js requirements_dev.txt
+	docker-compose -f devops/dev-compose.yml up
+
+.PHONY: rebuild
+rebuild: reqs/static/js/bundle.js requirements.txt requirements_dev.txt
+	docker-compose -f devops/dev-compose.yml build
+	docker-compose -f devops/prod-compose.yml build
+	docker-compose -f devops/piptools-compose.yml build
+
+.PHONY: createsuperuser
+createsuperuser: requirements.txt
+	docker-compose -f devops/prod-compose.yml run web ./devops/wait_for_db_then ./manage.py migrate
+	docker-compose -f devops/prod-compose.yml run web ./manage.py createsuperuser
+
+.PHONY: loaddata
+loaddata:
+	docker-compose -f devops/prod-compose.yml run web ./devops/wait_for_db_then make native_loaddata
+
+
+## Frontend files
+reqs/static/js/bundle.js: $(shell find reqs/static/js | grep -v bundle.js) package.json
+	docker run -it --rm -v `pwd`:/usr/src/app -w /usr/src/app node:6 npm install
+	docker run -it --rm -v `pwd`:/usr/src/app -w /usr/src/app node:6 ./node_modules/.bin/webpack
+
+
+## Pip-tools
+requirements_dev.txt: requirements.txt requirements_dev.in
+	docker-compose -f devops/piptools-compose.yml run compile --output-file requirements_dev.txt requirements_dev.in
+requirements.txt: requirements.in
+	docker-compose -f devops/piptools-compose.yml run compile --output-file requirements.txt requirements.in
+
+
+## Tests
+.PHONY: pytest
+pytest:
+	docker-compose -f devops/dev-compose.yml run web py.test
+	docker-compose -f devops/dev-compose.yml run web flake8
+
+.PHONY: integration_tests
+integration_tests: data.csv
+	docker-compose -f devops/integration-compose.yml run web
+	docker-compose -f devops/integration-compose.yml down
+
+
+## Commands which run in the container (Docker or Cloud.gov)
+.PHONY: prod_native
+prod_native:
+	./manage.py migrate --noinput
+	./manage.py collectstatic --noinput
+	gunicorn omb_eregs.wsgi:application -b 0.0.0.0:$(PORT)
+
+.PHONY: dev_native
+dev_native:
+	./manage.py migrate --noinput
+	./manage.py runserver 0.0.0.0:$(PORT)
+
+bad_encoding.csv:
+	wget https://github.com/ombegov/policy-v2/raw/master/assets/Phase1_CombinedQA_AllPhase1_Nov21.csv -O bad_encoding.csv
+data.csv: bad_encoding.csv
+	iconv -f Windows-1252 -t utf-8 bad_encoding.csv > data.csv
+.PHONY: loaddata_native
+loaddata_native: data.csv
+	./manage.py migrate --noinput
+	./manage.py import_reqs data.csv

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./run.sh
+web: make prod_native

--- a/README.md
+++ b/README.md
@@ -12,42 +12,23 @@ YouTube](https://www.youtube.com/playlist?list=PLd9b-GuOJ3nEJsDD5BZ5qlVkr9RZ0Piv
 ## Running
 
 ### Requirements
-This project assumes Python 3.5. Perhaps the easiest way to get this installed
-is through [pyenv](https://github.com/yyuu/pyenv):
 
-```bash
-curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
-pyenv update
-pyenv install 3.5.3
-pyenv shell 3.5.3   # will need to run this when opening a new shell, too
-```
-
-Once you have Python set up, you'll want to install the project's developer
-requirements:
-
-```bash
-pip install -r requirements_dev.txt
-```
-
-We use [`pip-tools`](https://github.com/nvie/pip-tools) to pin our
-dependencies. If adding a new requirement, you'll want to modify
-`requirements.in`, then run:
-
-```bash
-pip install pip-tools   # if you haven't already
-pip-compile --output-file requirements.txt requirements.in
-pip-compile --output-file requirements_dev.txt requirements_dev.in
-pip-sync requirements_dev.txt
-```
+We recommend using
+[Docker](https://www.docker.com/products/overview#install_the_platform), an
+open source container engine. If you haven't already please install Docker and
+[Docker-compose](https://docs.docker.com/compose/install/) (which is installed
+automatically with Docker on Windows and OS X). We'll also assume your
+environment has `make`.
 
 ### Admin
 
-Now that you have the libraries installed, let's run the admin.
+Let's start by adding an admin user.
 
 ```bash
-python manage.py migrate    # updates a local (sqlite) database
-python manage.py createsuperuser
-python manage.py runserver
+make createsuperuser
+# fill out information
+make
+# Ctrl-c to kill
 ```
 
 Then navigate to http://localhost:8000/admin/ and log in.
@@ -57,15 +38,25 @@ Then navigate to http://localhost:8000/admin/ and log in.
 Let's also load the requirements data from OMB:
 
 ```bash
-# Download the CSV
-wget https://github.com/ombegov/policy-v2/raw/master/assets/Phase1_CombinedQA_AllPhase1_Nov21.csv
-# Convert it to UTF-8
-iconv -f Windows-1252 -t utf-8 Phase1_CombinedQA_AllPhase1_Nov21.csv > data.csv
-python manage.py import_reqs data.csv
+make loaddata
 ```
 
 This may emit some warnings for improper input. The next time you visit the
 admin, you'll see it's populated.
+
+### Make commands
+
+* [Nothing]/`prod` - Build the app and run it in "production" mode on port
+  8000
+* `dev` - Build the app and run it in "development" mode on port 8000
+* `rebuild` - When modifying the requirements (both Python and Node), you'll
+  want to regenerate the Docker environment. `rebuild` does exactly that
+* `createsuperuser` - Creates a Django admin user (asks you for information at
+  the command line)
+* `loaddata` - Fetches the CSV from OMB's dataset and imports it
+* `pytest` - Run py.test (Python) tests
+* `integration_tests` - Using an empty database, try to load the data and
+  check for any explosions
 
 ## Documentation and contributing
 

--- a/devops/dev-compose.yml
+++ b/devops/dev-compose.yml
@@ -1,0 +1,26 @@
+version: '2'
+services:
+  database:
+    image: postgres:9.4
+    volumes:
+      - database:/data/postgres
+  web:
+    image: omb-eregs:debug
+    build:
+      context: ..
+      args:
+        DEBUG: "true"
+    ports:
+      - "8000:8000"
+    environment:
+      - DATABASE_URL=postgres://postgres@database/postgres
+      - PORT=8000
+      - DJANGO_SETTINGS_MODULE=omb_eregs.settings
+    command: ./devops/wait_for_db_then make dev_native
+    volumes:
+      - $PWD:/code    # override to source the current directory
+    depends_on:
+      - database
+volumes:
+  database:
+

--- a/devops/integration-compose.yml
+++ b/devops/integration-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+  database:
+    image: postgres:9.4
+  web:
+    image: omb-eregs:debug
+    build:
+      context: ..
+      args:
+        DEBUG: "true"
+    command: ./devops/wait_for_db_then make loaddata_native
+    environment:
+      - DATABASE_URL=postgres://postgres@database/postgres
+      - DJANGO_SETTINGS_MODULE=omb_eregs.settings
+    volumes:
+      - $PWD:/code    # override to source the current directory
+    depends_on:
+      - database

--- a/devops/piptools-compose.yml
+++ b/devops/piptools-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  compile:
+    image: pip-tools:1.8.0
+    build:
+      context: .
+      dockerfile: piptools.Dockerfile
+    volumes:
+      - $PWD:/code

--- a/devops/piptools.Dockerfile
+++ b/devops/piptools.Dockerfile
@@ -1,0 +1,9 @@
+# Install pip-tools to a container so that we can run pip-compile
+FROM python:3.5.2
+
+WORKDIR /code
+ENV PYTHONUNBUFFERED="1"
+
+RUN pip install pip-tools==1.8.0
+
+ENTRYPOINT ["pip-compile"]

--- a/devops/prod-compose.yml
+++ b/devops/prod-compose.yml
@@ -1,0 +1,24 @@
+version: '2'
+services:
+  database:
+    image: postgres:9.4
+    volumes:
+      - database:/data/postgres
+  web:
+    image: omb-eregs:prod
+    build:
+      context: ..
+    ports:
+      - "8000:8000"
+    environment:
+      - DATABASE_URL=postgres://postgres@database/postgres
+      - PORT=8000
+      - DJANGO_SETTINGS_MODULE=omb_eregs.settings_prod
+      - TMPDIR=/tmp
+    command: ./devops/wait_for_db_then make prod_native
+    volumes:
+      - $PWD:/code    # override to source the current directory
+    depends_on:
+      - database
+volumes:
+  database:

--- a/devops/wait_for_db_then
+++ b/devops/wait_for_db_then
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+until (echo 2>/dev/null > /dev/tcp/database/5432)
+do
+  echo "Startup: Waiting for Postgres"
+  sleep 1
+done
+
+exec "$@"

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-./manage.py migrate --noinput
-./manage.py collectstatic --noinput
-gunicorn omb_eregs.wsgi:application


### PR DESCRIPTION
This tries to standardize development using docker by using it to contain all of the Python and JS environment. It also introduces a make file (which should be executable on Linux and OS X without issue) as the command center for the app.

There's a lot of boiler plate here (notably, the docker-compose files) that we can probably clean up and no doubt some edge cases I missed. That said, I could get the app running in one command on OSX (without Node/Python/Postgres configured) and have imported data and an admin user with one command a piece.