### PR TITLE
Add django-reversion to admin view, and a basic test for it.

### DIFF
--- a/devops/dev_api.sh
+++ b/devops/dev_api.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 ./manage.py migrate --noinput
+./manage.py createinitialrevisions
 ./manage.py runserver 0.0.0.0:$PORT

--- a/devops/prod_api.sh
+++ b/devops/prod_api.sh
@@ -2,4 +2,5 @@
 
 ./manage.py migrate --noinput
 ./manage.py collectstatic --noinput
+./manage.py createinitialrevisions
 gunicorn omb_eregs.wsgi:application -b 0.0.0.0:$PORT

--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = (
     'dal_select2',
     'corsheaders',
     'rest_framework',
+    'reversion',
     'taggit_serializer',
     'django.contrib.admin',
     'django.contrib.auth',

--- a/reqs/admin.py
+++ b/reqs/admin.py
@@ -1,6 +1,7 @@
 from dal_select2_taggit.widgets import TaggitSelect2
 from django import forms
 from django.contrib import admin
+from reversion.admin import VersionAdmin
 from taggit.models import Tag
 
 from reqs.models import Keyword, Policy, Requirement
@@ -10,12 +11,12 @@ admin.site.unregister(Tag)
 
 
 @admin.register(Policy)
-class PolicyAdmin(admin.ModelAdmin):
+class PolicyAdmin(VersionAdmin):
     search_fields = ['title', 'omb_policy_id']
 
 
 @admin.register(Keyword)
-class KeywordAdmin(admin.ModelAdmin):
+class KeywordAdmin(VersionAdmin):
     search_fields = ['name']
 
 
@@ -50,6 +51,6 @@ class RequirementForm(forms.ModelForm):
 
 
 @admin.register(Requirement)
-class RequirementAdmin(admin.ModelAdmin):
+class RequirementAdmin(VersionAdmin):
     form = RequirementForm
     search_fields = ['req_id', 'req_text']

--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,7 @@ django>=1.10,<1.11
 django-autocomplete-light
 django-cors-headers
 django-filter
+django-reversion
 django-taggit
 django-taggit-serializer
 djangorestframework

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ dj-database-url==0.4.2
 django-autocomplete-light==3.2.1
 django-cors-headers==2.0.2
 django-filter==1.0.1
+django-reversion==2.0.8
 django-taggit-serializer==0.1.5
 django-taggit==0.22.0
 django==1.10.5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,6 +13,7 @@ django-autocomplete-light==3.2.1
 django-cors-headers==2.0.2
 django-debug-toolbar==1.7
 django-filter==1.0.1
+django-reversion==2.0.8
 django-taggit-serializer==0.1.5
 django-taggit==0.22.0
 django==1.10.5


### PR DESCRIPTION
That which was before /
Can be again, but the rain /
Never falls upwards.

Add tracking of version history for changes made to objects in the admin view, with the ability to both see the history of a given object and revert to prior states.