### PR TITLE
Include keyword ids in nested models of Requirements API

### DIFF
--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -43,7 +43,6 @@ INSTALLED_APPS = (
     'corsheaders',
     'rest_framework',
     'reversion',
-    'taggit_serializer',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/reqs/serializers.py
+++ b/reqs/serializers.py
@@ -1,6 +1,4 @@
 from rest_framework import serializers
-from taggit_serializer.serializers import (TaggitSerializer,
-                                           TagListSerializerField)
 
 from reqs.models import Keyword, Policy, Requirement
 
@@ -14,9 +12,15 @@ class PolicySerializer(serializers.ModelSerializer):
         )
 
 
-class RequirementSerializer(TaggitSerializer, serializers.ModelSerializer):
+class KeywordSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Keyword
+        fields = ('id', 'name')
+
+
+class RequirementSerializer(serializers.ModelSerializer):
     policy = PolicySerializer(read_only=True)
-    keywords = TagListSerializerField()
+    keywords = KeywordSerializer(read_only=True, many=True)
 
     class Meta:
         model = Requirement
@@ -25,9 +29,3 @@ class RequirementSerializer(TaggitSerializer, serializers.ModelSerializer):
             'policy_sub_section', 'req_text', 'verb', 'impacted_entity',
             'req_deadline', 'citation', 'keywords',
         )
-
-
-class KeywordSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Keyword
-        fields = ('id', 'name')

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,6 @@ django-cors-headers
 django-filter
 django-reversion
 django-taggit
-django-taggit-serializer
 djangorestframework
 dj-database-url
 gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ django-cas-ng==3.5.7
 django-cors-headers==2.0.2
 django-filter==1.0.2
 django-reversion==2.0.8
-django-taggit-serializer==0.1.5
 django-taggit==0.22.0
 django==1.10.7
 djangorestframework==3.6.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,7 +15,6 @@ django-cors-headers==2.0.2
 django-debug-toolbar==1.7
 django-filter==1.0.2
 django-reversion==2.0.8
-django-taggit-serializer==0.1.5
 django-taggit==0.22.0
 django==1.10.7
 djangorestframework==3.6.2

--- a/ui/components/requirements/requirement.jsx
+++ b/ui/components/requirements/requirement.jsx
@@ -25,8 +25,8 @@ export default function Requirement({ requirement }) {
             <span>Topics: </span>
             <ul className="topics-list list-reset inline">
               { requirement.keywords.map(keyword => (
-                <li key={keyword} className="inline">
-                  { keyword }
+                <li key={keyword.id} className="inline">
+                  { keyword.name }
                 </li>
               ))}
             </ul>
@@ -39,6 +39,7 @@ export default function Requirement({ requirement }) {
 
 Requirement.defaultProps = {
   requirement: {
+    keywords: [],
     policy: {},
     req_text: '',
     req_id: '',
@@ -47,6 +48,10 @@ Requirement.defaultProps = {
 
 Requirement.propTypes = {
   requirement: React.PropTypes.shape({
+    keywords: React.PropTypes.arrayOf(React.PropTypes.shape({
+      id: React.PropTypes.number,
+      name: React.PropTypes.string,
+    })),
     policy: React.PropTypes.shape({
       sunset: React.PropTypes.string,
     }),


### PR DESCRIPTION
This is needed for #181 (so we know which keyword id was clicked)