### PR TITLE
Display more metadata with requirements

### DIFF
--- a/ui/__tests__/components/requirements/metadata.test.jsx
+++ b/ui/__tests__/components/requirements/metadata.test.jsx
@@ -1,0 +1,57 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { Metadata } from '../../../components/requirements/requirement';
+
+describe('<Metadata />', () => {
+  const basic = shallow(
+    <Metadata
+      className="something-hyphenated"
+      name="IAmAKey"
+      value="IAmAValue"
+    />);
+  it('renders', () => {
+    expect(basic.type()).toBe('div');
+  });
+  it('has the right classes', () => {
+    expect(basic.props().className).toMatch('something-hyphenated metadata');
+  });
+  it('has the right text content', () => {
+    expect(basic.text()).toMatch('IAmAKey: IAmAValue');
+  });
+
+  const separated = shallow(
+    <Metadata
+      className="something-hyphenated"
+      name="IAmAKey"
+      value="IAmAValue"
+      separator=" I separate things "
+    />);
+  it('has the right text content with separator', () => {
+    expect(separated.text()).toMatch('IAmAKey I separate things IAmAValue');
+  });
+
+  const noValue = shallow(
+    <Metadata
+      className="something-hyphenated"
+      name="IAmAKey"
+      value=""
+    />);
+  it('returns null when value and nullValue are null', () => {
+    expect(noValue.type()).toBe(null);
+  });
+
+  const noValueAlt = shallow(
+    <Metadata
+      className="something-hyphenated"
+      name="IAmAKey"
+      value=""
+      nullValue="Show this instead"
+    />);
+  it('renders if nullValue is present', () => {
+    expect(noValueAlt.type()).toBe('div');
+  });
+  it('shows the nullValue content', () => {
+    expect(noValueAlt.text()).toMatch('Show this instead');
+  });
+});

--- a/ui/assets/css/_requirements.scss
+++ b/ui/assets/css/_requirements.scss
@@ -9,9 +9,7 @@
     color: $color-gray-dark;
   }
 
