### PR TITLE
Show 99+ when there are 100 or more relevant requirements

### DIFF
--- a/ui/assets/css/_policies.scss
+++ b/ui/assets/css/_policies.scss
@@ -39,4 +39,8 @@
        text-align: center;
     }
   }
+
+  .ninety-nine-plus {
+    font-size: 0.9375rem; 
+  }
 }

--- a/ui/components/policies/policy-view.jsx
+++ b/ui/components/policies/policy-view.jsx
@@ -15,6 +15,8 @@ export default function Policy({ policy, topicsIds }) {
       topics__id__in: topicsIds,
     },
   };
+  const relevantReqCount = policy.relevant_reqs >= 100 ? '99+' : policy.relevant_reqs;
+  const countClass = relevantReqCount === '99+' ? 'ninety-nine-plus' : '';
   return (
     <li key={policy.id} className="my2">
       <section className="border rounded gray-border p2">
@@ -22,8 +24,8 @@ export default function Policy({ policy, topicsIds }) {
         <div className="clearfix">
           <span className="requirements-links col col-6">
             <div className="circle-bg border gray-border center p1">
-              <Link to={relevantReqs}>
-                {policy.relevant_reqs}
+              <Link to={relevantReqs} className={countClass}>
+                {relevantReqCount}
               </Link>
             </div> of&nbsp;
             {policy.total_reqs} requirements


### PR DESCRIPTION
Makes things look neater. I made the size of the font in "99+" circles smaller to unwonkify the display.

<img width="728" alt="screen shot 2017-05-15 at 3 56 19 pm" src="https://cloud.githubusercontent.com/assets/126935/26083009/f5646190-3987-11e7-9978-d7b6b9bf2842.png">
