### PR TITLE
Use the router in `context` rather than passing it around

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "node": "6.9.x"
   },
   "jest": {
-    "rootDir": "ui"
+    "rootDir": "ui",
+    "testPathIgnorePatterns": ["<rootDir>/__tests__/util/"]
   }
 }

--- a/ui/__tests__/components/filter-list.test.jsx
+++ b/ui/__tests__/components/filter-list.test.jsx
@@ -2,12 +2,12 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import FilterList, { Filter } from '../../components/filter-list';
+import mockRouter from '../util/mockRouter';
 
 
 describe('<FilterList />', () => {
   it('passed transformed args to its Filters', () => {
     const params = {
-      router: { location: { query: { some: 'field', page: '5' } } },
       lookup: 'keywords',
       existingFilters: [
         { id: 1, name: 'a' }, { id: 7, name: 'b' }, { id: 10, name: 'c' },
@@ -17,11 +17,9 @@ describe('<FilterList />', () => {
     expect(filter.prop('existingIds')).toEqual([1, 7, 10]);
     expect(filter.prop('idToRemove')).toEqual(1);
     expect(filter.prop('name')).toEqual('a');
-    expect(filter.prop('location')).toEqual(params.router.location);
   });
   it('contains the correct number of Filters', () => {
     const params = {
-      router: { location: { query: {} } },
       lookup: 'keywords',
       existingFilters: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
     };
@@ -34,7 +32,6 @@ describe('<FilterList />', () => {
   });
   it('contains an AddKeyword', () => {
     const params = {
-      router: { location: { query: {} } },
       lookup: 'keywords',
       existingFilters: [],
     };
@@ -45,14 +42,16 @@ describe('<FilterList />', () => {
 });
 
 describe('<Filter />', () => {
+  const context = {
+    router: mockRouter({ pathname: '/path/', query: { some: 'stuff' } }),
+  };
   const params = {
     existingIds: [3, 5, 7],
     idToRemove: 5,
-    location: { pathname: '/path/', query: { some: 'stuff' } },
     name: 'AkeyWord',
     removeParam: 'someStr',
   };
-  const result = shallow(<Filter {...params} />);
+  const result = shallow(<Filter {...params} />, { context });
 
   it('contains the keyword name', () => {
     expect(result.text()).toMatch(/AkeyWord/);

--- a/ui/__tests__/components/pagers.test.jsx
+++ b/ui/__tests__/components/pagers.test.jsx
@@ -2,22 +2,27 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import Pagers from '../../components/pagers';
+import mockRouter from '../util/mockRouter';
+
 
 describe('<Pagers />', () => {
   it('shows zero pages when there are no results', () => {
-    const result = shallow(<Pagers count={0} />);
+    const context = { router: mockRouter() };
+    const result = shallow(<Pagers count={0} />, { context });
     expect(result.text()).toMatch(/0 of 0/);
     expect(result.find('Link').length).toEqual(0);
   });
 
   it('shows one page when there are less than 25 results', () => {
-    const result = shallow(<Pagers count={10} />);
+    const context = { router: mockRouter() };
+    const result = shallow(<Pagers count={10} />, { context });
     expect(result.text()).toMatch(/1 of 1/);
     expect(result.find('Link').length).toEqual(0);
   });
 
   it('shows a right arrow but no left arrow when on page 1', () => {
-    const result = shallow(<Pagers count={100} location={{ query: { page: '1' } }} />);
+    const context = { router: mockRouter({ query: { page: '1' } }) };
+    const result = shallow(<Pagers count={100} />, { context });
     expect(result.text()).toMatch(/1 of 4/);
     expect(result.find('Link').length).toEqual(1);
     expect(result.childAt(0).name()).toBeNull();
@@ -25,7 +30,8 @@ describe('<Pagers />', () => {
   });
 
   it('shows a left arrow but no right arrow when on final page', () => {
-    const result = shallow(<Pagers count={100} location={{ query: { page: '4' } }} />);
+    const context = { router: mockRouter({ query: { page: '4' } }) };
+    const result = shallow(<Pagers count={100} />, { context });
     expect(result.text()).toMatch(/4 of 4/);
     expect(result.find('Link').length).toEqual(1);
     expect(result.childAt(0).name()).toEqual('Link');
@@ -33,7 +39,8 @@ describe('<Pagers />', () => {
   });
 
   it('shows both arrows if on an intermediary page', () => {
-    const result = shallow(<Pagers count={100} location={{ query: { page: '2' } }} />);
+    const context = { router: mockRouter({ query: { page: '2' } }) };
+    const result = shallow(<Pagers count={100} />, { context });
     expect(result.text()).toMatch(/2 of 4/);
     expect(result.find('Link').length).toEqual(2);
     expect(result.childAt(0).name()).toEqual('Link');
@@ -42,23 +49,26 @@ describe('<Pagers />', () => {
   });
 
   it('handles corner cases around entry count', () => {
-    let text = shallow(<Pagers count={49} />).text();
+    const context = { router: mockRouter() };
+    let text = shallow(<Pagers count={49} />, { context }).text();
     expect(text).toMatch(/1 of 2/);
 
-    text = shallow(<Pagers count={50} />).text();
+    text = shallow(<Pagers count={50} />, { context }).text();
     expect(text).toMatch(/1 of 2/);
 
-    text = shallow(<Pagers count={51} />).text();
+    text = shallow(<Pagers count={51} />, { context }).text();
     expect(text).toMatch(/1 of 3/);
   });
 
   it('defaults to 1 for bad page numbers', () => {
-    const text = shallow(<Pagers count={100} location={{ query: { page: 'abcd' } }} />).text();
+    const context = { router: mockRouter({ query: { page: 'abcd' } }) };
+    const text = shallow(<Pagers count={100} />, { context }).text();
     expect(text).toMatch(/1 of 4/);
   });
 
   it('links to one page less and one more than the current', () => {
-    const component = shallow(<Pagers count={125} location={{ query: { page: '3' } }} />);
+    const context = { router: mockRouter({ query: { page: '3' } }) };
+    const component = shallow(<Pagers count={125} />, { context });
     expect(component.childAt(0).prop('to').query.page).toEqual(2);
     expect(component.childAt(2).prop('to').query.page).toEqual(4);
   });

--- a/ui/__tests__/components/requirements/tabs.test.jsx
+++ b/ui/__tests__/components/requirements/tabs.test.jsx
@@ -2,24 +2,22 @@ import { mount } from 'enzyme';
 import React from 'react';
 
 import Tabs from '../../../components/requirements/tabs';
+import mockRouter from '../../util/mockRouter';
 
 describe('<Tabs />', () => {
-  const params = {
-    router: {
-      routes: [
-        {}, { path: '/' },
-        { path: 'parent',
-          childRoutes: [
-          { path: 'child1', tabName: 'Tab 1' },
-          { path: 'childB', tabName: 'Tab B' },
-          { path: 'other', tabName: 'Other' },
-          { path: 'one-more', tabName: 'Yet Another' }] },
-        { path: 'childB' },
-      ],
-      location: { query: { some: 'value', another: 'here', page: '5' } },
-    },
-  };
-  const tabs = mount(<Tabs {...params} />).find('Tab');
+  const location = { query: { some: 'value', another: 'here', page: '5' } };
+  const routes = [
+    {}, { path: '/' },
+    { path: 'parent',
+      childRoutes: [
+        { path: 'child1', tabName: 'Tab 1' },
+        { path: 'childB', tabName: 'Tab B' },
+        { path: 'other', tabName: 'Other' },
+        { path: 'one-more', tabName: 'Yet Another' }] },
+    { path: 'childB' },
+  ];
+  const context = { router: mockRouter(location, routes) };
+  const tabs = mount(<Tabs />, { context }).find('Tab');
 
   it('includes all peer routes', () => {
     expect(tabs).toHaveLength(4);

--- a/ui/__tests__/util/mockRouter.js
+++ b/ui/__tests__/util/mockRouter.js
@@ -1,0 +1,10 @@
+import createMemoryHistory from 'react-router/lib/createMemoryHistory';
+import createTransitionManager from 'react-router/lib/createTransitionManager';
+import { createRouterObject } from 'react-router/lib/RouterUtils';
+
+export default function mockRouter(location = { pathname: '', query: {} }, routes = []) {
+  const history = createMemoryHistory(location);
+  return createRouterObject(
+    history, createTransitionManager(history, routes),
+    { location, routes });
+}

--- a/ui/components/filter-list.jsx
+++ b/ui/components/filter-list.jsx
@@ -8,9 +8,9 @@ import { Link } from 'react-router';
 import { apiParam } from './lookup-search';
 import SearchAutocomplete from './search-autocomplete';
 
-export function Filter({ existingIds, idToRemove, location, name, removeParam }) {
+export function Filter({ existingIds, idToRemove, name, removeParam }, { router }) {
   const remainingIds = existingIds.filter(v => v !== idToRemove);
-  const { pathname, query } = location;
+  const { location: { pathname, query } } = router;
   const modifiedQuery = Object.assign({}, query, {
     [removeParam]: remainingIds.join(','),
   });
@@ -31,19 +31,22 @@ export function Filter({ existingIds, idToRemove, location, name, removeParam })
 Filter.defaultProps = {
   existingIds: [],
   idToRemove: 0,
-  location: { pathname: '', query: {} },
   name: '',
   removeParam: '',
 };
 Filter.propTypes = {
   existingIds: React.PropTypes.arrayOf(React.PropTypes.number),
   idToRemove: React.PropTypes.number,
-  location: React.PropTypes.shape({
-    pathname: React.PropTypes.string,
-    query: React.PropTypes.shape({}),
-  }),
   name: React.PropTypes.string,
   removeParam: React.PropTypes.string,
+};
+Filter.contextTypes = {
+  router: React.PropTypes.shape({
+    location: React.PropTypes.shape({
+      pathname: React.PropTypes.string,
+      query: React.PropTypes.shape({}),
+    }),
+  }),
 };
 
 /* Mapping between a lookup type (e.g. "keywords") and the query field that
@@ -53,7 +56,7 @@ export const searchParam = {
   policies: 'policy_id__in',
 };
 
-export default function FilterList({ existingFilters, lookup, router }) {
+export default function FilterList({ existingFilters, lookup }) {
   const filterIds = existingFilters.map(existing => existing.id);
   return (
     <div className="req-filter-ui my2">
@@ -64,25 +67,20 @@ export default function FilterList({ existingFilters, lookup, router }) {
         { existingFilters.map(filter =>
           <Filter
             key={filter.id} existingIds={filterIds} idToRemove={filter.id}
-            location={router.location} name={filter[apiParam[lookup]]}
-            removeParam={searchParam[lookup]}
+            name={filter[apiParam[lookup]]} removeParam={searchParam[lookup]}
           />)}
       </ol>
-      <SearchAutocomplete lookup={lookup} insertParam={searchParam[lookup]} router={router} />
+      <SearchAutocomplete lookup={lookup} insertParam={searchParam[lookup]} />
     </div>
   );
 }
 FilterList.defaultProps = {
   existingFilters: [],
   lookup: 'keywords',
-  router: { location: {} },
 };
 FilterList.propTypes = {
   existingFilters: React.PropTypes.arrayOf(React.PropTypes.shape({
     id: React.PropTypes.number,
   })),
   lookup: React.PropTypes.oneOf(Object.keys(searchParam)),
-  router: React.PropTypes.shape({
-    location: React.PropTypes.shape({}),
-  }),
 };

--- a/ui/components/pagers.jsx
+++ b/ui/components/pagers.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Link } from 'react-router';
 
-export default function Pagers({ location, count }) {
+export default function Pagers({ count }, { router }) {
   let prevPage = null;
   let nextPage = null;
-  const { pathname, query } = location;
+  const { location: { pathname, query } } = router;
   let pageInt = parseInt(query.page || '1', 10) || 1;
   const nextOffset = pageInt * 25;
 
@@ -30,16 +30,19 @@ export default function Pagers({ location, count }) {
 }
 
 Pagers.defaultProps = {
-  location: { pathname: '/', query: { page: '1' } },
   count: 0,
 };
 
 Pagers.propTypes = {
-  location: React.PropTypes.shape({
-    pathname: React.PropTypes.string,
-    query: React.PropTypes.shape({
-      page: React.PropTypes.string,
+  count: React.PropTypes.number,
+};
+Pagers.contextTypes = {
+  router: React.PropTypes.shape({
+    location: React.PropTypes.shape({
+      pathname: React.PropTypes.string,
+      query: React.PropTypes.shape({
+        page: React.PropTypes.string,
+      }),
     }),
   }),
-  count: React.PropTypes.number,
 };

--- a/ui/components/requirements/by-policy.jsx
+++ b/ui/components/requirements/by-policy.jsx
@@ -51,7 +51,7 @@ export function groupReqs(requirements) {
   return groups;
 }
 
-function ByPolicy({ pagedReqs, router }) {
+function ByPolicy({ pagedReqs }) {
   const groups = groupReqs(pagedReqs.results);
   return (
     <div>
@@ -59,13 +59,12 @@ function ByPolicy({ pagedReqs, router }) {
         { groups.map(group =>
           <li key={group[0].policy.id}><Group group={group} /></li>)}
       </ul>
-      <Pagers location={router.location} count={pagedReqs.count} />
+      <Pagers count={pagedReqs.count} />
     </div>
   );
 }
 ByPolicy.defaultProps = {
   pagedReqs: { results: [], count: 0 },
-  router: { location: {} },
 };
 
 ByPolicy.propTypes = {
@@ -75,9 +74,6 @@ ByPolicy.propTypes = {
       req_id: React.PropTypes.string,
     })),
     count: React.PropTypes.number,
-  }),
-  router: React.PropTypes.shape({
-    location: React.PropTypes.shape({}),
   }),
 };
 

--- a/ui/components/requirements/container.jsx
+++ b/ui/components/requirements/container.jsx
@@ -1,21 +1,20 @@
 import React from 'react';
 import { resolve } from 'react-resolver';
-import { withRouter } from 'react-router';
 
 import { theApi } from '../../globals';
 import FilterList from '../filter-list';
 import Tabs from './tabs';
 
-function Container({ children, keywords, policies, router }) {
+function Container({ children, keywords, policies }) {
   return (
     <div className="clearfix">
       <div className="col col-2 p2">
         Search and filter
-        <FilterList existingFilters={keywords} lookup="keywords" router={router} />
-        <FilterList existingFilters={policies} lookup="policies" router={router} />
+        <FilterList existingFilters={keywords} lookup="keywords" />
+        <FilterList existingFilters={policies} lookup="policies" />
       </div>
       <div className="col col-10 pl4 border-left max-width-3">
-        <Tabs router={router} />
+        <Tabs />
         { children }
       </div>
     </div>
@@ -26,14 +25,12 @@ Container.defaultProps = {
   children: null,
   keywords: [],
   policies: [],
-  router: {},
 };
 
 Container.propTypes = {
   children: React.PropTypes.element,
   keywords: FilterList.propTypes.existingFilters,
   policies: FilterList.propTypes.existingFilters,
-  router: React.PropTypes.shape({}),
 };
 
 const fetchKeywords = ({ location: { query: { keywords__id__in } } }) =>
@@ -44,4 +41,4 @@ const fetchPolicies = ({ location: { query: { policy_id__in } } }) =>
 export default resolve({
   keywords: fetchKeywords,
   policies: fetchPolicies,
-})(withRouter(Container));
+})(Container);

--- a/ui/components/requirements/tabs.jsx
+++ b/ui/components/requirements/tabs.jsx
@@ -25,7 +25,7 @@ Tab.propTypes = {
   tabName: React.PropTypes.string,
 };
 
-export default function Tabs({ router }) {
+export default function Tabs(_, { router }) {
   if (router.routes.length < 2) {
     return null;
   }
@@ -57,10 +57,7 @@ export default function Tabs({ router }) {
     </div>
   );
 }
-Tabs.defaultProps = {
-  router: { routes: [], location: { query: {} } },
-};
-Tabs.propTypes = {
+Tabs.contextTypes = {
   router: React.PropTypes.shape({
     routes: React.PropTypes.arrayOf(React.PropTypes.shape({})),
     location: React.PropTypes.shape({

--- a/ui/components/search-autocomplete.jsx
+++ b/ui/components/search-autocomplete.jsx
@@ -9,8 +9,8 @@ import { Async } from 'react-select';
 import { apiParam, redirectQuery, search } from './lookup-search';
 
 export default class SearchAutocomplete extends React.Component {
-  constructor(props) {
-    super(props);
+  constructor(props, context) {
+    super(props, context);
     this.state = { autocomplete: false };
     // See https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md#es6-classes
     this.loadOptions = this.loadOptions.bind(this);
@@ -27,10 +27,10 @@ export default class SearchAutocomplete extends React.Component {
   }
 
   onChange(entry) {
-    const { location } = this.props.router;
+    const { location } = this.context.router;
     const query = redirectQuery(location.query, this.props.insertParam, entry.value);
     const paramStr = querystring.stringify(query);
-    this.props.router.push(`${location.pathname}?${paramStr}`);
+    this.context.router.push(`${location.pathname}?${paramStr}`);
   }
 
   loadOptions(inputStr) {
@@ -47,7 +47,7 @@ export default class SearchAutocomplete extends React.Component {
 
   render() {
     const { insertParam, lookup } = this.props;
-    const { pathname, query } = this.props.router.location;
+    const { pathname, query } = this.context.router.location;
     if (this.state.autocomplete) {
       return <Async loadOptions={this.loadOptions} onChange={this.onChange} />;
     }
@@ -66,14 +66,12 @@ export default class SearchAutocomplete extends React.Component {
 SearchAutocomplete.defaultProps = {
   lookup: '',
   insertParam: '',
-  router: {
-    location: { query: {}, pathname: '' },
-    push: null,
-  },
 };
 SearchAutocomplete.propTypes = {
   lookup: React.PropTypes.string,
   insertParam: React.PropTypes.string,
+};
+SearchAutocomplete.contextTypes = {
   router: React.PropTypes.shape({
     location: React.PropTypes.shape({
       query: React.PropTypes.shape({}),


### PR DESCRIPTION
Part of #170, this makes testing a bit more difficult, but means we don't have to thread the router through the whole app, which is particularly important as we create more and more nested components.