### PR TITLE
Remove password from MAX authenticated users

### DIFF
--- a/ereqs_admin/admin.py
+++ b/ereqs_admin/admin.py
@@ -1,5 +1,40 @@
+from django.conf import settings
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import User
+from django.utils.translation import gettext_lazy as _
 from taggit.models import Tag
+
+from ereqs_admin.forms import UserChangeForm, UserCreationForm
 
 # We have our own tag type; best to hide the taggit Tags from end users
 admin.site.unregister(Tag)
+
+
+class PasswordlessAdmin(UserAdmin):
+    """A replacement user admin which references the modified creation +
+    change forms. This also removes the password + is_staff fields and makes
+    the user name fields (which are set by our MAX integration) and date
+    fields read-only"""
+    add_form = UserCreationForm
+    add_fieldsets = (
+        (None, {
+            'classes': ('wide',),
+            'fields': ('username',),
+        }),
+    )
+    readonly_fields = ('last_login', 'date_joined', 'first_name', 'last_name',
+                       'email')
+    form = UserChangeForm
+    fieldsets = (
+        (None, {'fields': ('username',)}),
+        (_('Personal info'), {'fields': ('first_name', 'last_name', 'email')}),
+        (_('Permissions'), {'fields': ('is_active', 'is_superuser', 'groups',
+                                       'user_permissions')}),
+        (_('Important dates'), {'fields': ('last_login', 'date_joined')}),
+    )
+
+
+if settings.MAX_URL:
+    admin.site.unregister(User)
+    admin.site.register(User, PasswordlessAdmin)

--- a/ereqs_admin/forms.py
+++ b/ereqs_admin/forms.py
@@ -1,0 +1,41 @@
+from django.contrib.auth.forms import UsernameField
+from django.contrib.auth.models import User
+from django.forms import ModelForm
+
+
+class UserCreationForm(ModelForm):
+    """A replacement for user creation form which does not contain a
+    password. Largely lifted from Django"""
+    class Meta:
+        model = User
+        fields = ("username",)
+        field_classes = {'username': UsernameField}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self._meta.model.USERNAME_FIELD in self.fields:
+            self.fields[self._meta.model.USERNAME_FIELD].widget.attrs.update(
+                {'autofocus': True})
+
+    def save(self, commit=True):
+        user = super().save(commit=False)
+        user.is_staff = True
+        user.set_unusable_password()
+        if commit:
+            user.save()
+        return user
+
+
+class UserChangeForm(ModelForm):
+    """A replacement for user change which does not contain a password.
+    Largely lifted from Django"""
+    class Meta:
+        model = User
+        exclude = ['is_staff', 'password']
+        field_classes = {'username': UsernameField}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        f = self.fields.get('user_permissions')
+        if f is not None:
+            f.queryset = f.queryset.select_related('content_type')

--- a/ereqs_admin/templates/admin/auth/user/add_form.html
+++ b/ereqs_admin/templates/admin/auth/user/add_form.html
@@ -1,0 +1,21 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block form_top %}
+  {% if adminform.form.password1 %}
+  HERE
+  {% endif %}
+  {% if not is_popup %}
+    {% if adminform.form.password1 %}
+      <p>{% trans "First, enter a username and password. Then, you'll be able to edit more user options." %}</p>
+    {% else %}
+      <p>{% trans "First, enter a username. Then, you'll be able to edit more user options." %}</p>
+    {% endif %}
+  {% else %}
+    {% if adminform.form.password1 %}
+      <p>{% trans "Enter a username and password." %}</p>
+    {% else %}
+      <p>{% trans "Enter a username." %}</p>
+    {% endif %}
+  {% endif %}
+{% endblock %}

