### PR TITLE
Adds keywords to requirements

### DIFF
--- a/ui/assets/css/_requirements.scss
+++ b/ui/assets/css/_requirements.scss
@@ -17,6 +17,16 @@
     color: $color-gray;
     font-size: .8em;
   }
+
+  .topics {
+    li:after {
+      content: ', ';
+    }
+
+    li:last-child:after {
+      content: '';
+    }
+  }
 }
 
 .organize-tabs {

--- a/ui/assets/css/_requirements.scss
+++ b/ui/assets/css/_requirements.scss
@@ -11,7 +11,8 @@
   }
 
   .applies-to,
-  .sunset-date {
+  .sunset-date,
+  .topics {
     @include font-source-sans-pro();
     color: $color-gray;
     font-size: .8em;

--- a/ui/components/requirements/requirement.jsx
+++ b/ui/components/requirements/requirement.jsx
@@ -18,14 +18,11 @@ export default function Requirement({ requirement }) {
             Sunset date by { requirement.policy.sunset || 'none' }
           </div>
           <div className="topics">
-            <ul className="topics-list list-reset">
-              <li className="inline">Topics: </li>
+            <span>Topics: </span>
+            <ul className="topics-list list-reset inline">
               { requirement.keywords.map((keyword, index, keywords) => (
-                <li className="inline">
+                <li key={keyword} className="inline">
                   { keyword }
-                  { index !== keywords.length - 1 &&
-                  <span>, </span>
-                  }
                 </li>
               ))}
             </ul>

--- a/ui/components/requirements/requirement.jsx
+++ b/ui/components/requirements/requirement.jsx
@@ -38,7 +38,6 @@ export default function Requirement({ requirement }) {
 
 Requirement.defaultProps = {
   requirement: {
-    keywords: [],
     policy: {},
     req_text: '',
     req_id: '',
@@ -47,7 +46,6 @@ Requirement.defaultProps = {
 
 Requirement.propTypes = {
   requirement: React.PropTypes.shape({
-    keywords: React.PropTypes.array,
     policy: React.PropTypes.shape({
       sunset: React.PropTypes.string,
     }),

--- a/ui/components/requirements/requirement.jsx
+++ b/ui/components/requirements/requirement.jsx
@@ -17,6 +17,19 @@ export default function Requirement({ requirement }) {
           <div className="sunset-date">
             Sunset date by { requirement.policy.sunset || 'none' }
           </div>
+          <div className="topics">
+            <ul className="topics-list list-reset">
+              <li className="inline">Topics: </li>
+              { requirement.keywords.map((keyword, index, keywords) => (
+                <li className="inline">
+                  { keyword }
+                  { index !== keywords.length - 1 &&
+                  <span>, </span>
+                  }
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
       </div>
     </div>
@@ -25,6 +38,7 @@ export default function Requirement({ requirement }) {
 
 Requirement.defaultProps = {
   requirement: {
+    keywords: [],
     policy: {},
     req_text: '',
     req_id: '',
@@ -33,6 +47,7 @@ Requirement.defaultProps = {
 
 Requirement.propTypes = {
   requirement: React.PropTypes.shape({
+    keywords: React.PropTypes.array,
     policy: React.PropTypes.shape({
       sunset: React.PropTypes.string,
     }),

--- a/ui/components/requirements/requirement.jsx
+++ b/ui/components/requirements/requirement.jsx
@@ -20,7 +20,7 @@ export default function Requirement({ requirement }) {
           <div className="topics">
             <span>Topics: </span>
             <ul className="topics-list list-reset inline">
-              { requirement.keywords.map((keyword, index, keywords) => (
+              { requirement.keywords.map(keyword => (
                 <li key={keyword} className="inline">
                   { keyword }
                 </li>


### PR DESCRIPTION
For each requirement, the list of associated keywords is shown. This does not link the keywords. 

@cmc333333, I'd like to work together on linking them if you have time. My best thinking involves fetching the `keywords` endpoint and comparing strings to get the appropriate ID. I wonder if there's not a more elegant solution, given that this information is already in the app.