### PR TITLE
Up the number of UI services we're running.

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -18,6 +18,8 @@ applications:
       MAX_URL: https://login.test.max.gov/cas/login
   - name: ui
     buildpack: nodejs_buildpack
+    instances: 4
+    memory: 128M
     command: node ui-dist/server.js
     routes:
       - route: omb-eregs-demo.app.cloud.gov

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -1,12 +1,12 @@
 ---
 inherit: manifest_base.yml
-instances: 2
 
 # Unfortunately, these configs needs to be repeated across dev/prod. Can be
 # fixed by using different domains
 applications:
   - name: api
     buildpack: python_buildpack
+    instances: 2
     services:
       - database  # aws-rds medium-psql
       - config    # user-provided service w/ DJANGO_SECRET_KEY and NEW_RELIC_LICENSE_KEY
@@ -20,6 +20,8 @@ applications:
       MAX_URL: https://login.max.gov/cas/login
   - name: ui
     buildpack: nodejs_buildpack
+    instances: 4
+    memory: 128M
     command: node ui-dist/server.js
     routes:
       - route: omb-eregs.app.cloud.gov


### PR DESCRIPTION
The UI instances are rather minimal -- not only does Node have a light
footprint (hovering around 50M usage), most users will only hit the service
once on initial page load. As a result, it looks like we can spin up several
more UI servers to handle request volume by dropping their memory consumption.