### PR TITLE
Django settings tweaks

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,0 @@
-[bandit]
-skips: B101

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
 # Python tests and linting
 - docker-compose run --rm py.test
 - docker-compose run --rm flake8
+- docker-compose run --rm bandit -r ereqs_admin reqs omb_eregs -s B101  # skip asserts
 # Integration tests
 # - ./devops/integration-tests.sh
 before_deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,13 @@ services:
     command: ''
     ports: []
 
+  bandit:
+    <<: *DEV_API
+    entrypoint: ./devops/activate_then bandit
+    depends_on: []
+    command: ''
+    ports: []
+
   npm:
     <<: *DEV_UI
     entrypoint: ./devops/deps_ok_then npm

--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -94,7 +94,7 @@ if DEBUG:
 # Allow most URLs to be used by any service; do not allow the admin to be
 # accessed this way
 CORS_ORIGIN_ALLOW_ALL = True
-CORS_URLS_REGEX = r'^/(?!admin).*$'
+CORS_URLS_REGEX = r'^/(?!admin)(?!static).*$'
 
 # Request the browser not allow the CSRF cookie to be used in JS (not: this
 # means we can't have AJAX forms)

--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -96,7 +96,7 @@ if DEBUG:
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r'^/(?!admin)(?!static).*$'
 
-# Request the browser not allow the CSRF cookie to be used in JS (not: this
+# Request the browser not allow the CSRF cookie to be used in JS (note: this
 # means we can't have AJAX forms)
 CSRF_COOKIE_HTTPONLY = True
 # Request browsers block XSS attacks when they can

--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -107,6 +107,8 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 USING_SSL = env.get_credential('USING_SSL', 'TRUE').upper() == 'TRUE'
 SESSION_COOKIE_SECURE = USING_SSL
 CSRF_COOKIE_SECURE = USING_SSL
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+SESSION_COOKIE_AGE = 8*60*60  # 8 hrs
 
 # For the time being, tell downstream (notably CloudFront) to avoid caching
 # content rather than guessing.

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -1,4 +1,5 @@
 -r requirements.txt
+bandit
 django-debug-toolbar
 flake8
 flake8-bugbear

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@
 #
 appdirs==1.4.0            # via setuptools
 attrs==16.3.0             # via flake8-bugbear
+bandit==1.4.0
 boto3==1.4.4
 botocore==1.5.39
 cfenv==0.5.2
@@ -33,6 +34,8 @@ flake8-string-format==0.2.3
 flake8-tuple==0.2.12
 flake8==3.3.0
 furl==1.0.0
+gitdb2==2.0.0             # via gitpython
+gitpython==2.1.3          # via bandit
 gunicorn==19.7.1
 isort==4.2.5              # via flake8-isort
 jedi==0.10.0
@@ -42,6 +45,7 @@ model-mommy==1.3.2
 newrelic==2.82.0.62
 orderedmultidict==0.7.11
 packaging==16.8           # via setuptools
+pbr==3.0.0                # via stevedore
 pep8-naming==0.4.1
 psycopg2==2.7.1
 py==1.4.32                # via pytest
@@ -60,11 +64,14 @@ pytest==3.0.6
 python-cas==1.2.0
 python-dateutil==2.6.0
 pytz==2017.2
+pyyaml==3.12              # via bandit
 requests==2.13.0
 s3transfer==0.1.10
 selenium==3.3.3           # via pytest-selenium
 six==1.10.0
+smmap2==2.0.1             # via gitdb2
 sqlparse==0.2.3           # via django-debug-toolbar
+stevedore==1.21.0         # via bandit
 testfixtures==4.13.4      # via flake8-isort
 whitenoise==3.3.0
 


### PR DESCRIPTION
The CORS headers one is a little hard to test (browsers generally ignore CORS stuff for localhost). What I'd recommend is 
* [verifying](http://pythex.org/) the regex works to allow CORS on all of the api endpoints, but not /static/... or /admin/....
* Check the headers (look for "Access-Control-Allow-Origin: *") using curl:
```
curl -I http://localhost:9001/static/admin/img/icon-addlink.svg -H "Origin: http://example.com/"
```
Unfortunately, that won't work on the admin site (due to the authentication redirect), unless you want to pass along a cookie.

Re session expiry, I'm just going off Django's [docs](https://docs.djangoproject.com/en/dev/ref/settings)