### PR TITLE
Add by-policy tab

### DIFF
--- a/ui/__tests__/components/requirements/by-policy.test.jsx
+++ b/ui/__tests__/components/requirements/by-policy.test.jsx
@@ -1,0 +1,48 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { groupReqs, Group } from '../../../components/requirements/by-policy';
+
+describe('<Group />', () => {
+  const policy = { title: 'PolicyAAA', uri: 'http://example.com/aaa' };
+  const group = [
+    { req_id: '1.1', policy },
+    { req_id: '1.2', policy },
+    { req_id: '1.3', policy },
+  ];
+  const result = shallow(<Group group={group} />);
+
+  it('includes all of the requirements', () => {
+    const reqs = result.find('Requirement');
+    expect(reqs).toHaveLength(3);
+    expect(reqs.at(0).prop('requirement')).toEqual(group[0]);
+    expect(reqs.at(1).prop('requirement')).toEqual(group[1]);
+    expect(reqs.at(2).prop('requirement')).toEqual(group[2]);
+  });
+
+  it('includes the policy name', () => {
+    expect(result.text()).toMatch(/PolicyAAA/);
+  });
+
+  it('includes a link to the policy', () => {
+    expect(result.find('a').first().prop('href')).toEqual('http://example.com/aaa');
+  });
+});
+
+describe('groupReqs()', () => {
+  it('handles empty requirements', () => {
+    expect(groupReqs([])).toEqual([]);
+  });
+
+  it('groups by policy', () => {
+    const reqs = [
+      { req_id: 'a', policy: { id: 1 } },
+      { req_id: 'b', policy: { id: 1 } },
+      { req_id: 'c', policy: { id: 2 } },
+      { req_id: 'd', policy: { id: 3 } },
+      { req_id: 'e', policy: { id: 3 } },
+    ];
+    expect(groupReqs(reqs)).toEqual([
+      reqs.slice(0, 2), reqs.slice(2, 3), reqs.slice(3)]);
+  });
+});

--- a/ui/__tests__/components/requirements/tabs.test.jsx
+++ b/ui/__tests__/components/requirements/tabs.test.jsx
@@ -1,0 +1,42 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import Tabs from '../../../components/requirements/tabs';
+
+describe('<Tabs />', () => {
+  const params = {
+    router: {
+      routes: [
+        {}, { path: '/' },
+        { path: 'parent',
+          childRoutes: [
+          { path: 'child1', tabName: 'Tab 1' },
+          { path: 'childB', tabName: 'Tab B' },
+          { path: 'other', tabName: 'Other' },
+          { path: 'one-more', tabName: 'Yet Another' }] },
+        { path: 'childB' },
+      ],
+      location: { query: { some: 'value', another: 'here', page: '5' } },
+    },
+  };
+  const tabs = mount(<Tabs {...params} />).find('Tab');
+
+  it('includes all peer routes', () => {
+    expect(tabs).toHaveLength(4);
+    expect(tabs.at(0).text()).toEqual('Tab 1');
+    expect(tabs.at(1).text()).toEqual('Tab B');
+    expect(tabs.at(2).text()).toEqual('Other');
+    expect(tabs.at(3).text()).toEqual('Yet Another');
+  });
+  it('has links for the peers', () => {
+    expect(tabs.at(0).find('Link').exists()).toBe(true);
+    expect(tabs.at(1).find('Link').exists()).toBe(false);
+    expect(tabs.at(2).find('Link').exists()).toBe(true);
+    expect(tabs.at(3).find('Link').exists()).toBe(true);
+  });
+  it('has links which include the query params', () => {
+    expect(tabs.at(2).find('Link').first().prop('to')).toEqual({
+      pathname: '/parent/other', query: { some: 'value', another: 'here' },
+    });
+  });
+});

