### PR TITLE
Remove pympler.

### DIFF
--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -55,7 +55,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
 )
 if DEBUG:
-    INSTALLED_APPS += ('debug_toolbar', 'pympler')
+    INSTALLED_APPS += ('debug_toolbar',)
 
 MIDDLEWARE = (
     'django.middleware.cache.UpdateCacheMiddleware',
@@ -89,7 +89,6 @@ if DEBUG:
         'debug_toolbar.panels.signals.SignalsPanel',
         'debug_toolbar.panels.logging.LoggingPanel',
         'debug_toolbar.panels.redirects.RedirectsPanel',
-        'pympler.panels.MemoryPanel',
     )
 
 # Allow most URLs to be used by any service; do not allow the admin to be

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -13,7 +13,6 @@ jedi
 model_mommy
 pep8-naming
 pyinotify
-pympler
 pytest
 pytest-cov
 pytest-django

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -48,7 +48,6 @@ py==1.4.32                # via pytest
 pycodestyle==2.3.1        # via flake8
 pyflakes==1.5.0           # via flake8
 pyinotify==0.9.6
-pympler==0.5
 pyparsing==2.1.10         # via packaging
 pytest-base-url==1.3.0    # via pytest-selenium
 pytest-cov==2.4.0


### PR DESCRIPTION
Pympler causes 500s in some situations around multiple requests (thanks for
finding this issue, @tadhg-ohiggins!). We only used it to provide a panel in
the debug toolbar, so let's just axe it.