### PR TITLE
Attach the config service to the UI servers.

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -15,6 +15,8 @@ applications:
     buildpack: nodejs_buildpack
     command: node ui-dist/server.js
     host: omb-eregs-demo
+    services:
+      - config    # user-provided service w/ UI_BASIC_AUTH defined
     env:
       INTERNAL_API: https://omb-eregs-api-demo.app.cloud.gov/
       PUBLIC_API: https://omb-eregs-api-demo.app.cloud.gov/

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -16,6 +16,8 @@ applications:
     buildpack: nodejs_buildpack
     command: node ui-dist/server.js
     host: omb-eregs
+    services:
+      - config    # user-provided service w/ UI_BASIC_AUTH defined
     env:
       INTERNAL_API: https://omb-eregs-api.app.cloud.gov/
       PUBLIC_API: https://omb-eregs-api.app.cloud.gov/


### PR DESCRIPTION
Lest they won't see the password config.

Both demo and prod environments are configured, so this will close #77.