### PR TITLE
Fix issue around preloading topics.

### DIFF
--- a/reqs/tests/admin_tests.py
+++ b/reqs/tests/admin_tests.py
@@ -71,6 +71,19 @@ def test_reqs_in_policy(admin_client):
     assert req3.req_id not in result
 
 
+def test_topics_displayed(admin_client):
+    """Existing topics should be in the markup of a requirement edit page"""
+    topics = mommy.make(Topic, _quantity=4)
+    req = mommy.make(Requirement)
+    req.topics.add(*[topic.name for topic in topics])
+
+    resp = admin_client.get('/admin/reqs/requirement/{0}/change/'.format(
+        req.pk))
+    markup = resp.content.decode('utf-8')
+    for topic in topics:
+        assert topic.name in markup
+
+
 def req_query_str():
     """Create a requirement and generate the query string associated with
     it"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ boto3==1.4.4
 botocore==1.5.39          # via boto3, s3transfer
 cfenv==0.5.2
 dj-database-url==0.4.2
-django-autocomplete-light==3.2.1
+django-autocomplete-light==3.2.7
 django-cas-ng==3.5.7
 django-cors-headers==2.0.2
 django-filter==1.0.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ botocore==1.5.39
 cfenv==0.5.2
 coverage==4.3.4           # via pytest-cov
 dj-database-url==0.4.2
-django-autocomplete-light==3.2.1
+django-autocomplete-light==3.2.7
 django-cas-ng==3.5.7
 django-cors-headers==2.0.2
 django-debug-toolbar==1.7


### PR DESCRIPTION
We updated to Django 1.11 this past sprint, which introduced an
incompatibility with django-autocomplete-light. Annoyingly, when going to the
edit screen, existing topics were not populated (though they were saved
correctly.)

This should resolve #285