### PR TITLE
Pass API 404's to the user.

### DIFF
--- a/devops/integration_tests/smoke_tests.py
+++ b/devops/integration_tests/smoke_tests.py
@@ -23,3 +23,10 @@ def test_admin_lists_models(selenium, admin_login):
     assert selenium.find_element_by_link_text('Keywords') is not None
     assert selenium.find_element_by_link_text('Policies') is not None
     assert selenium.find_element_by_link_text('Requirements') is not None
+
+
+def test_ui_proxies_404(selenium, app_urls):
+    selenium.get(app_urls.ui + 'requirements/by-keyword?page=9999')
+    html = selenium.find_element_by_tag_name('html')
+    assert 'Server Error' not in html.text
+    assert 'Page not found' in html.text

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,9 @@ services:
       VCAP_APPLICATION: >
         {"uris": ["localhost", "0.0.0.0", "127.0.0.1", "prod-api", "dev-api"]}
       VCAP_SERVICES: >
-        {"config": [{"credentials": {"DJANGO_SECRET_KEY": "NotASecret"}}]}
+        {"config": [{"credentials":
+          {"DJANGO_SECRET_KEY": "NotASecret", "USING_SSL": "False"}
+        }]}
     volumes:
       - $PWD:/usr/src/app
     working_dir: /usr/src/app

--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -82,6 +82,10 @@ CSRF_COOKIE_HTTPONLY = True
 SECURE_BROWSER_XSS_FILTER = True
 # Request browsers not guess at mimetypes
 SECURE_CONTENT_TYPE_NOSNIFF = True
+# Request cookies only be sent over SSL
+USING_SSL = env.get_credential('USING_SSL', 'TRUE').upper() == 'TRUE'
+SESSION_COOKIE_SECURE = USING_SSL
+CSRF_COOKIE_SECURE = USING_SSL
 
 ROOT_URLCONF = 'omb_eregs.urls'
 

--- a/ui/server-render.js
+++ b/ui/server-render.js
@@ -11,6 +11,11 @@ import FourOhFour from './components/errors/fourOhFour';
 import Html from './components/html';
 
 
+function render404(res) {
+  const fourOhFour = React.createElement(FourOhFour);
+  res.status(404).send(renderToStaticMarkup(fourOhFour));
+}
+
 function resolveAndRender(renderProps, res) {
   Resolver
     .resolve(() => React.createElement(RouterContext, renderProps))
@@ -20,7 +25,11 @@ function resolveAndRender(renderProps, res) {
       res.status(200).send(renderToStaticMarkup(html));
     })
     .catch((err) => {
-      handleError(err, null, res);
+      if (err.response && err.response.status === 404) {
+        render404(res);
+      } else {
+        handleError(err, null, res);
+      }
     });
 }
 
@@ -34,8 +43,7 @@ export default function (req, res) {
     } else if (renderProps) {
       resolveAndRender(renderProps, res);
     } else {
-      const fourOhFour = React.createElement(FourOhFour);
-      res.status(404).send(renderToStaticMarkup(fourOhFour));
+      render404(res);
     }
   });
 }


### PR DESCRIPTION
This resolves two issues ZAP found:
* using a large page number gives a 404 from the API, but had been 500ing the UI
* cookies should only be sent over SSL (when SSL is available)

~~I think it makes the most sense to write an integration test once #208's merged.~~