### PR TITLE
Use Docker for local development (take 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 # No need to commit databases
 *.sqlite3
 
+# Javascript stuff
+node_modules
+reqs/static/js/bundle.js
+
+# Data
+*.csv
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
-language: python
-sudo: false
-python: 3.5
-before_install:
-- nvm install node
-install:
-- pip install -r requirements_dev.txt
-- npm install
+language: generic
+sudo: required
+services:
+- docker
 script:
-- py.test
-- flake8
-- wget https://github.com/ombegov/policy-v2/raw/master/assets/Phase1_CombinedQA_AllPhase1_Nov21.csv
-- iconv -f Windows-1252 -t utf-8 Phase1_CombinedQA_AllPhase1_Nov21.csv > data.csv
-- python manage.py migrate
-- python manage.py import_reqs data.csv
-- webpack
+# Smoke test for Node
+- docker-compose run npm install
+- docker-compose run webpack
+# Python tests and linting
+- docker-compose run py.test
+- docker-compose run flake8
+# Smoke test for loading data
+- docker-compose run manage.py migrate --noinput
+- docker-compose run manage.py fetch_csv
+- docker-compose run manage.py import_reqs data.csv
 deploy:
   edge: true
   provider: cloudfoundry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.5.2
+
+WORKDIR /code
+ENV PYTHONUNBUFFERED="1"
+EXPOSE 8000
+
+COPY ["requirements.txt", "requirements_dev.txt", "/code/"]
+
+RUN pip install -r requirements.txt
+
+COPY ["manage.py", "/code/"]
+COPY ["omb_eregs", "/code/omb_eregs"]
+COPY ["reqs", "/code/reqs"]
+COPY ["devops", "/code/devops"]
+
+ARG DEV_MODE=""
+RUN [ -z $DEV_MODE ] || ./devops/dev_mode_install.sh
+

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./run.sh
+web: ./devops/prod.sh

--- a/README.md
+++ b/README.md
@@ -12,42 +12,22 @@ YouTube](https://www.youtube.com/playlist?list=PLd9b-GuOJ3nEJsDD5BZ5qlVkr9RZ0Piv
 ## Running
 
 ### Requirements
-This project assumes Python 3.5. Perhaps the easiest way to get this installed
-is through [pyenv](https://github.com/yyuu/pyenv):
 
-```bash
-curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
-pyenv update
-pyenv install 3.5.3
-pyenv shell 3.5.3   # will need to run this when opening a new shell, too
-```
-
-Once you have Python set up, you'll want to install the project's developer
-requirements:
-
-```bash
-pip install -r requirements_dev.txt
-```
-
-We use [`pip-tools`](https://github.com/nvie/pip-tools) to pin our
-dependencies. If adding a new requirement, you'll want to modify
-`requirements.in`, then run:
-
-```bash
-pip install pip-tools   # if you haven't already
-pip-compile --output-file requirements.txt requirements.in
-pip-compile --output-file requirements_dev.txt requirements_dev.in
-pip-sync requirements_dev.txt
-```
+We recommend using
+[Docker](https://www.docker.com/products/overview#install_the_platform), an
+open source container engine. If you haven't already please install Docker and
+[Docker-compose](https://docs.docker.com/compose/install/) (which is installed
+automatically with Docker on Windows and OS X).
 
 ### Admin
 
-Now that you have the libraries installed, let's run the admin.
+Let's start by adding an admin user.
 
 ```bash
-python manage.py migrate    # updates a local (sqlite) database
-python manage.py createsuperuser
-python manage.py runserver
+docker-compose run manage.py createsuperuser
+# fill out information
+docker-compose up prod
+# Ctrl-c to kill
 ```
 
 Then navigate to http://localhost:8000/admin/ and log in.
@@ -57,15 +37,29 @@ Then navigate to http://localhost:8000/admin/ and log in.
 Let's also load the requirements data from OMB:
 
 ```bash
-# Download the CSV
-wget https://github.com/ombegov/policy-v2/raw/master/assets/Phase1_CombinedQA_AllPhase1_Nov21.csv
-# Convert it to UTF-8
-iconv -f Windows-1252 -t utf-8 Phase1_CombinedQA_AllPhase1_Nov21.csv > data.csv
-python manage.py import_reqs data.csv
+docker-compose run manage.py fetch_csv
+docker-compose run manage.py import_reqs data.csv
 ```
 
 This may emit some warnings for improper input. The next time you visit the
 admin, you'll see it's populated.
+
+### Docker-compose commands
+
+There are two types of entry points:
+
+1. Services which will run until you press `ctrl-c`. These are activated via
+  `docker-compose up`
+  * `prod` - Build the app and run it in "production" mode on port 8000
+  * `dev` - Build the app and run it in "development" mode on port 8000
+1. One use commands which run until complete. These are ran via
+  `docker-compose run`
+  * `manage.py`
+  * `py.test`
+  * `flake8`
+  * `pip-compile`
+  * `npm`
+  * `webpack`
 
 ## Documentation and contributing
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ automatically with Docker on Windows and OS X).
 Let's start by adding an admin user.
 
 ```bash
+docker-compose run manage.py migrate  # set up database
 docker-compose run manage.py createsuperuser
-# fill out information
+# [fill out information]
 docker-compose up prod
 # Ctrl-c to kill
 ```

--- a/devops/dev.sh
+++ b/devops/dev.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./manage.py migrate --noinput
+./manage.py runserver 0.0.0.0:$PORT

--- a/devops/dev_mode_install.sh
+++ b/devops/dev_mode_install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pip install -r requirements_dev.txt
+pip install pip-tools==1.8.0

--- a/devops/prod.sh
+++ b/devops/prod.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./manage.py migrate --noinput
+./manage.py collectstatic --noinput
+gunicorn omb_eregs.wsgi:application -b 0.0.0.0:$PORT

--- a/devops/wait_for_db_then
+++ b/devops/wait_for_db_then
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+until (echo 2>/dev/null > /dev/tcp/persistent_db/5432)
+do
+  echo "Startup: Waiting for Postgres"
+  sleep 1
+done
+
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       context: .
       args:
         DEV_MODE: "true"
-    command: ./devops/wait_for_db_then ./devops/prod.sh
+    command: ./devops/wait_for_db_then ./devops/dev.sh
     environment:
       <<: *WEB_ENV
       DJANGO_SETTINGS_MODULE: omb_eregs.settings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,75 @@
+version: '2'
+services:
+  persistent_db:
+    image: postgres:9.4
+    volumes:
+      - database_data:/data/postgres
+
+  prod: &PROD_BASE
+    image: omb-eregs:prod
+    build:
+      context: .
+    command: ./devops/wait_for_db_then ./devops/prod.sh
+    ports:
+      - "8000:8000"
+    environment: &WEB_ENV
+      DATABASE_URL: postgres://postgres@persistent_db/postgres
+      PORT: 8000
+      DJANGO_SETTINGS_MODULE: omb_eregs.settings_prod
+      TMPDIR: /tmp
+    volumes:
+      - $PWD:/code    # override to source the current directory
+    depends_on:
+      - persistent_db
+    stdin_open: true
+    tty: true
+
+  dev:  &DEV_BASE
+    <<: *PROD_BASE
+    image: omb-eregs:debug
+    build:
+      context: .
+      args:
+        DEV_MODE: "true"
+    command: ./devops/wait_for_db_then ./devops/prod.sh
+    environment:
+      <<: *WEB_ENV
+      DJANGO_SETTINGS_MODULE: omb_eregs.settings
+
+  #---- Commands ----
+  manage.py:
+    <<: *PROD_BASE
+    entrypoint: ./devops/wait_for_db_then ./manage.py
+    command: ''
+
+  py.test:
+    <<: *DEV_BASE
+    entrypoint: ./devops/wait_for_db_then py.test
+    command: ''
+
+  flake8:
+    <<: *DEV_BASE
+    entrypoint: flake8
+    depends_on: []
+    command: ''
+
+  pip-compile:
+    <<: *DEV_BASE
+    entrypoint: pip-compile
+    depends_on: []
+    command: ''
+
+  npm: &NODE_BASE
+    image: node:6
+    volumes:
+      - $PWD:/usr/src/app
+    working_dir: /usr/src/app
+    entrypoint: npm
+
+  webpack:
+    <<: *NODE_BASE
+    entrypoint: ./node_modules/.bin/webpack
+
+
+volumes:
+  database_data:

--- a/omb_eregs/settings_prod.py
+++ b/omb_eregs/settings_prod.py
@@ -3,4 +3,4 @@ from cfenv import AppEnv
 from .settings import *     # noqa
 
 DEBUG = False
-ALLOWED_HOSTS = ['localhost'] + AppEnv().uris
+ALLOWED_HOSTS = ['localhost', '0.0.0.0', '127.0.0.1'] + AppEnv().uris

--- a/reqs/management/commands/fetch_csv.py
+++ b/reqs/management/commands/fetch_csv.py
@@ -1,0 +1,23 @@
+import logging
+import os
+
+import requests
+from django.core.management.base import BaseCommand
+
+logger = logging.getLogger(__name__)
+CSV_URL = ("https://github.com/ombegov/policy-v2/raw/master/assets/"
+           "Phase1_CombinedQA_AllPhase1_Nov21.csv")
+FILENAME = 'data.csv'
+
+
+class Command(BaseCommand):
+    help = "Fetch CSV data from OMB's GitHub"   # noqa
+
+    def handle(self, *args, **options):
+        if not os.path.isfile(FILENAME):
+            response = requests.get(CSV_URL).content
+            response_str = response.decode('cp1252')
+            with open(FILENAME, 'w') as data_csv:
+                data_csv.write(response_str)
+        else:
+            logger.warning("%s already exists, skipping.", FILENAME)

--- a/requirements.in
+++ b/requirements.in
@@ -5,4 +5,5 @@ django-taggit-autosuggest
 dj-database-url
 gunicorn
 psycopg2
+requests
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,11 @@ cfenv==0.5.2
 dj-database-url==0.4.2
 django-taggit-autosuggest==0.3.0
 django-taggit==0.22.0
-django==1.10.5
+Django==1.10.5
 furl==0.5.6               # via cfenv
 gunicorn==19.6.0
 orderedmultidict==0.7.11  # via furl
 psycopg2==2.6.2
+requests==2.13.0
 six==1.10.0               # via furl, orderedmultidict
 whitenoise==3.3.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ coverage==4.3.4           # via pytest-cov
 dj-database-url==0.4.2
 django-taggit-autosuggest==0.3.0
 django-taggit==0.22.0
-django==1.10.5
+Django==1.10.5
 flake8-bugbear==16.12.2
 flake8-builtins==0.2
 flake8-comprehensions==1.2.1
@@ -21,24 +21,26 @@ flake8-polyfill==1.0.1    # via flake8-isort
 flake8-print==2.0.2
 flake8-string-format==0.2.3
 flake8-tuple==0.2.12
-flake8==3.2.1
+flake8==3.3.0
 furl==0.5.6
 gunicorn==19.6.0
 isort==4.2.5              # via flake8-isort
-jedi==0.9.0
-mccabe==0.5.3             # via flake8
+jedi==0.10.0
+mccabe==0.6.1             # via flake8
 orderedmultidict==0.7.11
 packaging==16.8           # via setuptools
 pep8-naming==0.4.1
 psycopg2==2.6.2
 py==1.4.32                # via pytest
-pycodestyle==2.2.0        # via flake8
-pyflakes==1.3.0           # via flake8
+pycodestyle==2.3.1        # via flake8
+pyflakes==1.5.0           # via flake8
+pyparsing==2.1.10         # via packaging
 pytest-cov==2.4.0
 pytest-django==3.1.2
 pytest==3.0.6
+requests==2.13.0
 six==1.10.0
-testfixtures==4.13.3      # via flake8-isort
+testfixtures==4.13.4      # via flake8-isort
 whitenoise==3.3.0
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-./manage.py migrate --noinput
-./manage.py collectstatic --noinput
-gunicorn omb_eregs.wsgi:application


### PR DESCRIPTION
This tries to standardize development using docker by using it to contain all of the Python and JS environment. The `docker-compose` command serves as the primary entry point to the app, with single-use "services" acting as commands. I don't think this is _too_ much of a pain (it's akin to running `bundle exec`) but I'd appreciate feedback. I can get the app running in one command on OSX (without Node/Python/Postgres configured), which is pretty awesome. Hypothetically, the same should apply on Windows.