### PR TITLE
Tweaks to admin

### DIFF
--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -36,8 +36,8 @@ ALLOWED_HOSTS = env.uris
 # Application definition
 
 INSTALLED_APPS = (
-    'reqs.apps.ReqsConfig',
     'taggit',
+    'reqs.apps.ReqsConfig',
     'dal',
     'dal_select2',
     'corsheaders',

--- a/reqs/admin.py
+++ b/reqs/admin.py
@@ -1,11 +1,14 @@
 from dal_select2_taggit.widgets import TaggitSelect2
 from django import forms
 from django.contrib import admin
+from taggit.models import Tag
 
 from reqs.models import Keyword, Policy, Requirement
 
 admin.site.register(Policy)
 admin.site.register(Keyword)
+# We have our own tag type; best to hide the taggit Tags from end users
+admin.site.unregister(Tag)
 
 
 def handle_quotation_marks(value):

--- a/reqs/admin.py
+++ b/reqs/admin.py
@@ -5,10 +5,18 @@ from taggit.models import Tag
 
 from reqs.models import Keyword, Policy, Requirement
 
-admin.site.register(Policy)
-admin.site.register(Keyword)
 # We have our own tag type; best to hide the taggit Tags from end users
 admin.site.unregister(Tag)
+
+
+@admin.register(Policy)
+class PolicyAdmin(admin.ModelAdmin):
+    search_fields = ['title', 'omb_policy_id']
+
+
+@admin.register(Keyword)
+class KeywordAdmin(admin.ModelAdmin):
+    search_fields = ['name']
 
 
 def handle_quotation_marks(value):
@@ -44,3 +52,4 @@ class RequirementForm(forms.ModelForm):
 @admin.register(Requirement)
 class RequirementAdmin(admin.ModelAdmin):
     form = RequirementForm
+    search_fields = ['req_id', 'req_text']

--- a/reqs/models.py
+++ b/reqs/models.py
@@ -73,6 +73,9 @@ class Policy(models.Model):
         text = self.title[:40]
         if len(self.title) > 40:
             text += '...'
+        if self.omb_policy_id:
+            return '{0}: ({1}) {2}'.format(
+                self.policy_number, self.omb_policy_id, text)
         return '{0}: {1}'.format(self.policy_number, text)
 
 


### PR DESCRIPTION
Three quick wins that OMB's requested:
* Remove taggit's Tag model from the admin
* Add a search box for filtering models. Super naive approach, but this works
* Add OMB policy id to policy names