### PR TITLE
Add a "title_with_number" policy attribute.

### DIFF
--- a/reqs/models.py
+++ b/reqs/models.py
@@ -70,14 +70,17 @@ class Policy(models.Model):
     policy_status = models.CharField(max_length=256, blank=True)
     document_source = models.FileField(blank=True)
 
-    def __str__(self):
-        text = self.title[:100]
-        if len(self.title) > 100:
-            text += '...'
+    @property
+    def title_with_number(self):
         if self.omb_policy_id:
-            return '{0}: ({1}) {2}'.format(
-                self.policy_number, self.omb_policy_id, text)
-        return '{0}: {1}'.format(self.policy_number, text)
+            return '{0}: {1}'.format(self.omb_policy_id, self.title)
+        return self.title
+
+    def __str__(self):
+        text = self.title_with_number
+        if len(text) > 100:
+            text = text[:100] + '...'
+        return '({0}) {1}'.format(self.policy_number, text)
 
 
 class Requirement(models.Model):

--- a/reqs/serializers.py
+++ b/reqs/serializers.py
@@ -6,6 +6,7 @@ from reqs.models import Policy, Requirement, Topic
 class PolicySerializer(serializers.ModelSerializer):
     total_reqs = serializers.IntegerField(read_only=True)
     relevant_reqs = serializers.IntegerField(read_only=True)
+    title_with_number = serializers.CharField(read_only=True)
 
     class Meta:
         model = Policy
@@ -21,6 +22,7 @@ class PolicySerializer(serializers.ModelSerializer):
             'total_reqs',
             'relevant_reqs',
             'document_source',
+            'title_with_number',
         )
 
 

--- a/reqs/tests/model_tests.py
+++ b/reqs/tests/model_tests.py
@@ -1,0 +1,19 @@
+from reqs import models
+
+
+def test_policy_title_with_number():
+    """title_with_number field should include omb_policy_id if present"""
+    policy = models.Policy(title="Some Title")
+    assert policy.title_with_number == "Some Title"
+
+    policy.omb_policy_id = "A123"
+    assert policy.title_with_number == "A123: Some Title"
+
+
+def test_policy_str():
+    """Should trim the policy title and add the policy number"""
+    policy = models.Policy(policy_number=5, title="Short", omb_policy_id="ID")
+    assert str(policy) == "(5) ID: Short"
+
+    policy.title = "Long"*100
+    assert str(policy) == "(5) ID: {0}...".format("Long"*24)

--- a/ui/components/policies/policy-view.jsx
+++ b/ui/components/policies/policy-view.jsx
@@ -16,7 +16,7 @@ export default function Policy({ policy, topicsIds }) {
   return (
     <li key={policy.id} className="py1">
       <section className="border rounded gray-border p2">
-        <h2 className="mt0 mb3">{policy.title}</h2>
+        <h2 className="mt0 mb3">{policy.title_with_number}</h2>
         <div className="clearfix">
           <span className="requirements-links col col-6">
             <span className="circle-bg border gray-border p1">
@@ -40,7 +40,7 @@ export default function Policy({ policy, topicsIds }) {
 Policy.propTypes = {
   policy: React.PropTypes.shape({
     id: React.PropTypes.number,
-    title: React.PropTypes.string,
+    title_with_number: React.PropTypes.string,
     relevant_reqs: React.PropTypes.number,
     total_reqs: React.PropTypes.number,
   }),


### PR DESCRIPTION
Per #251, we'd like to include a policy number (where available) in the UI.
Rather than calculate it there, this just adds a computed field to the API
which includes the information.

It then uses this field when displaying the policy titles in the policies tab.