### PR TITLE
Reduce number of queries in the policies edit page.

### DIFF
--- a/reqs/models.py
+++ b/reqs/models.py
@@ -83,6 +83,10 @@ class Policy(models.Model):
             return self.document_source.url
         return self.uri
 
+    @property
+    def requirements_with_topics(self):
+        return self.requirements.prefetch_related('topics').distinct()
+
     def __str__(self):
         text = self.title_with_number
         if len(text) > 100:
@@ -120,3 +124,9 @@ class Requirement(models.Model):
         if len(self.req_text) > 40:
             text += '...'
         return '{0}: {1}'.format(self.req_id, text)
+
+    @property
+    def prefetched_topic_names(self):
+        """Using self.topics.names will result in a new query. That's very
+        inefficient if we've already prefetched that data."""
+        return [topic.name for topic in self.topics.all()]

--- a/reqs/templates/admin/reqs/policy/change_form.html
+++ b/reqs/templates/admin/reqs/policy/change_form.html
@@ -18,7 +18,7 @@
           </tr>
         </thead>
         <tbody>
-          {% for req in original.requirements.all %}
+          {% for req in original.requirements_with_topics %}
           <tr class="form-row {% cycle "row1" "row2" %}">
             {% comment %}
               We'll let the req text be a bit longer in this view.
@@ -28,7 +28,7 @@
             </td>
             <td>{{ req.policy_section | truncatechars:40}}</td>
             <td>{{ req.policy_sub_section | truncatechars:40 }}</td>
-            <td>{{ req.topics.names | join:", " }}</td>
+            <td>{{ req.prefetched_topic_names | join:", " }}</td>
           </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
We had been making one query per requirement on the policies edit page (to
gather the topics names). We can prefetch all of those topics in a single
query instead, though it requires a few hoops.

This cuts load time of one of the pages from about 30 seconds to 6 for me (in
dev mode), so, still not fast, but much better.