### PR TITLE
Add minimal policy->req interface.

### DIFF
--- a/reqs/serializers.py
+++ b/reqs/serializers.py
@@ -10,7 +10,7 @@ class PolicySerializer(serializers.ModelSerializer):
         model = Policy
         fields = (
             'policy_number', 'title', 'uri', 'omb_policy_id', 'policy_type',
-            'issuance', 'sunset'
+            'issuance', 'sunset', 'id'
         )
 
 

--- a/reqs/views.py
+++ b/reqs/views.py
@@ -45,6 +45,7 @@ class RequirementViewSet(viewsets.ModelViewSet):
         'impacted_entity': ('icontains',),
         'req_deadline': ('icontains',),
         'citation': ('icontains',),
+        'policy_id': ('exact', 'in'),
     }
     # Allow filtering by related objects
     filter_fields.update(

--- a/ui/components/index.jsx
+++ b/ui/components/index.jsx
@@ -7,6 +7,7 @@ export default function Index() {
       <h2>Index</h2>
       <ul>
         <li><Link to="/keywords">Keywords</Link></li>
+        <li><Link to="/policies">Policies</Link></li>
         <li><Link to="/requirements">Requirements</Link></li>
       </ul>
     </div>

--- a/ui/components/policies.jsx
+++ b/ui/components/policies.jsx
@@ -1,0 +1,59 @@
+import axios from 'axios';
+import React from 'react';
+import { resolve } from 'react-resolver';
+import { Link } from 'react-router';
+
+import { apiUrl } from '../globals';
+import Pagers from './pagers';
+
+function Policy({ policy }) {
+  return (
+    <li>
+      <Link to={{ pathname: '/requirements/', query: { policy_id: policy.id } }} >{ policy.policy_number }: { policy.title }</Link>
+    </li>
+  );
+}
+
+Policy.defaultProps = {
+  policy: {},
+};
+Policy.propTypes = {
+  policy: React.PropTypes.shape({
+    id: React.PropTypes.number,
+    policy_number: React.PropTypes.number,
+    title: React.PropTypes.string,
+  }),
+};
+
+function Policies({ location: { query }, data }) {
+  return (
+    <div>
+      <h1>Policies</h1>
+      <ul>
+        { data.results.map(policy => <Policy key={policy.id} policy={policy} />) }
+      </ul>
+      <Pagers pathname="/policies/" query={query} count={data.count} />
+    </div>
+  );
+}
+
+Policies.defaultProps = {
+  data: { results: [], count: 0 },
+  location: { query: {} },
+};
+Policies.propTypes = {
+  data: React.PropTypes.shape({
+    results: React.PropTypes.arrayOf(Policy.propTypes.policy),
+    count: React.PropTypes.number,
+  }),
+  location: React.PropTypes.shape({
+    query: React.PropTypes.shape({}),
+  }),
+};
+
+export default resolve(
+  'data',
+  ({ location: { query } }) =>
+    axios.get(`${apiUrl()}policies/`, { params: query }).then(({ data }) => data),
+)(Policies);
+

--- a/ui/routes.jsx
+++ b/ui/routes.jsx
@@ -4,6 +4,7 @@ import { browserHistory, IndexRoute, Route, Router } from 'react-router';
 import App from './components/app';
 import Keywords from './components/keywords';
 import Index from './components/index';
+import Policies from './components/policies';
 import Requirements from './components/requirements';
 
 
@@ -11,6 +12,7 @@ export default <Router history={browserHistory} >
   <Route path="/" component={App}>
     <IndexRoute component={Index} />
     <Route path="keywords" component={Keywords} />
+    <Route path="policies" component={Policies} />
     <Route path="requirements" component={Requirements} />
   </Route>
 </Router>;


### PR DESCRIPTION
Copy-paste then tweak the Keywords UI into a Policies UI, where the user can
see a list of all policies, and click through to the requirements contained in
that policy. There's a lot of overlap with the Keywords code, but I figure
we'll be replacing both soon, so I'm not too worried.

Should resolve #87.