### PR TITLE
Log changes to console

### DIFF
--- a/ereqs_admin/apps.py
+++ b/ereqs_admin/apps.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.apps import AppConfig
-from django.db.models.signals import post_migrate
+from django.db.models.signals import m2m_changed, post_migrate, post_save
 
 logger = logging.getLogger(__name__)
 
@@ -17,8 +17,50 @@ def create_editors(**kwargs):
             content_type__app_label='reqs')
 
 
+def adminlog_post_save(sender, instance, **kwargs):
+    """Django's admin already logs when edits are made. Pass that along to our
+    logging system."""
+    # Can't load these at the top as this module is loaded before the apps are
+    # completely loaded
+    from django.contrib.admin.models import ADDITION, CHANGE, DELETION  # noqa
+    if instance.action_flag == ADDITION:
+        logger.info("%s created %s '%s'", instance.user.username,
+                    instance.content_type, instance.object_repr)
+    elif instance.action_flag == DELETION:
+        logger.info("%s deleted %s '%s'", instance.user.username,
+                    instance.content_type, instance.object_repr)
+    elif instance.action_flag == CHANGE:
+        logger.info("%s changed %s %s: '%s'", instance.user.username,
+                    instance.content_type, instance.object_repr,
+                    instance.get_change_message())
+
+
+def log_m2m_change(sender, instance, action, reverse, model, pk_set, **kwargs):
+    """Log changes for many-to-many fields, notably around permissions and
+    groups"""
+    model_name = model._meta.verbose_name_plural
+    instance_model = instance._meta.verbose_name
+    if action == 'post_add':
+        objects_added = list(model.objects.filter(pk__in=pk_set))
+        logger.info("%s given to %s '%s': %s", model_name, instance_model,
+                    instance, objects_added)
+    elif action == 'post_remove':
+        objects_added = list(model.objects.filter(pk__in=pk_set))
+        logger.info("%s removed from %s '%s': %s", model_name, instance_model,
+                    instance, objects_added)
+    elif action == 'post_clear':
+        logger.info("All %s removed from %s '%s'", model_name, instance_model,
+                    instance)
+
+
 class EreqsAdminConfig(AppConfig):
     name = 'ereqs_admin'
 
     def ready(self):
+        from django.contrib.auth.models import Group, User     # noqa
         post_migrate.connect(create_editors, sender=self)
+        post_save.connect(adminlog_post_save, sender='admin.LogEntry')
+        m2m_changed.connect(log_m2m_change, sender=User.groups.through)
+        m2m_changed.connect(log_m2m_change,
+                            sender=User.user_permissions.through)
+        m2m_changed.connect(log_m2m_change, sender=Group.permissions.through)

--- a/ereqs_admin/tests/apps_tests.py
+++ b/ereqs_admin/tests/apps_tests.py
@@ -28,3 +28,29 @@ def test_create_editors_once():
     assert Group.objects.count() == 1
     # three permissions per model
     assert Group.objects.first().permissions.count() == 3*4
+
+
+class MockLogger():
+    def __init__(self):
+        self.logs = []
+
+    def info(self, fmt, *args):
+        self.logs.append(fmt % args)    # noqa log format uses %s
+
+
+def test_admin_logging(monkeypatch, admin_client):
+    """Spot check that we receive logs around Group edits"""
+    monkeypatch.setattr(apps, 'logger', MockLogger())
+    admin_client.post('/admin/auth/group/add/', {
+        'name': 'Looking For', 'permissions': '1'})
+    group = Group.objects.get(name='Looking For')
+    admin_client.post('/admin/auth/group/{0}/change/'.format(group.pk), {
+        'name': 'Looking For Group', 'permissions': ['2']
+    })
+
+    logs = '\n'.join(apps.logger.logs)
+    assert "permissions given to group 'Looking For'" in logs
+    assert "admin created group 'Looking For'" in logs
+    assert "<Permission:" in logs
+    assert "Changed name" in logs
+    assert "permissions removed from group 'Looking For Group'" in logs

--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -172,10 +172,16 @@ TAGGIT_CASE_INSENSITIVE = True
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'formatters': {
+        'default': {
+            'format': '%(levelname)s %(asctime)s %(name)-20s %(message)s',
+        }
+    },
     'handlers': {
         'console': {
             'level': 'INFO',
             'class': 'logging.StreamHandler',
+            'formatter': 'default',
         }
     },
     'loggers': {

--- a/reqs/models.py
+++ b/reqs/models.py
@@ -70,8 +70,8 @@ class Policy(models.Model):
     policy_status = models.CharField(max_length=256, blank=True)
 
     def __str__(self):
-        text = self.title[:40]
-        if len(self.title) > 40:
+        text = self.title[:100]
+        if len(self.title) > 100:
             text += '...'
         if self.omb_policy_id:
             return '{0}: ({1}) {2}'.format(


### PR DESCRIPTION
As users make changes in the admin screen, Django generates minimal logs which are then stored in the database. This also logs those changes to the console. Additionally, Django's admin doesn't do a great job of tracking how many-to-many fields change (which is problematic as both permissions and groups are many-to-many), so this also specifically logs those.

Should resolve #219