--- a/ui/components/requirements/by-keyword.jsx
+++ b/ui/components/requirements/by-keyword.jsx
@@ -10,7 +10,9 @@ function ByKeyword({ pagedReqs, location }) {
     <div>
       <ul className="list-reset">
         { pagedReqs.results.map(requirement =>
-          <Requirement key={requirement.req_id} requirement={requirement} />) }
+          <li key={requirement.req_id} className="border rounded mb2">
+            <Requirement requirement={requirement} />
+          </li>) }
       </ul>
       <Pagers location={location} count={pagedReqs.count} />
     </div>

--- a/ui/components/requirements/by-keyword.jsx
+++ b/ui/components/requirements/by-keyword.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { resolve } from 'react-resolver';
+
+import { theApi } from '../../globals';
+import Pagers from '../pagers';
+import Requirement from './requirement';
+
+function ByKeyword({ pagedReqs, location }) {
+  return (
+    <div>
+      <ul className="list-reset">
+        { pagedReqs.results.map(requirement =>
+          <Requirement key={requirement.req_id} requirement={requirement} />) }
+      </ul>
+      <Pagers location={location} count={pagedReqs.count} />
+    </div>
+  );
+}
+ByKeyword.defaultProps = {
+  pagedReqs: { results: [], count: 0 },
+  location: {},
+};
+ByKeyword.propTypes = {
+  location: React.PropTypes.shape({}),
+  pagedReqs: React.PropTypes.shape({
+    results: React.PropTypes.arrayOf(React.PropTypes.shape({
+      req_text: React.PropTypes.string,
+      req_id: React.PropTypes.string,
+    })),
+    count: React.PropTypes.number,
+  }),
+};
+
+const fetchRequirements = ({ location: { query } }) =>
+  theApi().requirements.fetch(query);
+
+export default resolve(
+  'pagedReqs', fetchRequirements,
+)(ByKeyword);

--- a/ui/components/requirements/by-policy.jsx
+++ b/ui/components/requirements/by-policy.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { resolve } from 'react-resolver';
+
+import { theApi } from '../../globals';
+import Pagers from '../pagers';
+import Requirement from './requirement';
+
+export function Group({ group }) {
+  if (group.length === 0) {
+    return null;
+  }
+
+  const policy = group[0].policy;
+  return (
+    <div className="border mb2 p2 rounded">
+      <h4>{policy.title}</h4>
+      <ol className="list-reset border-top">
+        { group.map(req =>
+          <li key={req.req_id} className="border-bottom">
+            <Requirement requirement={req} />
+          </li>) }
+      </ol>
+      <div className="clearfix">
+        <a href={policy.uri} className="center block">Read the whole policy</a>
+      </div>
+    </div>
+  );
+}
+Group.defaultProps = {
+  group: [],
+};
+Group.propTypes = {
+  group: React.PropTypes.arrayOf(React.PropTypes.shape({
+    req_id: React.PropTypes.string,
+    policy: React.PropTypes.shape({
+      title: React.PropTypes.string,
+    }),
+  })),
+};
+
+export function groupReqs(requirements) {
+  const groups = [];
+  let lastPolicy = null;
+  requirements.forEach((req) => {
+    if (lastPolicy !== req.policy.id) {
+      lastPolicy = req.policy.id;
+      groups.push([]);
+    }
+    groups[groups.length - 1].push(req);
+  });
+  return groups;
+}
+
+function ByPolicy({ pagedReqs, router }) {
+  const groups = groupReqs(pagedReqs.results);
+  return (
+    <div>
+      <ul className="list-reset">
+        { groups.map(group =>
+          <li key={group[0].policy.id}><Group group={group} /></li>)}
+      </ul>
+      <Pagers location={router.location} count={pagedReqs.count} />
+    </div>
+  );
+}
+ByPolicy.defaultProps = {
+  pagedReqs: { results: [], count: 0 },
+  router: { location: {} },
+};
+
+ByPolicy.propTypes = {
+  pagedReqs: React.PropTypes.shape({
+    results: React.PropTypes.arrayOf(React.PropTypes.shape({
+      req_text: React.PropTypes.string,
+      req_id: React.PropTypes.string,
+    })),
+    count: React.PropTypes.number,
+  }),
+  router: React.PropTypes.shape({
+    location: React.PropTypes.shape({}),
+  }),
+};
+
+const fetchRequirements = ({ location: { query } }) => {
+  const params = Object.assign({}, query, { ordering: 'policy__policy_number' });
+  return theApi().requirements.fetch(params);
+};
+
+export default resolve(
+  'pagedReqs', fetchRequirements,
+)(ByPolicy);

