### PR TITLE
Create shared, "proxy" network in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,19 +146,6 @@ services:
       MAX_URL: https://example.com/etc
 ```
 
-### Running w/ Local PDF Upload
-
-The default configuration includes a [Minio](https://www.minio.io/) server
-that we use to mock S3 for local development.
-Uploading PDFs should work without requiring any tweaks, and the web UI for
-the Minio interface should be available at http://localhost:9100 (the username
-and password are in the `minio` section of `docker-compose.yml`).
-However, PDF download links will be broken unless you add:
-```hosts
-127.0.0.1       minio
-```
-to your `hosts` file.
-
 ## API Endpoints
 
 We provide access to JSON-serialized versions of each of our data types via a

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ docker-compose up dev
 # Ctrl-c to kill
 ```
 
-Then navigate to http://localhost:8000/
+Then navigate to http://localhost:8002/
 
 This runs in development mode (including automatic JS recompilation). To run
 in prod mode, run
@@ -57,7 +57,7 @@ docker-compose run --rm webpack  # to build the server JS
 docker-compose up prod
 ```
 
-Then navigate to http://localhost:9000/ (prod and dev run on separate ports).
+Then navigate to http://localhost:9002/ (prod and dev run on separate ports).
 
 ### Data
 
@@ -81,9 +81,9 @@ There are two types of entry points:
     port 9001
   * `dev-api` - Build the admin/API app and run it in "development" mode on
     port 8001
-  * `dev` - Build and run the UI and API app in "development" mode (port 8000
+  * `dev` - Build and run the UI and API app in "development" mode (port 8002
     for UI, 8001 for API).
-  * `prod` - Run the UI and API apps in "production" mode (port 9000 for UI,
+  * `prod` - Run the UI and API apps in "production" mode (port 9002 for UI,
     9001 for API). Note that this requires the JS be compiled already.
 1. One use commands which run until complete. These are ran via
   `docker-compose run --rm` (the `--rm` just deletes the images after running;

--- a/devops/integration-compose.yml
+++ b/devops/integration-compose.yml
@@ -5,11 +5,13 @@ services:
     depends_on:
       - prod
       - prod-api
+      - proxy
   selenium_firefox:
     image: selenium/standalone-firefox:3
     depends_on:
       - prod
       - prod-api
+      - proxy
   selenium-py.test:
     image: python:3.5.3
     volumes:

--- a/devops/integration-compose.yml
+++ b/devops/integration-compose.yml
@@ -1,0 +1,25 @@
+version: '2'
+services:
+  selenium_chrome:
+    image: selenium/standalone-chrome:3
+    depends_on:
+      - prod
+      - prod-api
+  selenium_firefox:
+    image: selenium/standalone-firefox:3
+    depends_on:
+      - prod
+      - prod-api
+  selenium-py.test:
+    image: python:3.5.3
+    volumes:
+      - $PWD:/usr/src/app
+    working_dir: /usr/src/app
+    stdin_open: true
+    tty: true
+    entrypoint: ./devops/wait_for_db_then ./devops/activate_then py.test
+    external_links:
+      - selenium_chrome
+      - selenium_firefox
+    environment:
+      DEBUG: "true"

--- a/devops/integration-tests.sh
+++ b/devops/integration-tests.sh
@@ -2,13 +2,13 @@ set -v -e
 
 docker-compose down   # free up ports
 
-export COMPOSE_PROJECT_NAME='integration_tests'
+export COMPOSE_CMD='docker-compose -p integration_tests -f docker-compose.yml -f devops/integration-compose.yml'
 
-docker-compose down -v  # just in case there was an error previously
+$COMPOSE_CMD down -v # just in case there was an error previously
 
 # start the selenium services; they must be up by the time we hit the py.tests
 # below
-docker-compose up -d selenium_chrome selenium_firefox
+$COMPOSE_CMD up -d selenium_chrome selenium_firefox
 
 # wait for api to startup
 until (curl http://localhost:9001 &>/dev/null)
@@ -18,13 +18,13 @@ do
 done
 
 # Load data
-docker-compose run --rm manage.py fetch_csv
-docker-compose run --rm manage.py import_reqs data.csv
-docker-compose run --rm manage.py loaddata devops/integration_tests/admin.json
+$COMPOSE_CMD run --rm manage.py fetch_csv
+$COMPOSE_CMD run --rm manage.py import_reqs data.csv
+$COMPOSE_CMD run --rm manage.py loaddata devops/integration_tests/admin.json
 
 # We disable the django plugin as it's misleading (for now). The database
 # context isn't quite right
-docker-compose run --rm py.test -p no:django --driver Remote --capability browserName chrome --host selenium_chrome devops/integration_tests/
-docker-compose run --rm py.test -p no:django --driver Remote --capability browserName firefox --host selenium_firefox devops/integration_tests/
+$COMPOSE_CMD run --rm selenium-py.test -p no:django --driver Remote --capability browserName chrome --host selenium_chrome devops/integration_tests/
+$COMPOSE_CMD run --rm selenium-py.test -p no:django --driver Remote --capability browserName firefox --host selenium_firefox devops/integration_tests/
 
-docker-compose down -v  # cleanup
+$COMPOSE_CMD down -v  # cleanup

--- a/devops/integration_tests/conftest.py
+++ b/devops/integration_tests/conftest.py
@@ -14,11 +14,11 @@ def selenium(selenium):
 
 
 def pytest_addoption(parser):
-    parser.addoption('--ui-baseurl', default='http://prod:9002/',
+    parser.addoption('--ui-baseurl', default='http://proxy:9002/',
                      help='base url for the agency UI')
-    parser.addoption('--api-baseurl', default='http://prod-api:9001/',
+    parser.addoption('--api-baseurl', default='http://proxy:9001/',
                      help='base url for the API')
-    parser.addoption('--admin-baseurl', default='http://prod-api:9001/admin/',
+    parser.addoption('--admin-baseurl', default='http://proxy:9001/admin/',
                      help='base url for the admin')
 
 

--- a/devops/integration_tests/conftest.py
+++ b/devops/integration_tests/conftest.py
@@ -14,7 +14,7 @@ def selenium(selenium):
 
 
 def pytest_addoption(parser):
-    parser.addoption('--ui-baseurl', default='http://prod:9000/',
+    parser.addoption('--ui-baseurl', default='http://prod:9002/',
                      help='base url for the agency UI')
     parser.addoption('--api-baseurl', default='http://prod-api:9001/',
                      help='base url for the API')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,18 @@
 version: '2'
 services:
+  # This service is a shared network stack (i.e. shared "localhost") for all
+  # external-facing services. It allows "localhost" links to work correctly
+  # outside of Docker.
+  proxy:
+    image: busybox
+    command: sleep 100d   # do nothing
+    ports:  # forwarded
+      - 8001:8001   # dev-api
+      - 8002:8002   # dev
+      - 9001:9001   # prod-api
+      - 9002:9002   # prod
+      - 9100:9100   # minio
+
   persistent_db:
     image: postgres:9.4
     volumes:
@@ -17,11 +30,7 @@ services:
         - MINIO_ACCESS_KEY=LOCAL_ID
         - MINIO_SECRET_KEY=LOCAL_KEY
     command: server --address ':9100' minio-test
-    ports:
-        - 9100:9100
-        # port forward the prod-api and dev-api ports
-        - 8001:8001
-        - 9001:9001
+    network_mode: service:proxy
   prod-api: &PROD_API
     <<: *PYTHON
     command: ./devops/wait_for_db_then ./devops/activate_then ./devops/run_api.sh
@@ -42,17 +51,15 @@ services:
           {"DJANGO_SECRET_KEY": "NotASecret", "USING_SSL": "False"}
         }],
           "s3": [{"credentials":
-          {"access_key_id": "LOCAL_ID", "bucket": "pdfs", "secret_access_key": "LOCAL_KEY", "region": "irrelevant fake region", "endpoint": "http://localhost:9100"},
+          {"access_key_id": "LOCAL_ID", "bucket": "pdfs", "secret_access_key": "LOCAL_KEY", "region": "irrelevant fake region", "endpoint": "http://0.0.0.0:9100"},
           "label": "s3",
           "name": "storage-s3"
         }]
         }
     depends_on:
       - persistent_db
-      # minio's not needed due to the network_mode below
-    # We want to use `localhost` when referring to our minio endpoint, so put
-    # ourselves on minio's network
-    network_mode: service:minio
+      - minio
+    network_mode: service:proxy
 
   dev-api: &DEV_API
     <<: *PROD_API
@@ -70,29 +77,26 @@ services:
       - $PWD:/usr/src/app
     working_dir: /usr/src/app
     command: ./devops/deps_ok_then npm start
-    ports:
-      - 9000:9000
     environment: &UI_ENV
-      PORT: 9000
+      PORT: 9002
       NODE_ENV: production
-      INTERNAL_API: 'http://prod-api:9001/'
+      INTERNAL_API: 'http://0.0.0.0:9001/'
       PUBLIC_API: 'http://0.0.0.0:9001/'
       VCAP_SERVICES: >
         {"config": [{"name": "config", "credentials": {"UI_BASIC_AUTH": {
         }}}]}
     depends_on:
       - prod-api
+    network_mode: service:proxy
 
   dev: &DEV_UI
     <<: *PROD_UI
     command: ./devops/deps_ok_then ./devops/dev_ui.sh
-    ports:
-      - 8000:8000
     environment:
       <<: *UI_ENV
-      PORT: 8000
+      PORT: 8002
       NODE_ENV: ''
-      INTERNAL_API: 'http://dev-api:8001/'
+      INTERNAL_API: 'http://0.0.0.0:8001/'
       PUBLIC_API: 'http://0.0.0.0:8001/'
       VCAP_SERVICES: >
         {"config": [{"name": "config", "credentials": {"UI_BASIC_AUTH": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,13 @@ services:
     depends_on:
       - prod
       - prod-api
+  python: &PYTHON     # This command is out of order to aid with config reuse
+    image: python:3.5.3
+    volumes:
+      - $PWD:/usr/src/app
+    working_dir: /usr/src/app
+    stdin_open: true
+    tty: true
   minio:
     image: minio/minio
     environment:
@@ -25,8 +32,13 @@ services:
         # port forward the prod-api and dev-api ports
         - 8001:8001
         - 9001:9001
+    # similarly, even though minio doesn't access these links, we want py.test
+    # to have them
+    external_links:
+      - selenium_chrome
+      - selenium_firefox
   prod-api: &PROD_API
-    image: python:3.5.3
+    <<: *PYTHON
     command: ./devops/wait_for_db_then ./devops/activate_then ./devops/run_api.sh
     environment: &API_ENV
       DATABASE_URL: postgres://postgres@persistent_db/postgres
@@ -50,14 +62,9 @@ services:
           "name": "storage-s3"
         }]
         }
-    volumes:
-      - $PWD:/usr/src/app
-    working_dir: /usr/src/app
     depends_on:
       - persistent_db
-      - minio
-    stdin_open: true
-    tty: true
+      # minio's not needed due to the network_mode below
     # We want to use `localhost` when referring to our minio endpoint, so put
     # ourselves on minio's network
     network_mode: service:minio
@@ -65,7 +72,7 @@ services:
   dev-api: &DEV_API
     <<: *PROD_API
     command: ./devops/wait_for_db_then ./devops/activate_then ./devops/run_api.sh
-    environment:
+    environment: &DEV_API_ENV
       <<: *API_ENV
       PORT: 8001
       DEBUG: "true"
@@ -110,41 +117,34 @@ services:
 
 
   #---- Commands ----
+  flake8:
+    <<: *PYTHON
+    environment:
+      DEBUG: "true"
+    entrypoint: ./devops/activate_then flake8
+
+  pip-compile:
+    <<: *PYTHON
+    environment:
+      DEBUG: "true"
+    entrypoint: ./devops/activate_then pip-compile
+
+  bandit:
+    <<: *PYTHON
+    environment:
+      DEBUG: "true"
+    entrypoint: ./devops/activate_then bandit
+
+
   manage.py:
     <<: *DEV_API
     entrypoint: ./devops/wait_for_db_then ./devops/activate_then ./manage.py
     command: ''
-    ports: []
 
   py.test:
     <<: *DEV_API
     entrypoint: ./devops/wait_for_db_then ./devops/activate_then py.test
     command: ''
-    ports: []
-    external_links:
-      - selenium_chrome
-      - selenium_firefox
-
-  flake8:
-    <<: *DEV_API
-    entrypoint: ./devops/activate_then flake8
-    depends_on: []
-    command: ''
-    ports: []
-
-  pip-compile:
-    <<: *DEV_API
-    entrypoint: ./devops/activate_then pip-compile
-    depends_on: []
-    command: ''
-    ports: []
-
-  bandit:
-    <<: *DEV_API
-    entrypoint: ./devops/activate_then bandit
-    depends_on: []
-    command: ''
-    ports: []
 
   npm:
     <<: *DEV_UI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,16 +4,6 @@ services:
     image: postgres:9.4
     volumes:
       - database_data:/var/lib/postgresql/data
-  selenium_chrome:
-    image: selenium/standalone-chrome:3
-    depends_on:
-      - prod
-      - prod-api
-  selenium_firefox:
-    image: selenium/standalone-firefox:3
-    depends_on:
-      - prod
-      - prod-api
   python: &PYTHON     # This command is out of order to aid with config reuse
     image: python:3.5.3
     volumes:
@@ -32,11 +22,6 @@ services:
         # port forward the prod-api and dev-api ports
         - 8001:8001
         - 9001:9001
-    # similarly, even though minio doesn't access these links, we want py.test
-    # to have them
-    external_links:
-      - selenium_chrome
-      - selenium_firefox
   prod-api: &PROD_API
     <<: *PYTHON
     command: ./devops/wait_for_db_then ./devops/activate_then ./devops/run_api.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       # docker-compose configuration for local development and the cloud.gov
       # staging and production configurations.
       VCAP_APPLICATION: >
-        {"uris": ["localhost", "0.0.0.0", "127.0.0.1", "prod-api", "dev-api"]}
+        {"uris": ["localhost", "0.0.0.0", "127.0.0.1", "prod-api", "dev-api", "proxy"]}
       VCAP_SERVICES: >
         {"config": [{"credentials":
           {"DJANGO_SECRET_KEY": "NotASecret", "USING_SSL": "False"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,14 +19,15 @@ services:
     environment:
         - MINIO_ACCESS_KEY=LOCAL_ID
         - MINIO_SECRET_KEY=LOCAL_KEY
-    command: server --address 'minio:9100' minio-test
+    command: server --address ':9100' minio-test
     ports:
         - 9100:9100
+        # port forward the prod-api and dev-api ports
+        - 8001:8001
+        - 9001:9001
   prod-api: &PROD_API
     image: python:3.5.3
     command: ./devops/wait_for_db_then ./devops/activate_then ./devops/run_api.sh
-    ports:
-      - 9001:9001
     environment: &API_ENV
       DATABASE_URL: postgres://postgres@persistent_db/postgres
       PORT: 9001
@@ -44,7 +45,7 @@ services:
           {"DJANGO_SECRET_KEY": "NotASecret", "USING_SSL": "False"}
         }],
           "s3": [{"credentials":
-          {"access_key_id": "LOCAL_ID", "bucket": "pdfs", "secret_access_key": "LOCAL_KEY", "region": "irrelevant fake region", "endpoint": "http://minio:9100"},
+          {"access_key_id": "LOCAL_ID", "bucket": "pdfs", "secret_access_key": "LOCAL_KEY", "region": "irrelevant fake region", "endpoint": "http://localhost:9100"},
           "label": "s3",
           "name": "storage-s3"
         }]
@@ -57,12 +58,13 @@ services:
       - minio
     stdin_open: true
     tty: true
+    # We want to use `localhost` when referring to our minio endpoint, so put
+    # ourselves on minio's network
+    network_mode: service:minio
 
   dev-api: &DEV_API
     <<: *PROD_API
     command: ./devops/wait_for_db_then ./devops/activate_then ./devops/run_api.sh
-    ports:
-      - 8001:8001
     environment:
       <<: *API_ENV
       PORT: 8001


### PR DESCRIPTION
We'd like to use a `localhost` URL when presenting uploaded files to end users
(so they can access those files outside of Docker). ~~To do this, we'll attach
the APIs to the minio network stack. This conflicts with exposing ports
directly, however, so we need *minio* to expose those ports.~~

To do this, we'll create a "proxy" container which exists solely for other containers to join its network stack. This will allow apps to talk to each other via `localhost` just as the end user will.

@tadhg-ohiggins what do you think of this approach?