### PR TITLE
Agency Filter UI

### DIFF
--- a/omb_eregs/settings.py
+++ b/omb_eregs/settings.py
@@ -242,6 +242,7 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': (
         'django_filters.rest_framework.DjangoFilterBackend',
         'rest_framework.filters.OrderingFilter',
+        'rest_framework.filters.SearchFilter',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly',

--- a/reqs/models.py
+++ b/reqs/models.py
@@ -17,10 +17,14 @@ class Agency(models.Model):
     omb_agency_code = models.CharField(max_length=8, blank=True)
     nonpublic = models.BooleanField(default=False)
 
-    def __str__(self):
+    @property
+    def name_with_abbr(self):
         if self.abbr:
             return '{0} ({1})'.format(self.name, self.abbr)
         return self.name
+
+    def __str__(self):
+        return self.name_with_abbr
 
 
 class AgencyGroup(models.Model):

--- a/reqs/serializers.py
+++ b/reqs/serializers.py
@@ -6,7 +6,7 @@ from reqs.models import Agency, AgencyGroup, Policy, Requirement, Topic
 class AgencySerializer(serializers.ModelSerializer):
     class Meta:
         model = Agency
-        fields = ('id', 'name', 'abbr')
+        fields = ('id', 'name', 'abbr', 'name_with_abbr')
 
 
 class AgencyGroupSerializer(serializers.ModelSerializer):

--- a/reqs/tests/views_simple_tests.py
+++ b/reqs/tests/views_simple_tests.py
@@ -1,0 +1,24 @@
+import pytest
+from model_mommy import mommy
+from rest_framework.test import APIClient
+
+from reqs.models import Agency
+
+
+@pytest.mark.django_db
+def test_filter_agency_by_abbr():
+    mommy.make(Agency)
+    fbi = mommy.make(Agency, abbr='FBI')
+    gsa = mommy.make(Agency, name='General Services Administration')
+    client = APIClient()
+
+    response = client.get('/agencies/').json()
+    assert response['count'] == 3
+
+    response = client.get('/agencies/?search=fbi').json()
+    assert response['count'] == 1
+    assert response['results'][0]['id'] == fbi.id
+
+    response = client.get('/agencies/?search=general').json()
+    assert response['count'] == 1
+    assert response['results'][0]['id'] == gsa.id

--- a/reqs/views/policies.py
+++ b/reqs/views/policies.py
@@ -65,6 +65,7 @@ class PolicyViewSet(viewsets.ModelViewSet):
     queryset = Policy.objects.all()
     serializer_class = PolicySerializer
     filter_fields = PolicyFilter.get_fields()
+    search_fields = ('title',)
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/reqs/views/requirements.py
+++ b/reqs/views/requirements.py
@@ -66,6 +66,7 @@ class RequirementViewSet(viewsets.ModelViewSet):
         for key, value in TopicFilter.get_fields().items()})
     filter_backends = (DjangoFilterBackend, PriorityOrderingFilter)
     ordering_fields = filter_fields.keys()
+    search_fields = ('req_text',)
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/reqs/views/simple.py
+++ b/reqs/views/simple.py
@@ -12,6 +12,7 @@ class TopicViewSet(viewsets.ModelViewSet):
     queryset = Topic.objects.all()
     serializer_class = TopicSerializer
     filter_fields = TopicFilter.get_fields()
+    search_fields = ('name',)
 
 
 class TopicAdminAutocomplete(Select2QuerySetView):
@@ -24,6 +25,7 @@ class AgencyViewSet(viewsets.ModelViewSet):
     queryset = Agency.objects.filter(nonpublic=False)
     serializer_class = AgencySerializer
     filter_fields = AgencyFilter.get_fields()
+    search_fields = ('name', 'abbr')
 
 
 class AgencyGroupViewSet(viewsets.ModelViewSet):
@@ -34,3 +36,4 @@ class AgencyGroupViewSet(viewsets.ModelViewSet):
     filter_fields.update({
         'agencies__' + key: value
         for key, value in AgencyFilter.get_fields().items()})
