### PR TITLE
Configure New Relic to ignore 401s.

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -26,4 +26,10 @@ exports.config = {
     level: 'info',
   },
   agent_enabled: !!(process.env.NEW_RELIC_APP_NAME && creds.NEW_RELIC_LICENSE_KEY),
+  error_collector: {
+    enabled: true, // default
+    ignore_status_codes: [401, 404],  // added 401 to the default: [404]
+    capture_events: true, // default
+    max_event_samples_stored: 100, // default
+  },
 };


### PR DESCRIPTION
By default, New Relic will treat a 401 as an error (hence affecting downtime
alerts, etc.). 401's do not indicate an error state for us, so we should
ignore them the same way 404s are.

Should resolve #274 

Tested on demo -- appears to continue to log hits while not registering errors on 401s