### PR TITLE
Add an API cache to the frontend.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -29,7 +29,7 @@
     },
     "asap": {
       "version": "2.0.5",
-      "from": "asap@>=2.0.3 <2.1.0",
+      "from": "asap@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
     },
     "axios": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "express": "^4.14.1",
     "helmet": "^3.5.0",
     "http-auth": "^3.1.1",
+    "lru-cache": "^4.0.2",
     "morgan": "^1.8.1",
     "newrelic": "^1.38.1",
     "react": "^15.4.2",

--- a/ui/config.js
+++ b/ui/config.js
@@ -1,6 +1,10 @@
 const config = {
   apiRoot: 'https://example.com/',
   debug: false,
+  cacheConfig: {
+    max: 32,
+    maxAge: 1000 * 60 * 60,   // 1 hour
+  },
 };
 
 if (typeof process !== 'undefined') {


### PR DESCRIPTION
A short-term solution for #231, this sets up a per-endpoint
least-recently-used cache to prevent repeated API calls from being made.