### PR TITLE
Add ability to order requirements in API

### DIFF
--- a/reqs/tests/views_tests.py
+++ b/reqs/tests/views_tests.py
@@ -106,12 +106,12 @@ def test_requirements_ordered_by_multiple_keys(params, result):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('params', (
-    "sort=gibberish",
-    "sort=-gibberish",
-    "sort=-",
-    "sort=asdf",
-    "sort=policy__",
-    "sort=policy__gibberish",
+    "gibberish",
+    "-gibberish",
+    "-",
+    "asdf",
+    "policy__",
+    "policy__gibberish",
 ))
 def test_requirements_ordered_by_bad_key(params):
     """
@@ -121,6 +121,6 @@ def test_requirements_ordered_by_bad_key(params):
     for i in range(3):
         policy = mommy.make(Policy, policy_number=str(10 - i))
         mommy.make(Requirement, req_id=str(i), policy=policy)
-    path = "/requirements/?{0}".format(params)
+    path = "/requirements/?sort={0}".format(params)
     response = client.get(path)
     assert response.status_code == 400

--- a/reqs/tests/views_tests.py
+++ b/reqs/tests/views_tests.py
@@ -71,9 +71,9 @@ def test_requirements_ordered_by_key(params, req_ids, policy_numbers, result):
     We should be able to pass in arbitrary sort fields.
     """
     client = APIClient()
-    for i in range(len(req_ids)):
-        policy = mommy.make(Policy, policy_number=str(policy_numbers[i]))
-        mommy.make(Requirement, req_id=str(req_ids[i]), policy=policy)
+    for req_id, policy_number in zip(req_ids, policy_numbers):
+        policy = mommy.make(Policy, policy_number=str(policy_number))
+        mommy.make(Requirement, req_id=str(req_id), policy=policy)
     path = "/requirements/?{0}".format(params)
     response = client.get(path)
     req_ids = [req['req_id'] for req in response.json()['results']]


### PR DESCRIPTION
This adds support for a `sort` parameter to the `/requirements/` endpoint.

@cmc333333 I wasn't able to make this play nicely with the code for sorting by number of matching keywords when using `OrderingFilter`, which is why this is custom code. It's possible I missed something. Hopefully the tests should still be useful even if I did.