### PR TITLE
Don't specify node minor version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "validator": "^7.0.0"
   },
   "engines": {
-    "node": "6.9.x"
+    "node": "6.x"
   },
   "jest": {
     "rootDir": "ui",


### PR DESCRIPTION
Cloud Foundry buildpacks might drop support for a minor version; 6.x is the
LTS.