### PR TITLE
Insert newrelic browser logging.

### DIFF
--- a/ui/components/html.jsx
+++ b/ui/components/html.jsx
@@ -1,22 +1,44 @@
+import newrelic from 'newrelic';
 import React from 'react';
 import serialize from 'serialize-javascript';
 
 import config from '../config';
 import DAP from './dap';
 
-
-export default function Html({ contents, data }) {
+function scriptTag(data) {
   const jsStr = `
     window.__REACT_RESOLVER_PAYLOAD__ = ${serialize(data)};
     window.APP_CONFIG = ${serialize(config)};
   `;
   // Avoid escaping the JS
   /* eslint-disable react/no-danger */
-  const scriptTag = <script dangerouslySetInnerHTML={{ __html: jsStr }} />;
+  return <script dangerouslySetInnerHTML={{ __html: jsStr }} />;
   /* eslint-enable react/no-danger */
+}
+
+/* New Relic's automatically generated timing header is wrapped in script
+ * tags, which doesn't play well with React. Rather than copy-pasting their
+ * JS (which we'd need to figure out how to parametrize), strip the tags from
+ * the generated text. */
+function newRelicTag() {
+  const stringWithTags = newrelic.getBrowserTimingHeader();
+  if (!stringWithTags) {  /* agent is disabled */
+    return null;
+  }
+  const endOpeningTag = stringWithTags.indexOf('>');
+  const startClosingTag = stringWithTags.lastIndexOf('<');
+  const jsStr = stringWithTags.substring(endOpeningTag + 1, startClosingTag);
+  // Avoid escaping the JS
+  /* eslint-disable react/no-danger */
+  return <script dangerouslySetInnerHTML={{ __html: jsStr }} />;
+  /* eslint-enable react/no-danger */
+}
+
+export default function Html({ contents, data }) {
   return (
     <html lang="en-US">
       <head>
+        { newRelicTag() }
         <link rel="stylesheet" href="/static/styles.css" />
         <DAP />
       </head>
@@ -24,7 +46,7 @@ export default function Html({ contents, data }) {
         <div id="app">
           { contents }
         </div>
-        { scriptTag }
+        { scriptTag(data) }
         <script src="/static/browser.js" />
       </body>
     </html>


### PR DESCRIPTION
The Python client does this automatically, but the Node client does not.
Ironically, we probably want statistics around the Node app's browser more
than anything. Activate it here (it degrades to an empty string when newrelic
is not enabled).