+    search_fields = ('name',)

--- a/ui/__tests__/components/filters/existing-container.test.js
+++ b/ui/__tests__/components/filters/existing-container.test.js
@@ -7,20 +7,18 @@ import mockRouter from '../../util/mockRouter';
 
 describe('<ExistingFiltersContainer />', () => {
   it('contains the correct remove links', () => {
-    const topics = [{ id: 4, name: 'A' }, { id: 8, name: 'B' }];
-    const policies = [
-      { id: 1, title: 'C' }, { id: 3, title: 'D' }, { id: 5, title: 'E' }];
     const result = shallow(React.createElement(ExistingFiltersContainer, {
-      fieldNames: { policies: 'ppp', search: 'sss', topics: 'ttt' },
-      policies,
-      topics,
-    }));
+      topics: [{ id: 4, name: 'A' }, { id: 8, name: 'B' }],
+      policies: [
+        { id: 1, title: 'C' }, { id: 3, title: 'D' }, { id: 5, title: 'E' }],
+      agencies: [{ id: 9, name: 'F' }],
+      fieldNames: { agencies: 'aaa', policies: 'ppp', search: 'sss', topics: 'ttt' } }));
     const links = result.find('RemoveLinkContainer');
 
-    expect(links).toHaveLength(5);
+    expect(links).toHaveLength(6);
     expect(links.map(l => l.prop('heading'))).toEqual([
-      'Topic', 'Topic', 'Policy', 'Policy', 'Policy']);
-    expect(links.map(l => l.prop('idToRemove'))).toEqual([4, 8, 1, 3, 5]);
+      'Topic', 'Topic', 'Policy', 'Policy', 'Policy', 'Agency']);
+    expect(links.map(l => l.prop('idToRemove'))).toEqual([4, 8, 1, 3, 5, 9]);
 
     expect(result.find('RemoveSearchContainer')).toHaveLength(1);
   });

--- a/ui/__tests__/components/lookup-search.test.jsx
+++ b/ui/__tests__/components/lookup-search.test.jsx
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { cleanParams, LookupSearch, redirectIfMatched, redirectQuery, search } from '../../components/lookup-search';
+import { cleanParams, LookupSearch, redirectQuery, search } from '../../components/lookup-search';
 import api from '../../api';
 import { UserError } from '../../error-handling';
 
@@ -65,59 +65,6 @@ describe('redirectQuery()', () => {
     const query = { some: 'thing', myParam: '1,7,9' };
     const result = redirectQuery(query, 'myParam', 3);
     expect(result).toEqual({ some: 'thing', myParam: '1,7,9,3' });
-  });
-});
-
-describe('redirectIfMatched()', () => {
-  const query = {
-    q: 'qqq',
-    insertParam: 'ins',
-    redirectPathname: '/requirements',
-  };
-  const routes = [{ path: 'search-redirect' }, { path: 'topics' }];
-  it('does not hit the api if a page number is present', () => {
-    const modifiedQuery = Object.assign({}, query, { page: '5' });
-    const params = { routes, location: { query: modifiedQuery } };
-    const redirect = jest.fn();
-    const done = jest.fn();
-
-    redirectIfMatched(params, redirect, done);
-    expect(api.topics.fetch).not.toHaveBeenCalled();
-    expect(redirect).not.toHaveBeenCalled();
-    expect(done).toHaveBeenCalledWith();
-  });
-  it('redirects if there is an exact match', () => {
-    const params = { routes, location: { query } };
-    const redirect = jest.fn();
-    api.topics.fetch.mockImplementationOnce(() =>
-      Promise.resolve({ count: 1, results: [{ id: 4 }] }));
-
-    const asyncCall = new Promise(done => redirectIfMatched(params, redirect, done));
-    return asyncCall.then(() => {
-      expect(api.topics.fetch).toHaveBeenCalledWith({ name: 'qqq' });
-      expect(redirect).toHaveBeenCalled();
-    });
-  });
-  it('passes exceptions up', () => {
-    const params = { routes, location: { query } };
-    const redirect = jest.fn();
-    api.topics.fetch.mockImplementationOnce(() =>
-      Promise.reject(Error('oh noes')));
-    const asyncCall = new Promise(done => redirectIfMatched(params, redirect, done));
-    return asyncCall.then((error) => {
-      expect(error).toEqual(Error('oh noes'));
-      expect(redirect).not.toHaveBeenCalled();
-    });
-  });
-  it('continues if there is no exact match', () => {
-    const params = { routes, location: { query } };
-    const redirect = jest.fn();
-    api.topics.fetch.mockImplementationOnce(() =>
-      Promise.resolve({ count: 0, results: [] }));
-    const asyncCall = new Promise(done => redirectIfMatched(params, redirect, done));
-    return asyncCall.then(() => {
-      expect(redirect).not.toHaveBeenCalled();
-    });
   });
 });
 

