### PR TITLE
Allow cross-origin API usage.

### DIFF
--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'reqs.apps.ReqsConfig',
     'taggit',
     'taggit_autosuggest',
+    'corsheaders',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -47,6 +48,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -55,6 +57,8 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+CORS_ORIGIN_ALLOW_ALL = True    # Big ol' TODO
 
 ROOT_URLCONF = 'omb_eregs.urls'
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
 cfenv
 Django>=1.10,<1.11
+django-cors-headers
 django-taggit
 django-taggit-autosuggest
 dj-database-url

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,10 @@
 #
 cfenv==0.5.2
 dj-database-url==0.4.2
+django-cors-headers==2.0.2
 django-taggit-autosuggest==0.3.0
 django-taggit==0.22.0
-Django==1.10.5
+django==1.10.5
 furl==0.5.6               # via cfenv
 gunicorn==19.6.0
 orderedmultidict==0.7.11  # via furl

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,9 +9,10 @@ attrs==16.3.0             # via flake8-bugbear
 cfenv==0.5.2
 coverage==4.3.4           # via pytest-cov
 dj-database-url==0.4.2
+django-cors-headers==2.0.2
 django-taggit-autosuggest==0.3.0
 django-taggit==0.22.0
-Django==1.10.5
+django==1.10.5
 flake8-bugbear==16.12.2
 flake8-builtins==0.2
 flake8-comprehensions==1.2.1


### PR DESCRIPTION
We'll want to replace this replace this with a more strict strategy once we
have a working API. In the mean time, open the flood gates to all.