### PR TITLE
Request users not to cache content

### DIFF
--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -57,6 +57,7 @@ if DEBUG:
     INSTALLED_APPS += ('debug_toolbar', )
 
 MIDDLEWARE = (
+    'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'corsheaders.middleware.CorsMiddleware',
@@ -67,6 +68,7 @@ MIDDLEWARE = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.cache.FetchFromCacheMiddleware',
 )
 if DEBUG:
     MIDDLEWARE = ('debug_toolbar.middleware.DebugToolbarMiddleware',) + \
@@ -88,6 +90,10 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 USING_SSL = env.get_credential('USING_SSL', 'TRUE').upper() == 'TRUE'
 SESSION_COOKIE_SECURE = USING_SSL
 CSRF_COOKIE_SECURE = USING_SSL
+
+# For the time being, tell downstream (notably CloudFront) to avoid caching
+# content rather than guessing.
+CACHE_MIDDLEWARE_SECONDS = 0
 
 ROOT_URLCONF = 'omb_eregs.urls'
 

--- a/ui/do-not-cache.js
+++ b/ui/do-not-cache.js
@@ -1,0 +1,8 @@
+/* Middleware that asks down-stream caches (notably CloudFront) to _not_ keep
+ * anything. */
+export default function doNotCache(req, res, next) {
+  res.append('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store');
+  res.append('Expires', '0');
+  res.append('Pragma', 'no-cache');
+  next();
+}

--- a/ui/server.js
+++ b/ui/server.js
@@ -9,6 +9,7 @@ import helmet from 'helmet';
 import morgan from 'morgan';
 
 import basicAuth from './basic-auth';
+import doNotCache from './do-not-cache';
 import errorHandler from './error-handling';
 import serverRender from './server-render';
 
@@ -20,6 +21,7 @@ const auth = basicAuth(env.getServiceCreds('config'));
 // security headers. See docs around setOnOldIE: moral of the story is that
 // ZAP masquerades as IE6 which triggers a different policy within helmet
 app.use(helmet({ xssFilter: { setOnOldIE: true } }));
+app.use(doNotCache);
 // logging
 app.use(morgan('combined'));
 app.use('/static', express.static(path.join('ui-dist', 'static')));


### PR DESCRIPTION
Without setting explicit headers, CloudFront has a cache timeout of 24 hours. This sets that timeout to zero (which is what we assumed) for the time being. It should resolve #264.