### PR TITLE
Remove separate private/public API urls.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,8 +85,7 @@ services:
     environment: &UI_ENV
       PORT: 9002
       NODE_ENV: production
-      INTERNAL_API: 'http://0.0.0.0:9001/'
-      PUBLIC_API: 'http://0.0.0.0:9001/'
+      API_URL: 'http://0.0.0.0:9001/'
       VCAP_SERVICES: >
         {"config": [{"name": "config", "credentials": {"UI_BASIC_AUTH": {
         }}}]}
@@ -101,8 +100,7 @@ services:
       <<: *UI_ENV
       PORT: 8002
       NODE_ENV: ''
-      INTERNAL_API: 'http://0.0.0.0:8001/'
-      PUBLIC_API: 'http://0.0.0.0:8001/'
+      API_URL: 'http://0.0.0.0:8001/'
       VCAP_SERVICES: >
         {"config": [{"name": "config", "credentials": {"UI_BASIC_AUTH": {
         }}}]}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       PORT: 9001
       DJANGO_SETTINGS_MODULE: omb_eregs.settings
       TMPDIR: /tmp
+      USING_SSL: "False"
       # Uncomment the following line for MAX logins
       # MAX_URL: https://login.max.gov/cas/login
       # The following settings are to maintain environment parity between the
@@ -47,14 +48,18 @@ services:
       VCAP_APPLICATION: >
         {"uris": ["localhost", "0.0.0.0", "127.0.0.1", "prod-api", "dev-api", "proxy"]}
       VCAP_SERVICES: >
-        {"config": [{"credentials":
-          {"DJANGO_SECRET_KEY": "NotASecret", "USING_SSL": "False"}
-        }],
-          "s3": [{"credentials":
-          {"access_key_id": "LOCAL_ID", "bucket": "pdfs", "secret_access_key": "LOCAL_KEY", "region": "irrelevant fake region", "endpoint": "http://0.0.0.0:9100"},
-          "label": "s3",
-          "name": "storage-s3"
-        }]
+        {"config": [{"credentials": {"DJANGO_SECRET_KEY": "NotASecret"}}],
+         "s3": [{
+           "credentials": {
+             "access_key_id": "LOCAL_ID",
+             "bucket": "pdfs",
+             "region": "irrelevant fake region",
+             "endpoint": "http://0.0.0.0:9100",
+             "secret_access_key": "LOCAL_KEY"
+           },
+           "label": "s3",
+           "name": "storage-s3"
+         }]
         }
     depends_on:
       - persistent_db
@@ -64,7 +69,7 @@ services:
   dev-api: &DEV_API
     <<: *PROD_API
     command: ./devops/wait_for_db_then ./devops/activate_then ./devops/run_api.sh
-    environment: &DEV_API_ENV
+    environment:
       <<: *API_ENV
       PORT: 8001
       DEBUG: "true"

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -26,6 +26,5 @@ applications:
     services:
       - config    # user-provided service w/ UI_BASIC_AUTH and NEW_RELIC_LICENSE_KEY
     env:
-      INTERNAL_API: https://omb-eregs-api-demo.app.cloud.gov/
-      PUBLIC_API: https://omb-eregs-api-demo.app.cloud.gov/
+      API_URL: https://omb-eregs-api-demo.app.cloud.gov/
       NEW_RELIC_APP_NAME: OMB Demo UI

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -29,6 +29,5 @@ applications:
     services:
       - config    # user-provided service w/ UI_BASIC_AUTH and NEW_RELIC_LICENSE_KEY
     env:
-      INTERNAL_API: https://policy-api.cio.gov/
-      PUBLIC_API: https://policy-api.cio.gov/
+      API_URL: https://policy-api.cio.gov/
       NEW_RELIC_APP_NAME: OMB Prod UI

--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -104,7 +104,7 @@ SECURE_BROWSER_XSS_FILTER = True
 # Request browsers not guess at mimetypes
 SECURE_CONTENT_TYPE_NOSNIFF = True
 # Request cookies only be sent over SSL
-USING_SSL = env.get_credential('USING_SSL', 'TRUE').upper() == 'TRUE'
+USING_SSL = os.environ.get('USING_SSL', 'TRUE').upper() == 'TRUE'
 SESSION_COOKIE_SECURE = USING_SSL
 CSRF_COOKIE_SECURE = USING_SSL
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True

--- a/ui/components/html.jsx
+++ b/ui/components/html.jsx
@@ -6,13 +6,9 @@ import DAP from './dap';
 
 
 export default function Html({ contents, data }) {
-  const browserConfig = Object.assign({}, config, {
-    // Public API endpoint might not match private version
-    apiRoot: process.env.PUBLIC_API,
-  });
   const jsStr = `
     window.__REACT_RESOLVER_PAYLOAD__ = ${serialize(data)};
-    window.APP_CONFIG = ${serialize(browserConfig)};
+    window.APP_CONFIG = ${serialize(config)};
   `;
   // Avoid escaping the JS
   /* eslint-disable react/no-danger */

--- a/ui/config.js
+++ b/ui/config.js
@@ -9,7 +9,7 @@ const config = {
 
 if (typeof process !== 'undefined') {
   Object.assign(config, {
-    apiRoot: process.env.INTERNAL_API,
+    apiRoot: process.env.API_URL,
     debug: process.env.NODE_ENV !== 'production',
   });
 }


### PR DESCRIPTION
We had two different URLs to account for communications within the docker
network and between the browser and API. Since #345 puts all of that network
into one proxy component, we can collapse into a single configuration option.