### PR TITLE
Use cloud.gov structure for host + secret key.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,10 @@ services:
       PORT: 8001
       DJANGO_SETTINGS_MODULE: omb_eregs.settings_prod
       TMPDIR: /tmp
+      VCAP_APPLICATION: >
+        {"uris": ["localhost", "0.0.0.0", "127.0.0.1"]}
+      VCAP_SERVICES: >
+        {"config": [{"credentials": {"DJANGO_SECRET_KEY": "NotASecret"}}]}
     volumes:
       - $PWD:/code    # override to source the current directory
     depends_on:

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -8,6 +8,7 @@ applications:
     buildpack: python_buildpack
     services:
       - database  # aws-rds medium-psql
+      - config    # user-provided service w/ DJANGO_SECRET_KEY defined
     command: ./devops/prod_api.sh
     host: omb-eregs-api-demo
   - name: ui

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -9,6 +9,7 @@ applications:
     buildpack: python_buildpack
     services:
       - database  # aws-rds medium-psql
+      - config    # user-provided service w/ DJANGO_SECRET_KEY defined
     command: ./devops/prod_api.sh
     host: omb-eregs-api
   - name: ui

--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -13,7 +13,10 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 import os
 
 import dj_database_url
+from cfenv import AppEnv
 from django.utils.crypto import get_random_string
+
+env = AppEnv()
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -23,12 +26,12 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', get_random_string(50))
+SECRET_KEY = env.get_credential('DJANGO_SECRET_KEY', get_random_string(50))
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = env.uris
 
 
 # Application definition

--- a/omb_eregs/settings_prod.py
+++ b/omb_eregs/settings_prod.py
@@ -1,6 +1,3 @@
-from cfenv import AppEnv
-
 from .settings import *     # noqa
 
 DEBUG = False
-ALLOWED_HOSTS = ['localhost', '0.0.0.0', '127.0.0.1'] + AppEnv().uris


### PR DESCRIPTION
We'll be providing the DJANGO_SECRET_KEY via a cloud foundry user-provided
service, so mimic that in the Docker setup. Similarly, use the cloud.gov uris
variable instead of hard coding it into the settings file.

In the immediate, this resolves an issue in prod where a user'd be logged out roughly every other page view.