--- a/ui/components/requirements/container.jsx
+++ b/ui/components/requirements/container.jsx
@@ -2,34 +2,12 @@ import React from 'react';
 import { resolve } from 'react-resolver';
 import { Link, withRouter } from 'react-router';
 
-import { theApi } from '../globals';
-import Pagers from './pagers';
-import FilterList from './filter-list';
+import { theApi } from '../../globals';
+import Pagers from '../pagers';
+import FilterList from '../filter-list';
+import Requirement from './requirement';
 
-function Requirement({ requirement }) {
-  return (
-    <li className="req border rounded p2 mb2 clearfix max-width-3">
-      <div className="req-id col col-1 mb2">
-        { requirement.req_id }
-      </div>
-      <div className="req-text col col-11 pl1">
-        { requirement.req_text.split('\n').map(line => (
-          <span key={line} className="req-text-line mb1">{ line }<br /></span>
-          ))}
-        <div className="clearfix mt3">
-          <span className="applies-to mr2">
-            Applies to: [not implemented]
-          </span>
-          <span className="sunset-date">
-            Sunset date by { requirement.policy.sunset || 'none' }
-          </span>
-        </div>
-      </div>
-    </li>
-  );
-}
-
-function Requirements({ keywords, pagedReqs, policies, router }) {
+function Container({ keywords, pagedReqs, policies, router }) {
   return (
     <div className="clearfix">
       <div className="col col-2 p2">
@@ -60,14 +38,14 @@ function Requirements({ keywords, pagedReqs, policies, router }) {
   );
 }
 
-Requirements.defaultProps = {
+Container.defaultProps = {
   keywords: [],
   pagedReqs: { results: [], count: 0 },
   policies: [],
   router: { location: {} },
 };
 
-Requirements.propTypes = {
+Container.propTypes = {
   keywords: FilterList.propTypes.existingFilters,
   pagedReqs: React.PropTypes.shape({
     results: React.PropTypes.arrayOf(React.PropTypes.shape({
@@ -82,18 +60,6 @@ Requirements.propTypes = {
   }),
 };
 
-Requirement.defaultProps = {
-  requirement: {},
-};
-
-Requirement.propTypes = {
-  requirement: React.PropTypes.shape({
-    sunset: React.PropTypes.string,
-    req_text: React.PropTypes.string,
-    req_id: React.PropTypes.string,
-  }),
-};
-
 const fetchRequirements = ({ location: { query } }) =>
   theApi().requirements.fetch(query);
 const fetchKeywords = ({ location: { query: { keywords__id__in } } }) =>
@@ -105,4 +71,4 @@ export default resolve({
   keywords: fetchKeywords,
   pagedReqs: fetchRequirements,
   policies: fetchPolicies,
-})(withRouter(Requirements));
+})(withRouter(Container));

--- a/ui/components/requirements/container.jsx
+++ b/ui/components/requirements/container.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { resolve } from 'react-resolver';
-import { Link, withRouter } from 'react-router';
+import { withRouter } from 'react-router';
 
 import { theApi } from '../../globals';
 import Pagers from '../pagers';
 import FilterList from '../filter-list';
 import Requirement from './requirement';
+import Tabs from './tabs';
 
 function Container({ keywords, pagedReqs, policies, router }) {
   return (
@@ -15,15 +16,7 @@ function Container({ keywords, pagedReqs, policies, router }) {
         <FilterList existingFilters={policies} lookup="policies" router={router} />
       </div>
       <div className="col col-10 pl4 border-left">
-        <div>
-          <span className="mr4">Organize by</span>
-          <ul className="list-reset inline-block">
-            <li className="inline-block mr4 bold">Requirement</li>
-            <li className="inline-block mr4">
-              <Link to="/#not-implemented">Policy</Link>
-            </li>
-          </ul>
-        </div>
+        <Tabs router={router} />
         <ul className="list-reset">
           { pagedReqs.results.map(requirement =>
             <Requirement

--- a/ui/components/requirements/container.jsx
+++ b/ui/components/requirements/container.jsx
@@ -13,7 +13,7 @@ function Container({ children, keywords, policies, router }) {
         <FilterList existingFilters={keywords} lookup="keywords" router={router} />
         <FilterList existingFilters={policies} lookup="policies" router={router} />
       </div>
-      <div className="col col-10 pl4 border-left">
+      <div className="col col-10 pl4 border-left max-width-3">
         <Tabs router={router} />
         { children }
       </div>

--- a/ui/components/requirements/container.jsx
+++ b/ui/components/requirements/container.jsx
@@ -3,12 +3,10 @@ import { resolve } from 'react-resolver';
 import { withRouter } from 'react-router';
 
 import { theApi } from '../../globals';
-import Pagers from '../pagers';
 import FilterList from '../filter-list';
-import Requirement from './requirement';
 import Tabs from './tabs';
 
-function Container({ keywords, pagedReqs, policies, router }) {
+function Container({ children, keywords, policies, router }) {
   return (
     <div className="clearfix">
       <div className="col col-2 p2">
@@ -17,44 +15,26 @@ function Container({ keywords, pagedReqs, policies, router }) {
       </div>
       <div className="col col-10 pl4 border-left">
         <Tabs router={router} />
-        <ul className="list-reset">
-          { pagedReqs.results.map(requirement =>
-            <Requirement
-              key={requirement.req_id}
-              requirement={requirement}
-            />)
-          }
-        </ul>
-        <Pagers location={router.location} count={pagedReqs.count} />
+        { children }
       </div>
     </div>
   );
 }
 
 Container.defaultProps = {
+  children: null,
   keywords: [],
-  pagedReqs: { results: [], count: 0 },
   policies: [],
-  router: { location: {} },
+  router: {},
 };
 
 Container.propTypes = {
+  children: React.PropTypes.element,
   keywords: FilterList.propTypes.existingFilters,
-  pagedReqs: React.PropTypes.shape({
-    results: React.PropTypes.arrayOf(React.PropTypes.shape({
-      req_text: React.PropTypes.string,
-      req_id: React.PropTypes.string,
-    })),
-    count: React.PropTypes.number,
-  }),
   policies: FilterList.propTypes.existingFilters,
-  router: React.PropTypes.shape({
-    location: React.PropTypes.shape({}),
-  }),
+  router: React.PropTypes.shape({}),
 };
 
-const fetchRequirements = ({ location: { query } }) =>
-  theApi().requirements.fetch(query);
 const fetchKeywords = ({ location: { query: { keywords__id__in } } }) =>
   theApi().keywords.withIds(keywords__id__in);
 const fetchPolicies = ({ location: { query: { policy_id__in } } }) =>
@@ -62,6 +42,5 @@ const fetchPolicies = ({ location: { query: { policy_id__in } } }) =>
 
 export default resolve({
   keywords: fetchKeywords,
-  pagedReqs: fetchRequirements,
   policies: fetchPolicies,
 })(withRouter(Container));

--- a/ui/components/requirements/requirement.jsx
+++ b/ui/components/requirements/requirement.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export default function Requirement({ requirement }) {
+  return (
+    <li className="req border rounded p2 mb2 clearfix max-width-3">
+      <div className="req-id col col-1 mb2">
+        {requirement.req_id}
+      </div>
+      <div className="req-text col col-11">
+        { requirement.req_text.split('\n').map(line => (
+          <span key={line} className="req-text-line mb1">{ line }<br /></span>
+          ))}
+        <div className="clearfix mt3">
+          <span className="applies-to mr2">
+            Applies to: [not implemented]
+          </span>
+          <span className="sunset-date">
+            Sunset date by { requirement.policy.sunset || 'none' }
+          </span>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+Requirement.defaultProps = {
+  requirement: {
+    policy: {},
+    req_text: '',
+    req_id: '',
+  },
+};
+
+Requirement.propTypes = {
+  requirement: React.PropTypes.shape({
+    policy: React.PropTypes.shape({
+      sunset: React.PropTypes.string,
+    }),
+    req_text: React.PropTypes.string,
+    req_id: React.PropTypes.string,
+  }),
+};

--- a/ui/components/requirements/requirement.jsx
+++ b/ui/components/requirements/requirement.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function Requirement({ requirement }) {
   return (
-    <li className="req border rounded p2 mb2 clearfix max-width-3">
+    <div className="req p2 clearfix">
       <div className="req-id col col-1 mb2">
         {requirement.req_id}
       </div>
@@ -19,7 +19,7 @@ export default function Requirement({ requirement }) {
           </span>
         </div>
       </div>
-    </li>
+    </div>
   );
 }
 

--- a/ui/components/requirements/tabs.jsx
+++ b/ui/components/requirements/tabs.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Link } from 'react-router';
+
+function Tab({ active, link, tabName }) {
+  if (active) {
+    return <li className="inline-block mr4 bold">{ tabName }</li>;
+  }
+  return (
+    <li className="inline-block mr4">
+      <Link to={link} >{ tabName }</Link>
+    </li>
+  );
+}
+Tab.defaultProps = {
+  active: false,
+  link: { pathname: '', query: {} },
+  tabName: '',
+};
+Tab.propTypes = {
+  active: React.PropTypes.bool,
+  link: React.PropTypes.shape({
+    pathname: React.PropTypes.string,
+    query: React.PropTypes.shape({}),
+  }),
+  tabName: React.PropTypes.string,
+};
+
+export default function Tabs({ router }) {
+  if (router.routes.length < 2) {
+    return null;
+  }
+  const parentRoute = router.routes[router.routes.length - 2];
+  const currentPath = router.routes[router.routes.length - 1].path;
+
+  const modifiedQuery = Object.assign({}, router.location.query);
+  delete modifiedQuery.page;
+
+  const pathprefix = router.routes.filter(r => r.path && r.path !== '/').map(r => r.path);
+  pathprefix.pop();
+
+  const tabs = parentRoute.childRoutes.map(childRoute => ({
+    key: childRoute.path,
+    active: childRoute.path === currentPath,
+    tabName: childRoute.tabName,
+    link: {
+      pathname: `/${pathprefix.concat([childRoute.path]).join('/')}`,
+      query: modifiedQuery,
+    },
+  }));
+
+  return (
+    <div>
+      <span className="mr4">Organize by</span>
+      <ul className="list-reset inline-block">
+        { tabs.map(tab => <Tab {...tab} />) }
+      </ul>
+    </div>
+  );
+}
+Tabs.defaultProps = {
+  router: { routes: [], location: { query: {} } },
+};
+Tabs.propTypes = {
+  router: React.PropTypes.shape({
+    routes: React.PropTypes.arrayOf(React.PropTypes.shape({})),
+    location: React.PropTypes.shape({
+      query: React.PropTypes.shape({}),
+    }),
+  }),
+};

--- a/ui/routes.jsx
+++ b/ui/routes.jsx
@@ -7,6 +7,7 @@ import Index from './components/index';
 import Policies from './components/policies';
 import Requirements from './components/requirements/container';
 import ReqsByKeyword from './components/requirements/by-keyword';
+import ReqsByPolicy from './components/requirements/by-policy';
 import AsyncLookupSearch, { redirectIfMatched } from './components/lookup-search';
 
 export default <Router history={browserHistory} >
@@ -23,6 +24,7 @@ export default <Router history={browserHistory} >
     <Route path="requirements" component={Requirements} >
       <IndexRedirect to="./by-keyword" />
       <Route path="by-keyword" tabName="Requirement" component={ReqsByKeyword} />
+      <Route path="by-policy" tabName="Policy" component={ReqsByPolicy} />
     </Route>
   </Route>
 </Router>;

--- a/ui/routes.jsx
+++ b/ui/routes.jsx
@@ -6,6 +6,7 @@ import Keywords from './components/keywords';
 import Index from './components/index';
 import Policies from './components/policies';
 import Requirements from './components/requirements/container';
+import ReqsByKeyword from './components/requirements/by-keyword';
 import AsyncLookupSearch, { redirectIfMatched } from './components/lookup-search';
 
 export default <Router history={browserHistory} >
@@ -19,9 +20,9 @@ export default <Router history={browserHistory} >
       <IndexRoute component={Policies} />
       <Route path="search-redirect" component={AsyncLookupSearch} onEnter={redirectIfMatched} />
     </Route>
-    <Route path="requirements">
+    <Route path="requirements" component={Requirements} >
       <IndexRedirect to="./by-keyword" />
-      <Route path="by-keyword" tabName="Requirement" component={Requirements} />
+      <Route path="by-keyword" tabName="Requirement" component={ReqsByKeyword} />
     </Route>
   </Route>
 </Router>;

--- a/ui/routes.jsx
+++ b/ui/routes.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { browserHistory, IndexRoute, Route, Router } from 'react-router';
+import { browserHistory, IndexRedirect, IndexRoute, Route, Router } from 'react-router';
 
 import App from './components/app';
 import Keywords from './components/keywords';
 import Index from './components/index';
 import Policies from './components/policies';
-import Requirements from './components/requirements';
+import Requirements from './components/requirements/container';
 import AsyncLookupSearch, { redirectIfMatched } from './components/lookup-search';
 
 export default <Router history={browserHistory} >
@@ -19,6 +19,9 @@ export default <Router history={browserHistory} >
       <IndexRoute component={Policies} />
       <Route path="search-redirect" component={AsyncLookupSearch} onEnter={redirectIfMatched} />
     </Route>
-    <Route path="requirements" component={Requirements} />
+    <Route path="requirements">
+      <IndexRedirect to="./by-requirement" />
+      <Route path="by-requirement" component={Requirements} />
+    </Route>
   </Route>
 </Router>;

--- a/ui/routes.jsx
+++ b/ui/routes.jsx
@@ -20,8 +20,8 @@ export default <Router history={browserHistory} >
       <Route path="search-redirect" component={AsyncLookupSearch} onEnter={redirectIfMatched} />
     </Route>
     <Route path="requirements">
-      <IndexRedirect to="./by-requirement" />
-      <Route path="by-requirement" component={Requirements} />
+      <IndexRedirect to="./by-keyword" />
+      <Route path="by-keyword" tabName="Requirement" component={Requirements} />
     </Route>
   </Route>
 </Router>;


### PR DESCRIPTION
Building on #149, this splits up the Requirements component into:
* Container (which includes the left-side filters)
* Tabs
* ByKeyword
* ByPolicy

Requirements always include the Container and Tabs, but then, depending on path, include either ByKeyword or ByPolicy.

Looks like:

<img width="1132" alt="screen shot 2017-03-24 at 5 56 33 pm" src="https://cloud.githubusercontent.com/assets/326918/24315191/0d14515a-10bc-11e7-9e45-d037b1745d3f.png">

<img width="1127" alt="screen shot 2017-03-24 at 5 56 44 pm" src="https://cloud.githubusercontent.com/assets/326918/24315192/0d154af6-10bc-11e7-94a5-7d2b89071852.png">

Should resolve #123 