### PR TITLE
Include DAP for page tracking.

### DIFF
--- a/ui/components/dap.jsx
+++ b/ui/components/dap.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+
+export default () => (
+  <script
+    async
+    type="text/javascript"
+    id="_fed_an_ua_tag"
+    src="https://dap.digitalgov.gov/Universal­Federated­Analytics­Min.js?agency=EOP&subagency=OMB"
+  />
+);

--- a/ui/components/errors/fiveHundred.jsx
+++ b/ui/components/errors/fiveHundred.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import config from '../../config';
+import DAP from '../dap';
 
 
 export default function FiveHundred({ err }) {
@@ -23,6 +24,7 @@ export default function FiveHundred({ err }) {
     <html lang="en-US">
       <head>
         <title>{ title }</title>
+        <DAP />
       </head>
       <body>
         <h1>{ title }</h1>

--- a/ui/components/errors/fourHundred.jsx
+++ b/ui/components/errors/fourHundred.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import DAP from '../dap';
+
 
 export default function FourHundred({ message }) {
   const title = 'Invalid Request';
@@ -7,6 +9,7 @@ export default function FourHundred({ message }) {
     <html lang="en-US">
       <head>
         <title>{ title }</title>
+        <DAP />
       </head>
       <body>
         <h1>{ title }</h1>

--- a/ui/components/errors/fourOhFour.jsx
+++ b/ui/components/errors/fourOhFour.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
 
-export default function FourOhFour() {
-  return (
-    <html lang="en-US">
-      <head>
-        <title>Page not found</title>
-      </head>
-      <body>
-        <h1>Page not found</h1>
-        <p>Please check the URL and try again</p>
-      </body>
-    </html>
-  );
-}
+import DAP from '../dap';
+
+
+export default () => (
+  <html lang="en-US">
+    <head>
+      <title>Page not found</title>
+      <DAP />
+    </head>
+    <body>
+      <h1>Page not found</h1>
+      <p>Please check the URL and try again</p>
+    </body>
+  </html>
+);

--- a/ui/components/html.jsx
+++ b/ui/components/html.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import serialize from 'serialize-javascript';
 
 import config from '../config';
+import DAP from './dap';
 
 
 export default function Html({ contents, data }) {
@@ -21,6 +22,7 @@ export default function Html({ contents, data }) {
     <html lang="en-US">
       <head>
         <link rel="stylesheet" href="/static/styles.css" />
+        <DAP />
       </head>
       <body>
         <div id="app">

--- a/ui/routes.jsx
+++ b/ui/routes.jsx
@@ -10,6 +10,16 @@ import ReqsByKeyword from './components/requirements/by-keyword';
 import ReqsByPolicy from './components/requirements/by-policy';
 import AsyncLookupSearch, { redirectIfMatched } from './components/lookup-search';
 
+// Trigger DAP pageviews when our history changes (for single-page-app users)
+if (browserHistory && typeof gas !== 'undefined') {
+  browserHistory.listen((loc) => {
+    // Provided by DAP
+    /* eslint-disable no-undef */
+    gas('send', 'pageview', `${loc.pathname}${loc.search}`);
+    /* eslint-enable no-undef */
+  });
+}
+
 export default <Router history={browserHistory} >
   <Route path="/" component={App}>
     <IndexRoute component={Index} />


### PR DESCRIPTION
We need to explicitly trigger a pageview when the user loads another page,
too.

This doesn't attempt to resolve the link usage drama mentioned here:
https://github.com/digital-analytics-program/gov-wide-code/pull/47 but should
be enough to get us started.