### PR TITLE
Use MAX Login on cloud.gov

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,20 @@ services:
         }}}]}
 ```
 
+### Running w/ MAX Authentication
+
+In production, we always run with [MAX](https://max.gov/) authentication, but
+for local development, we've opted for Django's password-based authentication.
+If you would prefer to test MAX authentication, uncomment the appropriate
+environment variable in docker-compose.yml:
+
+```yml
+services:
+  dev-api:
+    environment:
+      MAX_URL: https://example.com/etc
+```
+
 
 ## API Endpoints
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       PORT: 8001
       DJANGO_SETTINGS_MODULE: omb_eregs.settings
       TMPDIR: /tmp
+      # Uncomment the following line for MAX logins
+      # MAX_URL: https://login.max.gov/cas/login
       VCAP_APPLICATION: >
         {"uris": ["localhost", "0.0.0.0", "127.0.0.1", "prod-api", "dev-api"]}
       VCAP_SERVICES: >
@@ -39,6 +41,8 @@ services:
     environment:
       <<: *API_ENV
       DEBUG: "true"
+      # Uncomment the following line for MAX logins
+      # MAX_URL: https://login.test.max.gov/cas/login
 
   prod: &PROD_UI
     image: node:6

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -12,7 +12,8 @@ applications:
     command: ./devops/prod_api.sh
     host: omb-eregs-api-demo
     env:
-      NEW_RELIC_APP_NAME: 'OMB Demo API/Admin'
+      NEW_RELIC_APP_NAME: OMB Demo API/Admin
+      MAX_URL: https://login.test.max.gov/cas/login
   - name: ui
     buildpack: nodejs_buildpack
     command: node ui-dist/server.js
@@ -22,4 +23,4 @@ applications:
     env:
       INTERNAL_API: https://omb-eregs-api-demo.app.cloud.gov/
       PUBLIC_API: https://omb-eregs-api-demo.app.cloud.gov/
-      NEW_RELIC_APP_NAME: 'OMB Demo UI'
+      NEW_RELIC_APP_NAME: OMB Demo UI

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -13,7 +13,8 @@ applications:
     command: ./devops/prod_api.sh
     host: omb-eregs-api
     env:
-      NEW_RELIC_APP_NAME: 'OMB Prod API/Admin'
+      NEW_RELIC_APP_NAME: OMB Prod API/Admin
+      MAX_URL: https://login.max.gov/cas/login
   - name: ui
     buildpack: nodejs_buildpack
     command: node ui-dist/server.js
@@ -23,4 +24,4 @@ applications:
     env:
       INTERNAL_API: https://omb-eregs-api.app.cloud.gov/
       PUBLIC_API: https://omb-eregs-api.app.cloud.gov/
-      NEW_RELIC_APP_NAME: 'OMB Prod UI'
+      NEW_RELIC_APP_NAME: OMB Prod UI

--- a/omb_eregs/max_backend.py
+++ b/omb_eregs/max_backend.py
@@ -16,6 +16,7 @@ class MAXBackend(CASBackend):
 
         user = User.objects.filter(username=email).first()
         if user:
+            # Trim to thirty chars to match Django User max lengths
             user.first_name = attributes.get('First-Name', '')[:30]
             user.last_name = attributes.get('Last-Name', '')[:30]
             user.email = email

--- a/omb_eregs/max_backend.py
+++ b/omb_eregs/max_backend.py
@@ -1,0 +1,25 @@
+from django.contrib.auth.models import User
+from django_cas_ng.backends import CASBackend
+from django_cas_ng.utils import get_cas_client
+
+
+class MAXBackend(CASBackend):
+    """A specific version of the CASBackend which uses email address as the
+    username"""
+    def authenticate(self, request, ticket, service):
+        client = get_cas_client(service_url=service)
+        max_username, attributes, _ = client.verify_ticket(ticket)
+        if not max_username:    # bad ticket
+            return None
+
+        email = attributes.get('Email-Address', '')
+
+        user = User.objects.filter(username=email).first()
+        if user:
+            user.first_name = attributes.get('First-Name', '')[:30]
+            user.last_name = attributes.get('Last-Name', '')[:30]
+            user.email = email
+            user.is_staff = True
+            user.save()
+
+            return user

--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -37,7 +37,7 @@ ALLOWED_HOSTS = env.uris
 
 INSTALLED_APPS = (
     'taggit',
-    'reqs.apps.ReqsConfig',
+    'reqs.apps.ReqsConfig',     # must be after taggit
     'dal',
     'dal_select2',
     'corsheaders',
@@ -114,6 +114,17 @@ AUTH_PASSWORD_VALIDATORS = [
         'CommonPasswordValidator', 'NumericPasswordValidator')
 ]
 
+MAX_URL = os.environ.get('MAX_URL')
+
+if MAX_URL:
+    INSTALLED_APPS += ('django_cas_ng',)
+    AUTHENTICATION_BACKENDS = ['omb_eregs.max_backend.MAXBackend']
+    CAS_SERVER_URL = MAX_URL
+    CAS_REDIRECT_URL = '/admin/'
+    # The following attributes are ignored in our implementation, including
+    # as documentation
+    CAS_CREATE_USER = False
+    CAS_USERNAME_ATTRIBUTE = 'Email-Address'
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.10/topics/i18n/

--- a/omb_eregs/templates/403.html
+++ b/omb_eregs/templates/403.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <title>Forbidden</title>
+  </head>
+  <body>
+    <h1>Forbidden</h1>
+    <p>You are not permitted to access this page. Please confirm your
+    permissions with your system administrator.</p>
+  </body>
+</html>

--- a/omb_eregs/tests/max_login_tests.py
+++ b/omb_eregs/tests/max_login_tests.py
@@ -1,0 +1,68 @@
+from unittest.mock import Mock, call
+
+import pytest
+from django.contrib.auth.models import User
+from model_mommy import mommy
+
+from omb_eregs import max_backend
+
+
+@pytest.fixture
+def max_setup(monkeypatch):
+    monkeypatch.setattr(max_backend, 'get_cas_client', Mock())
+    attributes = {
+        'First-Name': 'Freddie',
+        'Last-Name': 'Mercury',
+        'Email-Address': 'fred@example.com',
+    }
+    verify_ticket = max_backend.get_cas_client.return_value.verify_ticket
+    verify_ticket.return_value = (Mock(), attributes, Mock())
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures('max_setup')
+def test_authenticate_success():
+    """Verify that a user is configured correctly"""
+    get_cas_client = max_backend.get_cas_client
+    verify_ticket = get_cas_client.return_value.verify_ticket
+    user = mommy.make(User, is_staff=False, username='fred@example.com')
+
+    backend = max_backend.MAXBackend()
+    backend.authenticate(Mock(), 'some-ticket', 'service-url')
+
+    assert get_cas_client.call_args == call(service_url='service-url')
+    assert verify_ticket.call_args == call('some-ticket')
+
+    user = User.objects.get(pk=user.pk)
+    assert user.first_name == 'Freddie'
+    assert user.last_name == 'Mercury'
+    assert user.email == 'fred@example.com'
+    assert user.is_staff
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures('max_setup')
+def test_authenticate_failure_unknown_user():
+    """If MAX knows about the user but Django does not, we should fail"""
+    assert User.objects.count() == 0
+
+    backend = max_backend.MAXBackend()
+    result = backend.authenticate(Mock(), 'some-ticket', 'service-url')
+    assert result is None
+    assert User.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_authenticate_ticket_failure(monkeypatch):
+    """If MAX isn't aware of the user, we shouldn't explode (nor create a new
+    user)"""
+    monkeypatch.setattr(max_backend, 'get_cas_client', Mock())
+    verify_ticket = max_backend.get_cas_client.return_value.verify_ticket
+    verify_ticket.return_value = (None, Mock(), Mock())
+
+    assert User.objects.count() == 0
+
+    backend = max_backend.MAXBackend()
+    result = backend.authenticate(Mock(), 'some-ticket', 'service-url')
+    assert result is None
+    assert User.objects.count() == 0

--- a/omb_eregs/urls.py
+++ b/omb_eregs/urls.py
@@ -29,3 +29,7 @@ urlpatterns = [
 if settings.DEBUG:
     import debug_toolbar
     urlpatterns.insert(0, url(r'^__debug__/', include(debug_toolbar.urls)))
+
+if settings.MAX_URL:
+    from django_cas_ng.views import login as cas_login
+    urlpatterns.insert(0, url(r'^admin/login/$', cas_login))

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 cfenv
 django>=1.10,<1.11
 django-autocomplete-light
+django-cas-ng
 django-cors-headers
 django-filter
 django-reversion

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 cfenv==0.5.2
 dj-database-url==0.4.2
 django-autocomplete-light==3.2.1
+django-cas-ng==3.5.7
 django-cors-headers==2.0.2
 django-filter==1.0.1
 django-reversion==2.0.8
@@ -19,7 +20,8 @@ gunicorn==19.6.0
 newrelic==2.82.0.62
 orderedmultidict==0.7.11  # via furl
 psycopg2==2.6.2
+python-cas==1.2.0         # via django-cas-ng
 python-dateutil==2.6.0
 requests==2.13.0
-six==1.10.0               # via furl, orderedmultidict, python-dateutil
+six==1.10.0               # via furl, orderedmultidict, python-cas, python-dateutil
 whitenoise==3.3.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,6 +10,7 @@ cfenv==0.5.2
 coverage==4.3.4           # via pytest-cov
 dj-database-url==0.4.2
 django-autocomplete-light==3.2.1
+django-cas-ng==3.5.7
 django-cors-headers==2.0.2
 django-debug-toolbar==1.7
 django-filter==1.0.1
@@ -46,6 +47,7 @@ pyparsing==2.1.10         # via packaging
 pytest-cov==2.4.0
 pytest-django==3.1.2
 pytest==3.0.6
+python-cas==1.2.0
 python-dateutil==2.6.0
 requests==2.13.0
 six==1.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [tool:pytest]
 python_files=test*.py *test.py *tests.py
 DJANGO_SETTINGS_MODULE=omb_eregs.settings
-testpaths=reqs/tests
+testpaths=omb_eregs/tests reqs/tests
 
 [flake8]
 exclude = 


### PR DESCRIPTION
Connects to MAX for login needs. For the most part the django-cas-ng library does what we need; the exception is that MAX usernames are meaningless, so we override that bit to treat the email address as a username.

To emphasize, this strategy requires that we create user accounts _ahead_ of their first login; we're using MAX for authentication not authorization. I've create user accounts on the demo server for everyone on the 18F side.

This requires a `docker-compose build` if running Python tests; shouldn't need it otherwise. Should resolve #130 