### PR TITLE
Sort requirements by number of matching keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ There are two types of entry points:
   * `pip-compile`
   * `npm`
   * `webpack`
+  * `psql`
 
 ### Resolving common container issues
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,10 @@ services:
     entrypoint: ./node_modules/.bin/webpack
     command: ''
 
+  psql:
+    image: postgres:9.4
+    entrypoint: 'psql -h persistent_db -U postgres'
+    depends_on: ['persistent_db']
 
 volumes:
   database_data:

--- a/reqs/tests/views_tests.py
+++ b/reqs/tests/views_tests.py
@@ -38,3 +38,19 @@ def test_requirement_filtering_keyword(path, num_results):
     req3.keywords.add('3333')
     results = client.get(path).json()['results']
     assert len(results) == num_results
+
+
+@pytest.mark.django_db
+def test_requirements_queryset_order():
+    """We should receive results in # of matches order"""
+    client = APIClient()
+    for i in range(6):
+        mommy.make(Keyword, name=str(i + 1)*4)
+    req1, req2, req3 = [mommy.make(Requirement, req_id=str(i + 1))
+                        for i in range(3)]
+    req1.keywords.add('1111', '2222')
+    req2.keywords.add('2222', '3333', '4444')
+    req3.keywords.add('1111', '5555', '6666')
+    response = client.get('/requirements/?keywords__name__in=1111,3333,4444')
+    req_ids = [req['req_id'] for req in response.json()['results']]
+    assert req_ids == ['2', '1', '3']


### PR DESCRIPTION
Resolves #57. Also adds a `psql` command and fixes an issue where requirements could be repeated.