### PR TITLE
Add "dev" mode for UI; connect UI to local API

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "airbnb",
   "globals": {
-    "document": true
+    "document": true,
+    "window": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -38,11 +38,19 @@ Then navigate to http://localhost:8001/admin/ and log in.
 We can also start the UI server (which runs NodeJS) via:
 
 ```bash
-docker-compose up ui
+docker-compose up dev-ui
 # Ctrl-c to kill
 ```
 
 Then navigate to http://localhost:8000/
+
+This runs in development mode (including automatic JS recompilation). To run
+in prod mode, run
+
+```bash
+docker-compose run webpack  # to build the server JS
+docker-compose up prod-ui
+```
 
 ### Data
 
@@ -66,7 +74,9 @@ There are two types of entry points:
     port 8001
   * `dev-api` - Build the admin/API app and run it in "development" mode on
     port 8001
-  * `ui` - Build the UI app and run it on port 8000
+  * `dev-ui` - Build the UI app and run it "development" mode on port 8000
+  * `prod-ui` - Run the UI app in "production" mode on port 8000 (requires
+    JS be compiled already)
 1. One use commands which run until complete. These are ran via
   `docker-compose run`
   * `manage.py`

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Then navigate to http://localhost:8001/admin/ and log in.
 We can also start the UI server (which runs NodeJS) via:
 
 ```bash
-docker-compose up dev-ui
+docker-compose up dev
 # Ctrl-c to kill
 ```
 
@@ -49,7 +49,7 @@ in prod mode, run
 
 ```bash
 docker-compose run webpack  # to build the server JS
-docker-compose up prod-ui
+docker-compose up prod
 ```
 
 ### Data
@@ -74,9 +74,10 @@ There are two types of entry points:
     port 8001
   * `dev-api` - Build the admin/API app and run it in "development" mode on
     port 8001
-  * `dev-ui` - Build the UI app and run it "development" mode on port 8000
-  * `prod-ui` - Run the UI app in "production" mode on port 8000 (requires
-    JS be compiled already)
+  * `dev` - Build and run the UI and API app in "development" mode (port 8000
+    for UI, 8001 for API).
+  * `prod` - Run the UI and API apps in "production" mode (port 8000 for UI,
+    8001 for API). Note that this requires the JS be compiled already.
 1. One use commands which run until complete. These are ran via
   `docker-compose run`
   * `manage.py`

--- a/devops/dev_ui.sh
+++ b/devops/dev_ui.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Ensure we have _a_ build initially
+./node_modules/.bin/webpack
+# On file change, rebuild JS
+./node_modules/.bin/webpack --watch &
+# On server.js change, restart node server
+./node_modules/.bin/nodemon --watch ui-dist ui-dist/server.js

--- a/devops/ui_build_run.sh
+++ b/devops/ui_build_run.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-./node_modules/.bin/webpack
-node ui-dist/server.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,16 +3,16 @@ services:
   persistent_db:
     image: postgres:9.4
     volumes:
-      - database_data:/data/postgres
+      - database_data:/var/lib/postgresql/data
 
-  prod-api: &PROD_API_BASE
+  prod-api: &PROD_API
     image: omb-eregs:prod
     build:
       context: .
     command: ./devops/wait_for_db_then ./devops/prod_api.sh
     ports:
       - "8001:8001"
-    environment: &WEB_ENV
+    environment: &API_ENV
       DATABASE_URL: postgres://postgres@persistent_db/postgres
       PORT: 8001
       DJANGO_SETTINGS_MODULE: omb_eregs.settings_prod
@@ -28,8 +28,8 @@ services:
     stdin_open: true
     tty: true
 
-  dev-api:  &DEB_API_BASE
-    <<: *PROD_API_BASE
+  dev-api: &DEV_API
+    <<: *PROD_API
     image: omb-eregs:debug
     build:
       context: .
@@ -37,53 +37,61 @@ services:
         DEV_MODE: "true"
     command: ./devops/wait_for_db_then ./devops/dev_api.sh
     environment:
-      <<: *WEB_ENV
+      <<: *API_ENV
       DJANGO_SETTINGS_MODULE: omb_eregs.settings
 
-  ui:
+  prod-ui: &PROD_UI
     image: node:6
     volumes:
       - $PWD:/usr/src/app
     working_dir: /usr/src/app
-    command: ./devops/ui_build_run.sh
+    command: npm start
     ports:
       - "8000:8000"
-    environment:
+    environment: &UI_ENV
       PORT: 8000
+      NODE_ENV: production
+
+  dev-ui: &DEV_UI
+    <<: *PROD_UI
+    command: ./devops/dev_ui.sh
+    environment:
+      <<: *UI_ENV
+      NODE_ENV: ''
+
 
   #---- Commands ----
   manage.py:
-    <<: *PROD_API_BASE
+    <<: *PROD_API
     entrypoint: ./devops/wait_for_db_then ./manage.py
     command: ''
 
   py.test:
-    <<: *DEB_API_BASE
+    <<: *DEV_API
     entrypoint: ./devops/wait_for_db_then py.test
     command: ''
 
   flake8:
-    <<: *DEB_API_BASE
+    <<: *DEV_API
     entrypoint: flake8
     depends_on: []
     command: ''
 
   pip-compile:
-    <<: *DEB_API_BASE
+    <<: *DEV_API
     entrypoint: pip-compile
     depends_on: []
     command: ''
 
-  npm: &NODE_BASE
-    image: node:6
-    volumes:
-      - $PWD:/usr/src/app
-    working_dir: /usr/src/app
+  npm:
+    <<: *DEV_UI
     entrypoint: npm
+    command: ''
 
   webpack:
-    <<: *NODE_BASE
+    <<: *DEV_UI
     entrypoint: ./node_modules/.bin/webpack
+    command: ''
 
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       DJANGO_SETTINGS_MODULE: omb_eregs.settings_prod
       TMPDIR: /tmp
       VCAP_APPLICATION: >
-        {"uris": ["localhost", "0.0.0.0", "127.0.0.1"]}
+        {"uris": ["localhost", "0.0.0.0", "127.0.0.1", "prod-api", "dev-api"]}
       VCAP_SERVICES: >
         {"config": [{"credentials": {"DJANGO_SECRET_KEY": "NotASecret"}}]}
     volumes:
@@ -40,7 +40,7 @@ services:
       <<: *API_ENV
       DJANGO_SETTINGS_MODULE: omb_eregs.settings
 
-  prod-ui: &PROD_UI
+  prod: &PROD_UI
     image: node:6
     volumes:
       - $PWD:/usr/src/app
@@ -51,13 +51,19 @@ services:
     environment: &UI_ENV
       PORT: 8000
       NODE_ENV: production
+      API_URL: 'http://prod-api:8001/'
+    depends_on:
+      - prod-api
 
-  dev-ui: &DEV_UI
+  dev: &DEV_UI
     <<: *PROD_UI
     command: ./devops/dev_ui.sh
     environment:
       <<: *UI_ENV
       NODE_ENV: ''
+      API_URL: 'http://dev-api:8001/'
+    depends_on:
+      - dev-api
 
 
   #---- Commands ----

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,8 @@ services:
     environment: &UI_ENV
       PORT: 8000
       NODE_ENV: production
-      API_URL: 'http://prod-api:8001/'
+      INTERNAL_API: 'http://prod-api:8001/'
+      PUBLIC_API: 'http://0.0.0.0:8001/'
     depends_on:
       - prod-api
 
@@ -61,7 +62,8 @@ services:
     environment:
       <<: *UI_ENV
       NODE_ENV: ''
-      API_URL: 'http://dev-api:8001/'
+      INTERNAL_API: 'http://dev-api:8001/'
+      PUBLIC_API: 'http://0.0.0.0:8001/'
     depends_on:
       - dev-api
 

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -15,3 +15,5 @@ applications:
     buildpack: nodejs_buildpack
     command: node ui-dist/server.js
     host: omb-eregs-demo
+    env:
+      API_URL: https://omb-eregs-api-demo.app.cloud.gov/

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -16,4 +16,5 @@ applications:
     command: node ui-dist/server.js
     host: omb-eregs-demo
     env:
-      API_URL: https://omb-eregs-api-demo.app.cloud.gov/
+      INTERNAL_API: https://omb-eregs-api-demo.app.cloud.gov/
+      PUBLIC_API: https://omb-eregs-api-demo.app.cloud.gov/

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -17,4 +17,5 @@ applications:
     command: node ui-dist/server.js
     host: omb-eregs
     env:
-      API_URL: https://omb-eregs-api.app.cloud.gov/
+      INTERNAL_API: https://omb-eregs-api.app.cloud.gov/
+      PUBLIC_API: https://omb-eregs-api.app.cloud.gov/

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -16,3 +16,5 @@ applications:
     buildpack: nodejs_buildpack
     command: node ui-dist/server.js
     host: omb-eregs
+    env:
+      API_URL: https://omb-eregs-api.app.cloud.gov/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "webpack --config mywebpack.config.js"
+    "start": "node ui-dist/server.js"
   },
   "repository": {
     "type": "git",
@@ -31,6 +31,7 @@
     "eslint-plugin-react": "^6.9.0",
     "lodash.debounce": "^4.0.8",
     "node-sass": "^4.3.0",
+    "nodemon": "^1.11.0",
     "sass-loader": "^4.1.1",
     "style-loader": "^0.13.1",
     "webpack": "^2.2.0",

--- a/ui/browser.js
+++ b/ui/browser.js
@@ -1,5 +1,7 @@
-import ReactDOM from 'react-dom';
+import { Resolver } from 'react-resolver';
 
 import routes from './routes';
+import { setApiUrl } from './globals';
 
-ReactDOM.render(routes, document.getElementById('app'));
+setApiUrl(window.API_URL);
+Resolver.render(() => routes, document.getElementById('app'));

--- a/ui/components/keywords.jsx
+++ b/ui/components/keywords.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { resolve } from 'react-resolver';
 import { Link } from 'react-router';
 
+import { apiUrl } from '../globals';
+
 function Keyword(props) {
   return <li>{props.keyword}</li>;
 }
@@ -39,5 +41,5 @@ Keyword.propTypes = {
 
 export default resolve(
   'data',
-  () => axios.get('https://omb-eregs-api-demo.app.cloud.gov/keywords/').then(({ data }) => data),
+  () => axios.get(`${apiUrl()}keywords/`).then(({ data }) => data),
 )(Keywords);

--- a/ui/components/requirements.jsx
+++ b/ui/components/requirements.jsx
@@ -2,6 +2,8 @@ import axios from 'axios';
 import React from 'react';
 import { resolve } from 'react-resolver';
 
+import { apiUrl } from '../globals';
+
 function Requirement(props) {
   return <li>{props.req_id}: {props.req_text}</li>;
 }
@@ -49,5 +51,5 @@ Requirement.propTypes = {
 
 export default resolve(
   'data',
-  props => axios.get('https://omb-eregs-api-demo.app.cloud.gov/requirements/', { params: props.location.query }).then(({ data }) => data),
+  props => axios.get(`${apiUrl()}requirements/`, { params: props.location.query }).then(({ data }) => data),
 )(Requirements);

--- a/ui/globals.js
+++ b/ui/globals.js
@@ -1,0 +1,12 @@
+let staticApiUrl = null;
+
+export function setApiUrl(value) {
+  staticApiUrl = value;
+}
+
+export function apiUrl() {
+  if (staticApiUrl) {
+    return staticApiUrl;
+  }
+  throw new Error('API Url not set');
+}

--- a/ui/server.jsx
+++ b/ui/server.jsx
@@ -14,9 +14,8 @@ import { setApiUrl } from './globals';
 
 const app = express();
 const env = cfenv.getAppEnv();
-const apiFromEnv = process.env.API_URL;
 
-setApiUrl(apiFromEnv);
+setApiUrl(process.env.INTERNAL_API);
 app.use(morgan('combined'));
 app.use('/static', express.static(path.join('ui-dist', 'static')));
 
@@ -33,7 +32,7 @@ app.get('*', (req, res) => {
             <body>
               <div id="app">${renderToString(<Resolved />)}</div>
               <script>window.__REACT_RESOLVER_PAYLOAD__ = ${JSON.stringify(data)}</script>
-              <script>window.API_URL = "${apiFromEnv}";</script>
+              <script>window.API_URL = "${process.env.PUBLIC_API}";</script>
               <script src="/static/browser.js"></script>
             </body>
           </html>`);

--- a/ui/server.jsx
+++ b/ui/server.jsx
@@ -10,10 +10,13 @@ import { Resolver } from 'react-resolver';
 import { match, RouterContext } from 'react-router';
 
 import routes from './routes';
+import { setApiUrl } from './globals';
 
 const app = express();
 const env = cfenv.getAppEnv();
+const apiFromEnv = process.env.API_URL;
 
+setApiUrl(apiFromEnv);
 app.use(morgan('combined'));
 app.use('/static', express.static(path.join('ui-dist', 'static')));
 
@@ -30,6 +33,7 @@ app.get('*', (req, res) => {
             <body>
               <div id="app">${renderToString(<Resolved />)}</div>
               <script>window.__REACT_RESOLVER_PAYLOAD__ = ${JSON.stringify(data)}</script>
+              <script>window.API_URL = "${apiFromEnv}";</script>
               <script src="/static/browser.js"></script>
             </body>
           </html>`);


### PR DESCRIPTION
Dev mode for the UI (`docker-compose up dev`) will rebuild/restart the Node server. I wanted to get deeper into the hot module swapping, but hit my timebox.

This also connects the UI to the API (rather than calling out to the demo server); we'll need to merge this with the changes in #66. In that process, it should fix an issue where the database data was getting dropped on app shutdown.

There's a _little_ back tracking, but probably easiest to review changeset by changeset.