### PR TITLE
Add a policy search widget

### DIFF
--- a/reqs/views.py
+++ b/reqs/views.py
@@ -19,6 +19,7 @@ class PolicyViewSet(viewsets.ModelViewSet):
     queryset = Policy.objects.all()
     serializer_class = PolicySerializer
     filter_fields = {
+        'id': ('exact', 'in'),
         'policy_number': ('exact', 'gt', 'gte', 'lt', 'lte', 'in', 'range'),
         'title': ('exact', 'icontains'),
         'uri': ('exact', 'icontains'),

--- a/ui/__tests__/components/filter-list.test.jsx
+++ b/ui/__tests__/components/filter-list.test.jsx
@@ -2,16 +2,16 @@ import axios from 'axios';
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import FilterList, { fetchData, Filter } from '../../components/filter-list';
+import FilterList, { fetchKeywords, fetchPolicies, Filter } from '../../components/filter-list';
 
 jest.mock('axios');
 jest.mock('../../globals', () => ({ apiUrl: jest.fn(() => 'api-start/') }));
 
 
-describe('fetchData()', () => {
+describe('fetchKeywords()', () => {
   it('handles an empty query', () => {
     const props = { location: { query: {} } };
-    return fetchData(props).then(result =>
+    return fetchKeywords(props).then(result =>
       expect(result).toHaveLength(0));
   });
   it('hits our API when a keyword is present', () => {
@@ -19,7 +19,7 @@ describe('fetchData()', () => {
     axios.get = jest.fn(
       () => Promise.resolve({ data: { results: [1, 2, 3] } }),
     );
-    return fetchData(props).then((result) => {
+    return fetchKeywords(props).then((result) => {
       expect(result).toEqual([1, 2, 3]);
       expect(axios.get).toHaveBeenCalledWith(
         'api-start/keywords/', { params: { id__in: 'ids,here' } },
@@ -28,35 +28,59 @@ describe('fetchData()', () => {
   });
 });
 
+describe('fetchPolicies()', () => {
+  it('handles an empty query', () => {
+    const props = { location: { query: {} } };
+    return fetchPolicies(props).then(result =>
+      expect(result).toHaveLength(0));
+  });
+  it('hits our API when a keyword is present', () => {
+    const props = { location: { query: { policy_id__in: 'ids,here' } } };
+    axios.get = jest.fn(
+      () => Promise.resolve({ data: { results: [1, 2, 3] } }),
+    );
+    return fetchPolicies(props).then((result) => {
+      expect(result).toEqual([1, 2, 3]);
+      expect(axios.get).toHaveBeenCalledWith(
+        'api-start/policies/', { params: { id__in: 'ids,here' } },
+      );
+    });
+  });
+});
+
 describe('<FilterList />', () => {
   it('passed transformed args to its Filters', () => {
     const params = {
-      router: { location: { query: {
-        keywords__id__in: '1,7,10', some: 'field', page: '5',
-      } } },
-      keywords: [{ id: 1, name: 'a' }],
+      router: { location: { query: { some: 'field', page: '5' } } },
+      lookup: 'keywords',
+      existingFilters: [
+        { id: 1, name: 'a' }, { id: 7, name: 'b' }, { id: 10, name: 'c' },
+      ],
     };
     const filter = shallow(<FilterList {...params} />).find('Filter').first();
-    expect(filter.prop('keywordIds')).toEqual(['1', '7', '10']);
-    expect(filter.prop('keyword')).toEqual({ id: 1, name: 'a' });
-    expect(filter.prop('query')).toEqual({ some: 'field' });
+    expect(filter.prop('existingIds')).toEqual([1, 7, 10]);
+    expect(filter.prop('idToRemove')).toEqual(1);
+    expect(filter.prop('name')).toEqual('a');
+    expect(filter.prop('location')).toEqual(params.router.location);
   });
   it('contains the correct number of Filters', () => {
     const params = {
       router: { location: { query: {} } },
-      keywords: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
+      lookup: 'keywords',
+      existingFilters: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
     };
     let result = shallow(<FilterList {...params} />);
     expect(result.find('Filter')).toHaveLength(4);
 
-    params.keywords.pop();
+    params.existingFilters.pop();
     result = shallow(<FilterList {...params} />);
     expect(result.find('Filter')).toHaveLength(3);
   });
   it('contains an AddKeyword', () => {
     const params = {
       router: { location: { query: {} } },
-      keywords: [],
+      lookup: 'keywords',
+      existingFilters: [],
     };
     const result = shallow(<FilterList {...params} />);
     expect(result.find('DoesNotExist')).toHaveLength(0);
@@ -66,9 +90,11 @@ describe('<FilterList />', () => {
 
 describe('<Filter />', () => {
   const params = {
-    keywordIds: ['3', '5', '7'],
-    query: { some: 'stuff' },
-    keyword: { id: 5, name: 'AkeyWord' },
+    existingIds: [3, 5, 7],
+    idToRemove: 5,
+    location: { pathname: '/path/', query: { some: 'stuff' } },
+    name: 'AkeyWord',
+    removeParam: 'someStr',
   };
   const result = shallow(<Filter {...params} />);
 
@@ -78,8 +104,8 @@ describe('<Filter />', () => {
   it('links to the proper destination', () => {
     const link = result.find('Link').first();
     expect(link.prop('to')).toEqual({
-      pathname: '/requirements/',
-      query: { some: 'stuff', keywords__id__in: '3,7' },
+      pathname: '/path/',
+      query: { some: 'stuff', someStr: '3,7' },
     });
   });
 });

--- a/ui/components/filter-list.jsx
+++ b/ui/components/filter-list.jsx
@@ -48,6 +48,7 @@ Filter.propTypes = {
  * this would need to modify to add/remove lookup values */
 export const searchParam = {
   keywords: 'keywords__id__in',
+  policies: 'policy_id__in',
 };
 
 export default function FilterList({ existingFilters, lookup, router }) {
@@ -85,6 +86,13 @@ FilterList.propTypes = {
 export function fetchKeywords({ location: { query } }) {
   if (query.keywords__id__in) {
     const fetch = axios.get(`${apiUrl()}keywords/`, { params: { id__in: query.keywords__id__in } });
+    return fetch.then(({ data: { results } }) => results);
+  }
+  return Promise.resolve([]);
+}
+export function fetchPolicies({ location: { query } }) {
+  if (query.policy_id__in) {
+    const fetch = axios.get(`${apiUrl()}policies/`, { params: { id__in: query.policy_id__in } });
     return fetch.then(({ data: { results } }) => results);
   }
   return Promise.resolve([]);

--- a/ui/components/filter-list.jsx
+++ b/ui/components/filter-list.jsx
@@ -7,76 +7,82 @@ import React from 'react';
 import { Link } from 'react-router';
 
 import { apiUrl } from '../globals';
+import { apiParam } from './lookup-search';
 import SearchAutocomplete from './search-autocomplete';
 
-export function Filter({ keywordIds, keyword, query }) {
-  const remainingKws = keywordIds.filter(v => v !== keyword.id.toString());
-  const queryWithoutKw = Object.assign({}, query, {
-    keywords__id__in: remainingKws.join(','),
+export function Filter({ existingIds, idToRemove, location, name, removeParam }) {
+  const remainingIds = existingIds.filter(v => v !== idToRemove);
+  const { pathname, query } = location;
+  const modifiedQuery = Object.assign({}, query, {
+    [removeParam]: remainingIds.join(','),
   });
-  const destination = { pathname: '/requirements/', query: queryWithoutKw };
+  delete modifiedQuery.page;
 
   return (
     <li>
-      {keyword.name}
+      {name}
       &nbsp;
-      <Link to={destination}>x</Link>
+      <Link to={{ pathname, query: modifiedQuery }}>x</Link>
     </li>
   );
 }
 Filter.defaultProps = {
-  keywordIds: [],
-  keyword: {},
-  query: {},
+  existingIds: [],
+  idToRemove: 0,
+  location: { pathname: '', query: {} },
+  name: '',
+  removeParam: '',
 };
 Filter.propTypes = {
-  keywordIds: React.PropTypes.arrayOf(React.PropTypes.string),
-  keyword: React.PropTypes.shape({
-    id: React.PropTypes.number,
-    name: React.PropTypes.string,
+  existingIds: React.PropTypes.arrayOf(React.PropTypes.number),
+  idToRemove: React.PropTypes.number,
+  location: React.PropTypes.shape({
+    pathname: React.PropTypes.string,
+    query: React.PropTypes.shape({}),
   }),
-  query: React.PropTypes.shape({}),
+  name: React.PropTypes.string,
+  removeParam: React.PropTypes.string,
 };
 
-export default function FilterList({ keywords, router }) {
-  const { location: { query } } = router;
-  const keywordIds = (query.keywords__id__in || '').split(',');
-  const removeQuery = Object.assign({}, query);
-  delete removeQuery.page;
-  delete removeQuery.keywords__id__in;
+/* Mapping between a lookup type (e.g. "keywords") and the query field that
+ * this would need to modify to add/remove lookup values */
+export const searchParam = {
+  keywords: 'keywords__id__in',
+};
+
+export default function FilterList({ existingFilters, lookup, router }) {
+  const filterIds = existingFilters.map(existing => existing.id);
   return (
     <div className="req-filter-ui">
-      <h3>Keywords</h3>
+      <h3>{lookup.charAt(0).toUpperCase() + lookup.substr(1)}</h3>
       <ol className="list-reset">
-        { keywords.map(keyword =>
+        { existingFilters.map(filter =>
           <Filter
-            key={keyword.id} keywordIds={keywordIds} keyword={keyword}
-            query={removeQuery}
+            key={filter.id} existingIds={filterIds} idToRemove={filter.id}
+            location={router.location} name={filter[apiParam[lookup]]}
+            removeParam={searchParam[lookup]}
           />)}
       </ol>
-      <SearchAutocomplete lookup="keywords" insertParam="keywords__id__in" router={router} />
+      <SearchAutocomplete lookup={lookup} insertParam={searchParam[lookup]} router={router} />
     </div>
   );
 }
 FilterList.defaultProps = {
-  keywords: [],
-  router: { location: { query: {} } },
+  existingFilters: [],
+  lookup: 'keywords',
+  router: { location: {} },
 };
 FilterList.propTypes = {
-  keywords: React.PropTypes.arrayOf(React.PropTypes.shape({
+  existingFilters: React.PropTypes.arrayOf(React.PropTypes.shape({
     id: React.PropTypes.number,
-    name: React.PropTypes.string,
   })),
+  lookup: React.PropTypes.oneOf(Object.keys(searchParam)),
   router: React.PropTypes.shape({
-    location: React.PropTypes.shape({
-      query: React.PropTypes.shape({
-        keywords__id__in: React.PropTypes.string,
-      }),
-    }),
+    location: React.PropTypes.shape({}),
   }),
 };
 
-export function fetchData({ location: { query } }) {
+export function fetchKeywords({ location: { query } }) {
   if (query.keywords__id__in) {
     const fetch = axios.get(`${apiUrl()}keywords/`, { params: { id__in: query.keywords__id__in } });
     return fetch.then(({ data: { results } }) => results);

--- a/ui/components/lookup-search.jsx
+++ b/ui/components/lookup-search.jsx
@@ -74,6 +74,7 @@ function redirectUrl(params, idToInsert) {
  * should search against/display */
 export const apiParam = {
   keywords: 'name',
+  policies: 'title',
 };
 
 export function redirectIfMatched({ routes, location: { query } }, redirect, done) {

--- a/ui/components/lookup-search.jsx
+++ b/ui/components/lookup-search.jsx
@@ -70,6 +70,8 @@ function redirectUrl(params, idToInsert) {
   return `${params.redirect.pathname}?${paramStr}`;
 }
 
+/* Mapping between a lookup type (e.g. "keywords") and the field in the API we
+ * should search against/display */
 export const apiParam = {
   keywords: 'name',
 };

--- a/ui/components/requirements.jsx
+++ b/ui/components/requirements.jsx
@@ -5,7 +5,7 @@ import { Link, withRouter } from 'react-router';
 
 import { apiUrl } from '../globals';
 import Pagers from './pagers';
-import FilterList, { fetchData as fetchKeywords } from './filter-list';
+import FilterList, { fetchKeywords } from './filter-list';
 
 function Requirement({ requirement }) {
   return <li className="req">{requirement.req_id}: {requirement.req_text}</li>;
@@ -15,7 +15,7 @@ function Requirements({ keywords, pagedReqs, router }) {
   return (
     <div className="clearfix">
       <div className="col col-2 border p2">
-        <FilterList keywords={keywords} router={router} />
+        <FilterList existingFilters={keywords} lookup="keywords" router={router} />
       </div>
       <div className="col col-10 pl3">
         <div>

--- a/ui/components/requirements.jsx
+++ b/ui/components/requirements.jsx
@@ -5,17 +5,18 @@ import { Link, withRouter } from 'react-router';
 
 import { apiUrl } from '../globals';
 import Pagers from './pagers';
-import FilterList, { fetchKeywords } from './filter-list';
+import FilterList, { fetchKeywords, fetchPolicies } from './filter-list';
 
 function Requirement({ requirement }) {
   return <li className="req">{requirement.req_id}: {requirement.req_text}</li>;
 }
 
-function Requirements({ keywords, pagedReqs, router }) {
+function Requirements({ keywords, pagedReqs, policies, router }) {
   return (
     <div className="clearfix">
       <div className="col col-2 border p2">
         <FilterList existingFilters={keywords} lookup="keywords" router={router} />
+        <FilterList existingFilters={policies} lookup="policies" router={router} />
       </div>
       <div className="col col-10 pl3">
         <div>
@@ -38,13 +39,14 @@ function Requirements({ keywords, pagedReqs, router }) {
 }
 
 Requirements.defaultProps = {
-  keywords: FilterList.defaultProps.keywords,
+  keywords: [],
   pagedReqs: { results: [], count: 0 },
+  policies: [],
   router: { location: {} },
 };
 
 Requirements.propTypes = {
-  keywords: FilterList.propTypes.keywords,
+  keywords: FilterList.propTypes.existingFilters,
   pagedReqs: React.PropTypes.shape({
     results: React.PropTypes.arrayOf(React.PropTypes.shape({
       req_text: React.PropTypes.string,
@@ -52,6 +54,7 @@ Requirements.propTypes = {
     })),
     count: React.PropTypes.number,
   }),
+  policies: FilterList.propTypes.existingFilters,
   router: React.PropTypes.shape({
     location: React.PropTypes.shape({}),
   }),
@@ -74,6 +77,7 @@ function fetchRequirements({ location: { query } }) {
 }
 
 export default resolve({
-  pagedReqs: fetchRequirements,
   keywords: fetchKeywords,
+  pagedReqs: fetchRequirements,
+  policies: fetchPolicies,
 })(withRouter(Requirements));

--- a/ui/routes.jsx
+++ b/ui/routes.jsx
@@ -15,7 +15,10 @@ export default <Router history={browserHistory} >
       <IndexRoute component={Keywords} />
       <Route path="search-redirect" component={AsyncLookupSearch} onEnter={redirectIfMatched} />
     </Route>
-    <Route path="policies" component={Policies} />
+    <Route path="policies">
+      <IndexRoute component={Policies} />
+      <Route path="search-redirect" component={AsyncLookupSearch} onEnter={redirectIfMatched} />
+    </Route>
     <Route path="requirements" component={Requirements} />
   </Route>
 </Router>;


### PR DESCRIPTION
This generalizes the FilterList/Filters to remove ties to keywords, then configures a new set to work with policy titles. This does **not** need to be reviewed before today's demo.

Looks like:
<img width="1095" alt="screen shot 2017-03-17 at 10 28 36 am" src="https://cloud.githubusercontent.com/assets/326918/24047648/b9d8aa3c-0afc-11e7-9ccc-8293dbd50d00.png">