-  .applies-to,
-  .sunset-date,
-  .topics {
+  .metadata {
     @include font-source-sans-pro();
     color: $color-gray;
     font-size: 0.8125rem;

--- a/ui/components/requirements/requirement.jsx
+++ b/ui/components/requirements/requirement.jsx
@@ -52,8 +52,8 @@ export default function Requirement({ requirement }) {
           <Metadata
             className="applies-to mr2"
             name="Applies to"
-            value=""
-            nullValue="Applies to: [not implemented]"
+            value={requirement.impacted_entity}
+            nullValue="Applies to: unknown"
           />
           <Metadata
             className="issuing-body"

--- a/ui/components/requirements/requirement.jsx
+++ b/ui/components/requirements/requirement.jsx
@@ -1,5 +1,39 @@
 import React from 'react';
 
+export function Metadata({ className, name, value, nullValue, separator }) {
+  /**
+   * Returns a div element that has className equal to the argument plus 'metadata', and content
+   * that is either <name><separator><value> or, if value is null and nullValue is not, the content
+   * is the nullValue argument.
+   *
+   * If value and nullValue are both null, returns null.
+   */
+  if (!value && !nullValue) {
+    return null;
+  }
+  const classes = className.split(' ');
+  const classString = classes.includes('metadata') ? className : `${classes.join(' ')} metadata`;
+  const content = value ? `${name}${separator}${value}` : nullValue;
+  return (
+    <div className={classString}>
+      {`${content}`}
+    </div>);
+}
+
+Metadata.propTypes = {
+  className: React.PropTypes.string.isRequired,
+  name: React.PropTypes.string.isRequired,
+  value: React.PropTypes.string.isRequired,
+  nullValue: React.PropTypes.string,
+  separator: React.PropTypes.string,
+};
+
+Metadata.defaultProps = {
+  nullValue: '',
+  separator: ': ',
+};
+
+
 export default function Requirement({ requirement }) {
   // We could have multiple lines with the same text, so can't use a stable ID
   /* eslint-disable react/no-array-index-key */
@@ -7,7 +41,6 @@ export default function Requirement({ requirement }) {
     <span key={idx} className="req-text-line mb1">{ line }<br /></span>
   ));
   /* eslint-enable react/no-array-index-key */
-  const sunsetString = requirement.policy.sunset ? 'Sunset date by $requirement.policy.sunset' : 'Sunset date: none';
   return (
     <div className="req p2 clearfix max-width-3">
       <div className="req-id col col-1 mb2 mr1">
@@ -16,36 +49,40 @@ export default function Requirement({ requirement }) {
       <div className="req-text col col-10">
         { reqTexts }
         <div className="clearfix mt3">
-          <div className="applies-to mr2 metadata">
-            Applies to: [not implemented]
-          </div>
-          { requirement.issuing_body ? (
-            <div className="issuing-body metadata">
-              Issuing body: { requirement.issuing_body }
-            </div>
-          ) : (
-            ''
-          ) }
-          <div className="sunset-date metadata">
-            { sunsetString }
-          </div>
-          <div className="policy-title metadata">
-            Policy title: { requirement.policy.title || 'none' }
-          </div>
-          { requirement.policy.issuance ? (
-            <div className="issuance metadata">
-              Policy issuance: { requirement.policy.issuance }
-            </div>
-          ) : (
-            ''
-          ) }
-          { requirement.policy.omb_policy_id ? (
-            <div className="omb-policy-id metadata">
-              OMB Policy ID: { requirement.policy.omb_policy_id }
-            </div>
-          ) : (
-            ''
-          ) }
+          <Metadata
+            className="applies-to mr2"
+            name="Applies to"
+            value=""
+            nullValue="Applies to: [not implemented]"
+          />
+          <Metadata
+            className="issuing-body"
+            name="Issuing body"
+            value={requirement.issuing_body}
+          />
+          <Metadata
+            className="sunset-date"
+            name="Sunset date"
+            value={requirement.policy.sunset}
+            nullValue="Sunset date: none"
+            separator=" by "
+          />
+          <Metadata
+            className="policy-title"
+            name="Policy title"
+            value={requirement.policy.title}
+            nullValue="Policy title: none"
+          />
+          <Metadata
+            className="issuance"
+            name="Policy issuance"
+            value={requirement.policy.issuance}
+          />
+          <Metadata
+            className="omb-policy-id"
+            name="OMB Policy ID"
+            value={requirement.policy.omb_policy_id}
+          />
           <div className="topics metadata">
             <span>Topics: </span>
             <ul className="topics-list list-reset inline">

--- a/ui/components/requirements/requirement.jsx
+++ b/ui/components/requirements/requirement.jsx
@@ -7,6 +7,7 @@ export default function Requirement({ requirement }) {
     <span key={idx} className="req-text-line mb1">{ line }<br /></span>
   ));
   /* eslint-enable react/no-array-index-key */
+  const sunsetString = requirement.policy.sunset ? 'Sunset date by $requirement.policy.sunset' : 'Sunset date: none';
   return (
     <div className="req p2 clearfix max-width-3">
       <div className="req-id col col-1 mb2 mr1">
@@ -15,13 +16,37 @@ export default function Requirement({ requirement }) {
       <div className="req-text col col-10">
         { reqTexts }
         <div className="clearfix mt3">
-          <div className="applies-to mr2">
+          <div className="applies-to mr2 metadata">
             Applies to: [not implemented]
           </div>
-          <div className="sunset-date">
-            Sunset date by { requirement.policy.sunset || 'none' }
+          { requirement.issuing_body ? (
+            <div className="issuing-body metadata">
+              Issuing body: { requirement.issuing_body }
+            </div>
+          ) : (
+            ''
+          ) }
+          <div className="sunset-date metadata">
+            { sunsetString }
           </div>
-          <div className="topics">
+          <div className="policy-title metadata">
+            Policy title: { requirement.policy.title || 'none' }
+          </div>
+          { requirement.policy.issuance ? (
+            <div className="issuance metadata">
+              Policy issuance: { requirement.policy.issuance }
+            </div>
+          ) : (
+            ''
+          ) }
+          { requirement.policy.omb_policy_id ? (
+            <div className="omb-policy-id metadata">
+              OMB Policy ID: { requirement.policy.omb_policy_id }
+            </div>
+          ) : (
+            ''
+          ) }
+          <div className="topics metadata">
             <span>Topics: </span>
             <ul className="topics-list list-reset inline">
               { requirement.keywords.map(keyword => (


### PR DESCRIPTION
More information, /
More properties, more info. /
Surely thus better.

Adds:

- Issuing body
- Policy title
- Policy issuance date
- OMB Policy ID

Also displays “Sunset date: none” if there's no sunset date.

Other than OMB Policy ID, these are all arbitrary additions, and not my idea of what the essential properties are.