### PR TITLE
Restrict CORS around Django admin.

### DIFF
--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -63,7 +63,10 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-CORS_ORIGIN_ALLOW_ALL = True    # Big ol' TODO
+# Allow most URLs to be used by any service; do not allow the admin to be
+# accessed this way
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_URLS_REGEX = r'^/(?!admin).*$'
 
 ROOT_URLCONF = 'omb_eregs.urls'
 


### PR DESCRIPTION
While it's generally okay for an unrelated webpage to make AJAX requests
to our API, we _don't_ want that on the admin pages (due to the
"confused deputy" problem of a browser not knowing if AJAX requests were
intended by an end user).

This should resolve #49.