--- a/ui/__tests__/components/lookup-search.test.jsx
+++ b/ui/__tests__/components/lookup-search.test.jsx
@@ -157,14 +157,14 @@ describe('search()', () => {
   it('uses the correct parameters for topics', () => {
     search('topics', 'some query here');
     expect(api.topics.fetch).toHaveBeenCalledWith({
-      name__icontains: 'some query here', page: '1',
+      search: 'some query here', page: '1',
     });
   });
 
   it('uses the correct parameters for policies', () => {
     search('policies', 'some query here', '3');
     expect(api.policies.fetch).toHaveBeenCalledWith({
-      title__icontains: 'some query here', page: '3',
+      search: 'some query here', page: '3',
     });
   });
 });

--- a/ui/__tests__/components/policies/container.test.js
+++ b/ui/__tests__/components/policies/container.test.js
@@ -19,12 +19,18 @@ describe('<PoliciesContainer />', () => {
 
   it('has a topics filter controls', () => {
     const controls = result.prop('filterControls');
-    expect(controls).toHaveLength(1);
+    expect(controls).toHaveLength(2);
     expect(controls[0].props.heading).toEqual('Topics');
+    expect(controls[1].props.heading).toEqual('Agencies');
 
-    const autocompleter = controls[0].props.autocompleter;
+    let autocompleter = controls[0].props.autocompleter;
     expect(autocompleter.props.insertParam).toEqual('requirements__topics__id__in');
     expect(autocompleter.props.lookup).toEqual('topics');
+
+    autocompleter = controls[1].props.autocompleter;
+    expect(autocompleter.props.insertParam).toEqual(
+      'requirements__all_agencies__id__in');
+    expect(autocompleter.props.lookup).toEqual('agencies');
   });
 
 

--- a/ui/__tests__/components/requirements/container.test.js
+++ b/ui/__tests__/components/requirements/container.test.js
@@ -19,12 +19,17 @@ describe('<RequirementsContainer />', () => {
 
   it('has a topics filter controls', () => {
     const controls = result.prop('filterControls');
-    expect(controls).toHaveLength(1);
+    expect(controls).toHaveLength(2);
     expect(controls[0].props.heading).toEqual('Topics');
+    expect(controls[1].props.heading).toEqual('Agencies');
 
-    const autocompleter = controls[0].props.autocompleter;
+    let autocompleter = controls[0].props.autocompleter;
     expect(autocompleter.props.insertParam).toEqual('topics__id__in');
     expect(autocompleter.props.lookup).toEqual('topics');
+
+    autocompleter = controls[1].props.autocompleter;
+    expect(autocompleter.props.insertParam).toEqual('all_agencies__id__in');
+    expect(autocompleter.props.lookup).toEqual('agencies');
   });
 
   describe('its tabs', () => {

--- a/ui/api.js
+++ b/ui/api.js
@@ -38,7 +38,8 @@ export class Endpoint {
 }
 
 export default {
-  topics: new Endpoint('topics/'),
+  agencies: new Endpoint('agencies/'),
   policies: new Endpoint('policies/'),
   requirements: new Endpoint('requirements/'),
+  topics: new Endpoint('topics/'),
 };

--- a/ui/components/filters/autocompleter.js
+++ b/ui/components/filters/autocompleter.js
@@ -7,7 +7,7 @@ import React from 'react';
 import { Async } from 'react-select';
 
 import SearchView from './search-view';
-import { apiParam, redirectQuery, search } from '../lookup-search';
+import { apiNameField, redirectQuery, search } from '../lookup-search';
 
 export default class Autocompleter extends React.Component {
   constructor(props, context) {
@@ -36,7 +36,7 @@ export default class Autocompleter extends React.Component {
 
   loadOptions(inputStr) {
     const { lookup } = this.props;
-    const textField = apiParam[lookup];
+    const textField = apiNameField[lookup];
     return search(lookup, inputStr).then(data => ({
       options: data.results.map(
         entry => ({ value: entry.id, label: entry[textField] })),
@@ -58,7 +58,7 @@ export default class Autocompleter extends React.Component {
   }
 }
 Autocompleter.propTypes = {
-  lookup: React.PropTypes.oneOf(Object.keys(apiParam)).isRequired,
+  lookup: React.PropTypes.oneOf(Object.keys(apiNameField)).isRequired,
   insertParam: React.PropTypes.string.isRequired,
   pathname: React.PropTypes.string.isRequired,
 };

--- a/ui/components/filters/existing-container.js
+++ b/ui/components/filters/existing-container.js
@@ -57,7 +57,7 @@ RemoveSearchContainer.propTypes = {
 };
 RemoveSearchContainer.contextTypes = RemoveLinkContainer.contextTypes;
 
-export function ExistingFiltersContainer({ fieldNames, policies, topics }) {
+export function ExistingFiltersContainer({ agencies, fieldNames, policies, topics }) {
   const topicIds = topics.map(topic => topic.id);
   const topicFilters = topics.map(topic => React.createElement(
     RemoveLinkContainer, {
@@ -87,20 +87,35 @@ export function ExistingFiltersContainer({ fieldNames, policies, topics }) {
     }),
   ];
 
-  return React.createElement(
-    'ol', { className: 'list-reset' },
-    [].concat(topicFilters, policyFilters, searchFilters));
+  const agencyIds = agencies.map(agency => agency.id);
+  const agencyFilters = agencies.map(agency => React.createElement(
+    RemoveLinkContainer, {
+      existing: agencyIds,
+      field: fieldNames.agencies,
+      heading: 'Agency',
+      idToRemove: agency.id,
+      key: agency.id,
+      name: agency.name,
+    }));
+
+  const filters = [].concat(topicFilters, policyFilters, agencyFilters, searchFilters);
+
+  return React.createElement('ol', { className: 'list-reset' }, filters);
 }
 ExistingFiltersContainer.propTypes = {
-  policies: React.PropTypes.arrayOf(React.PropTypes.shape({
+  agencies: React.PropTypes.arrayOf(React.PropTypes.shape({
     id: React.PropTypes.number,
-    title: React.PropTypes.string,
+    name: React.PropTypes.string,
   })).isRequired,
   fieldNames: React.PropTypes.shape({
     policies: React.PropTypes.string,
     search: React.PropTypes.string,
     topics: React.PropTypes.string,
   }).isRequired,
+  policies: React.PropTypes.arrayOf(React.PropTypes.shape({
+    id: React.PropTypes.number,
+    title: React.PropTypes.string,
+  })).isRequired,
   topics: React.PropTypes.arrayOf(React.PropTypes.shape({
     id: React.PropTypes.number,
     name: React.PropTypes.string,
@@ -114,8 +129,12 @@ function fetchTopics({ query, fieldNames }) {
 function fetchPolicies({ query, fieldNames }) {
   return api.policies.withIds(query[fieldNames.policies]);
 }
+function fetchAgencies({ query, fieldNames }) {
+  return api.agencies.withIds(query[fieldNames.agencies]);
+}
 
 export default resolve({
+  agencies: fetchAgencies,
   policies: fetchPolicies,
   topics: fetchTopics,
 })(ExistingFiltersContainer);

--- a/ui/components/lookup-search.jsx
+++ b/ui/components/lookup-search.jsx
@@ -73,8 +73,9 @@ function redirectUrl(params, idToInsert) {
 /* Mapping between a lookup type (e.g. "topic") and the field in the API we
  * should search against/display */
 export const apiParam = {
-  topics: 'name',
+  agencies: 'name',
   policies: 'title',
+  topics: 'name',
 };
 
 export function redirectIfMatched({ routes, location: { query } }, redirect, done) {

--- a/ui/components/lookup-search.jsx
+++ b/ui/components/lookup-search.jsx
@@ -65,7 +65,7 @@ export function redirectQuery(query, insertParam, idToInsert) {
 /* Mapping between a lookup type (e.g. "topic") and the field in the API we
  * should display */
 export const apiNameField = {
-  agencies: 'name',
+  agencies: 'name_with_abbr',
   policies: 'title',
   topics: 'name',
 };

--- a/ui/components/lookup-search.jsx
+++ b/ui/components/lookup-search.jsx
@@ -165,8 +165,7 @@ LookupSearch.propTypes = {
 };
 
 export function search(lookup, q, page = '1') {
-  const queryParam = `${apiParam[lookup]}__icontains`;
-  const apiQuery = { [queryParam]: q, page };
+  const apiQuery = { search: q, page };
   return api[lookup].fetch(apiQuery);
 }
 

--- a/ui/components/policies/container.js
+++ b/ui/components/policies/container.js
@@ -36,12 +36,21 @@ export function PoliciesContainer({ location: { query }, pagedPolicies }) {
   const filterControls = [
     React.createElement(FilterListView, {
       autocompleter: React.createElement(Autocompleter, {
-        insertParam: 'requirements__topics__id__in',
+        insertParam: fieldNames.topics,
         lookup: 'topics',
         pathname: '/policies',
       }),
       heading: 'Topics',
       key: 'topic',
+    }),
+    React.createElement(FilterListView, {
+      autocompleter: React.createElement(Autocompleter, {
+        insertParam: fieldNames.agencies,
+        lookup: 'agencies',
+        patname: '/policies',
+      }),
+      heading: 'Agencies',
+      key: 'agency',
     }),
   ];
   const tabs = [

--- a/ui/components/policies/container.js
+++ b/ui/components/policies/container.js
@@ -25,6 +25,13 @@ function requirementsTab(policyQuery) {
     { active: false, tabName: 'Requirements', key: 'Requirements', link });
 }
 
+const fieldNames = {
+  agencies: 'requirements__all_agencies__id__in',
+  policies: 'id__in',
+  search: 'requirements__req_text__search',
+  topics: 'requirements__topics__id__in',
+};
+
 export function PoliciesContainer({ location: { query }, pagedPolicies }) {
   const filterControls = [
     React.createElement(FilterListView, {
@@ -50,14 +57,8 @@ export function PoliciesContainer({ location: { query }, pagedPolicies }) {
       topicsIds: query.requirements__topics__id__in,
     },
   );
-  const selectedFilters = React.createElement(ExistingFilters, {
-    fieldNames: {
-      policies: 'id__in',
-      search: 'requirements__req_text__search',
-      topics: 'requirements__topics__id__in',
-    },
-    query,
-  });
+  const selectedFilters = React.createElement(
+    ExistingFilters, { fieldNames, query });
   return React.createElement(
     SearchFilterView, { filterControls, pageContent, selectedFilters, tabs });
 }

--- a/ui/components/requirements/container.js
+++ b/ui/components/requirements/container.js
@@ -25,6 +25,13 @@ function policiesTab(reqQuery) {
     { active: false, tabName: 'Policies', key: 'Policies', link });
 }
 
+const fieldNames = {
+  agencies: 'all_agencies__id__in',
+  policies: 'policy__id__in',
+  search: 'req_text__search',
+  topics: 'topics__id__in',
+};
+
 export function RequirementsContainer({ location: { query }, pagedReqs }) {
   const filterControls = [
     React.createElement(FilterListView, {
@@ -46,14 +53,8 @@ export function RequirementsContainer({ location: { query }, pagedReqs }) {
     RequirementsView,
     { requirements: pagedReqs.results, count: pagedReqs.count },
   );
-  const selectedFilters = React.createElement(ExistingFilters, {
-    fieldNames: {
-      policies: 'policy__id__in',
-      search: 'req_text__search',
-      topics: 'topics__id__in',
-    },
-    query,
-  });
+  const selectedFilters = React.createElement(
+    ExistingFilters, { fieldNames, query });
   return React.createElement(
     SearchFilterView, { filterControls, pageContent, selectedFilters, tabs });
 }

--- a/ui/components/requirements/container.js
+++ b/ui/components/requirements/container.js
@@ -36,12 +36,21 @@ export function RequirementsContainer({ location: { query }, pagedReqs }) {
   const filterControls = [
     React.createElement(FilterListView, {
       autocompleter: React.createElement(Autocompleter, {
-        insertParam: 'topics__id__in',
+        insertParam: fieldNames.topics,
         lookup: 'topics',
         pathname: '/requirements',
       }),
       heading: 'Topics',
       key: 'topic',
+    }),
+    React.createElement(FilterListView, {
+      autocompleter: React.createElement(Autocompleter, {
+        insertParam: fieldNames.agencies,
+        lookup: 'agencies',
+        pathname: '/requirements',
+      }),
+      heading: 'Agencies',
+      key: 'agency',
     }),
   ];
   const tabs = [

--- a/ui/routes.jsx
+++ b/ui/routes.jsx
@@ -21,8 +21,9 @@ export default <Router history={browserHistory} >
   <Route path="/" component={App}>
     <IndexRoute component={Homepage} />
     <Route path="search-redirect">
-      <Route path="topics" component={LookupSearchResolver} onEnter={redirectIfMatched} />
+      <Route path="agencies" component={LookupSearchResolver} onEnter={redirectIfMatched} />
       <Route path="policies" component={LookupSearchResolver} onEnter={redirectIfMatched} />
+      <Route path="topics" component={LookupSearchResolver} onEnter={redirectIfMatched} />
     </Route>
     <Route path="policies" component={PolicyContainerResolver} />
     <Route path="requirements">

--- a/ui/routes.jsx
+++ b/ui/routes.jsx
@@ -4,7 +4,7 @@ import { browserHistory, IndexRoute, Redirect, Route, Router } from 'react-route
 import App from './components/app';
 import PolicyContainerResolver from './components/policies/container';
 import RequirementsContainerResolver from './components/requirements/container';
-import LookupSearchResolver, { redirectIfMatched } from './components/lookup-search';
+import LookupSearchResolver from './components/lookup-search';
 import Homepage from './components/homepage/view';
 
 // Trigger DAP pageviews when our history changes (for single-page-app users)
@@ -21,9 +21,9 @@ export default <Router history={browserHistory} >
   <Route path="/" component={App}>
     <IndexRoute component={Homepage} />
     <Route path="search-redirect">
-      <Route path="agencies" component={LookupSearchResolver} onEnter={redirectIfMatched} />
-      <Route path="policies" component={LookupSearchResolver} onEnter={redirectIfMatched} />
-      <Route path="topics" component={LookupSearchResolver} onEnter={redirectIfMatched} />
+      <Route path="agencies" component={LookupSearchResolver} />
+      <Route path="policies" component={LookupSearchResolver} />
+      <Route path="topics" component={LookupSearchResolver} />
     </Route>
     <Route path="policies" component={PolicyContainerResolver} />
     <Route path="requirements">


### PR DESCRIPTION
Builds on #351 ([diff](https://github.com/18F/omb-eregs/compare/340-agency-api...341-agency-filter-ui)) to add a UI element for searching by agency. To do this, query by a common `search` parameter over the API and re-using much of the existing filters code.

Should resolve #341 