--- a/ereqs_admin/tests/admin_tests.py
+++ b/ereqs_admin/tests/admin_tests.py
@@ -1,0 +1,80 @@
+import pytest
+from django.contrib.auth.models import User
+from model_mommy import mommy
+
+
+@pytest.mark.urls('ereqs_admin.tests.both_user_forms_urls')
+def test_user_create_notmax(admin_client):
+    resp = admin_client.get('/django_user_form/add/').content.decode('utf-8')
+    assert 'Password' in resp
+    assert 'Password confirmation' in resp
+
+    admin_client.post('/django_user_form/add/', {
+        'username': 'newuser',
+        'password1': 's3cr3ts3cr3t',
+        'password2': 's3cr3ts3cr3t',
+    })
+
+    user = User.objects.get(username='newuser')
+    assert user.check_password('s3cr3ts3cr3t')
+
+
+def user_change_post(user, **kwargs):
+    """Convert a user into a dictionary that might be used in the User edit
+    form"""
+    form = {
+        'first_name': user.username,
+        'username': user.username,
+        'last_name': user.last_name,
+        'email': user.email,
+        'date_joined_0': '2017-01-01',
+        'date_joined_1': '01:01:01',
+        'initial-date_joined_0': '2017-01-01',
+        'initial-date_joined_1': '01:01:01',
+        '_save': 'Save',
+    }
+    form.update(kwargs)
+    return form
+
+
+@pytest.mark.urls('ereqs_admin.tests.both_user_forms_urls')
+def test_user_edit_notmax(admin_client):
+    user = mommy.make(User, first_name='pretest')
+    resp = admin_client.get('/django_user_form/{0}/change/'.format(user.pk))
+    resp_text = resp.content.decode('utf-8')
+    assert 'Password' in resp_text
+    assert 'Staff status' in resp_text
+
+    admin_client.post('/django_user_form/{0}/change/'.format(user.pk),
+                      user_change_post(user, first_name='posttest'))
+
+    user.refresh_from_db()
+    assert user.first_name == 'posttest'
+
+
+@pytest.mark.urls('ereqs_admin.tests.both_user_forms_urls')
+def test_user_create_max(admin_client):
+    resp = admin_client.get('/max_user_form/add/').content.decode('utf-8')
+    assert 'Password' not in resp
+    assert 'Password confirmation' not in resp
+
+    admin_client.post('/max_user_form/add/', {'username': 'newuser'})
+
+    user = User.objects.get(username='newuser')
+    assert not user.check_password('s3cr3ts3cr3t')
+    assert user.is_staff
+
+
+@pytest.mark.urls('ereqs_admin.tests.both_user_forms_urls')
+def test_user_edit_max(admin_client):
+    user = mommy.make(User, first_name='pretest')
+    resp = admin_client.get('/max_user_form/{0}/change/'.format(user.pk))
+    resp_text = resp.content.decode('utf-8')
+    assert 'Password' not in resp_text
+    assert 'Staff status' not in resp_text
+
+    admin_client.post('/django_user_form/{0}/change/'.format(user.pk),
+                      user_change_post(user, first_name='posttest'))
+
+    user.refresh_from_db()
+    assert user.first_name == 'posttest'

--- a/ereqs_admin/tests/both_user_forms_urls.py
+++ b/ereqs_admin/tests/both_user_forms_urls.py
@@ -1,0 +1,16 @@
+from django.conf.urls import include, url
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
+from django.contrib.auth.models import User
+
+from ereqs_admin.admin import PasswordlessAdmin
+from omb_eregs.urls import urlpatterns
+
+normal_admin = DjangoUserAdmin(User, admin.site)
+max_admin = PasswordlessAdmin(User, admin.site)
+
+
+urlpatterns = [
+    url(r'^django_user_form/', include(normal_admin.urls)),
+    url(r'^max_user_form/', include(max_admin.urls)),
+] + urlpatterns

--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -38,6 +38,9 @@ ALLOWED_HOSTS = env.uris
 INSTALLED_APPS = (
     'reqs.apps.ReqsConfig',
     'taggit',
+    'django.contrib.contenttypes',
+    # must be after taggit and contenttypes, but before auth
+    'ereqs_admin.apps.EreqsAdminConfig',
     'corsheaders',
     'dal',
     'dal_select2',
@@ -46,12 +49,9 @@ INSTALLED_APPS = (
     'reversion',
     'django.contrib.admin',
     'django.contrib.auth',
-    'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    # must be after taggit, auth, contenttypes, etc.
-    'ereqs_admin.apps.EreqsAdminConfig',
 )
 if DEBUG:
     INSTALLED_APPS += ('debug_toolbar', )


### PR DESCRIPTION
Adds new forms to account for an environment where passwords aren't used. These forms should only be active when there's a configured MAX_URL (so, to test locally, you'll need to uncomment that environment variable from the docker-compose file).

Should close #252 