### PR TITLE
Add simple stylesheet support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^3.0.2",
     "eslint-plugin-react": "^6.9.0",
+    "extract-text-webpack-plugin": "^2.0.0",
     "lodash.debounce": "^4.0.8",
     "node-sass": "^4.3.0",
     "nodemon": "^1.11.0",

--- a/ui/components/requirements.jsx
+++ b/ui/components/requirements.jsx
@@ -5,7 +5,7 @@ import { resolve } from 'react-resolver';
 import { apiUrl } from '../globals';
 
 function Requirement(props) {
-  return <li>{props.req_id}: {props.req_text}</li>;
+  return <li className="req">{props.req_id}: {props.req_text}</li>;
 }
 
 function Requirements(props) {

--- a/ui/server.jsx
+++ b/ui/server.jsx
@@ -29,6 +29,7 @@ app.get('*', (req, res) => {
       Resolver.resolve(() => <RouterContext {...renderProps} />).then(({ Resolved, data }) => {
         res.status(200).send(
           `<html>
+            <head><link rel="stylesheet" href="/static/styles.css" /></head>
             <body>
               <div id="app">${renderToString(<Resolved />)}</div>
               <script>window.__REACT_RESOLVER_PAYLOAD__ = ${JSON.stringify(data)}</script>

--- a/ui/styles.scss
+++ b/ui/styles.scss
@@ -1,0 +1,3 @@
+.req {
+  border: solid 1px black;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,42 +1,35 @@
 const path = require('path');
 
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const webpack = require('webpack');
 const nodeExternals = require('webpack-node-externals');
 
 
 module.exports = [
   {
-    entry: path.join(__dirname, 'reqs', 'static', 'js', 'index.js'),
+    name: 'styles',
+    entry: path.join(__dirname, 'ui', 'styles.scss'),
     output: {
-      path: __dirname,
-      filename: path.join('reqs', 'static', 'js', 'bundle.js'),
+      path: path.join(__dirname, 'ui-dist', 'static'),
+      filename: 'styles.css',
     },
     module: {
       loaders: [
         {
-          test: /\.jsx?$/,
-          exclude: /node_modules/,
-          loader: 'babel-loader',
-          query: {
-            presets: ['es2015', 'react'],
-          },
-        },
-        {
-          test: /\.jsx?$/,
-          loader: 'eslint-loader',
-          exclude: /node_modules/,
-        },
-        {
           test: /\.scss$/,
-          loaders: ['style-loader', 'css-loader', 'sass-loader'],
+          use: ExtractTextPlugin.extract({
+            fallback: 'style-loader',
+            use: ['css-loader', 'sass-loader'],
+          }),
         },
       ],
     },
-    resolve: {
-      extensions: ['.js', '.jsx'],
-    },
+    plugins: [
+      new ExtractTextPlugin('styles.css'),
+    ],
   },
   {
+    name: 'browser-js',
     entry: path.join(__dirname, 'ui', 'browser.js'),
     output: {
       path: path.join(__dirname, 'ui-dist', 'static'),
@@ -57,10 +50,6 @@ module.exports = [
           loader: 'eslint-loader',
           exclude: /node_modules/,
         },
-        {
-          test: /\.scss$/,
-          loaders: ['style-loader', 'css-loader', 'sass-loader'],
-        },
       ],
     },
     resolve: {
@@ -68,6 +57,7 @@ module.exports = [
     },
   },
   {
+    name: 'server-js',
     target: 'node',
     entry: path.join(__dirname, 'ui', 'server.jsx'),
     output: {


### PR DESCRIPTION
This avoids the "webpack" way of combining style sheets with components in
favor of a separate CSS file. If we want to go the more modular route, we'll
need to figure out how to handle that CSS collection isomorphically.