### PR TITLE
Add agencies, groups to admin UI.

### DIFF
--- a/reqs/admin.py
+++ b/reqs/admin.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 from django.core.exceptions import ValidationError
 from reversion.admin import VersionAdmin
 
-from reqs.models import Policy, Requirement, Topic
+from reqs.models import Agency, AgencyGroup, Policy, Requirement, Topic
 
 
 def is_extension_pdf(uploaded_file):
@@ -68,3 +68,26 @@ class RequirementForm(forms.ModelForm):
 class RequirementAdmin(VersionAdmin):
     form = RequirementForm
     search_fields = ['req_id', 'req_text']
+
+
+@admin.register(Agency)
+class AgencyAdmin(VersionAdmin):
+    fieldsets = (
+        ('Editable fields', {'fields': ['nonpublic']}),
+        ('Imported fields', {
+            'description': ('Data for these fields has been imported from '
+                            'itdashboard.gov.'),
+            'fields': ['name', 'abbr']
+        })
+    )
+    list_display = ['name', 'abbr', 'nonpublic']
+    list_filter = ['nonpublic']
+    readonly_fields = ['name', 'abbr']
+    search_fields = ['name']
+
+
+@admin.register(AgencyGroup)
+class AgencyGroupAdmin(VersionAdmin):
+    fields = ['name', 'agencies']
+    filter_horizontal = ['agencies']
+    search_fields = ['name']

--- a/reqs/tests/admin_tests.py
+++ b/reqs/tests/admin_tests.py
@@ -5,7 +5,7 @@ from model_mommy import mommy
 from reversion.models import Version
 
 from reqs.admin import RequirementForm
-from reqs.models import Policy, Requirement, Topic
+from reqs.models import Agency, Policy, Requirement, Topic
 
 
 def test_reqs_in_topics(admin_client):
@@ -130,7 +130,7 @@ def test_taggit_widget_doublequotes(tag, expected):
 
 
 @pytest.mark.django_db
-def test_reversion(admin_client):
+def test_reversion():
     with reversion.create_revision():
         key = mommy.make(Topic, name="key1")
 
@@ -154,3 +154,17 @@ def test_reversion(admin_client):
 
     key.refresh_from_db()
     assert key.name == "key1"
+
+
+@pytest.mark.django_db
+def test_agency_form(admin_client):
+    agency = mommy.make(Agency)
+    resp = admin_client.get('/admin/reqs/agency/{0}/change/'.format(
+        agency.pk))
+
+    markup = resp.content.decode('utf-8')
+    assert 'Editable fields' in markup
+    assert 'Imported fields' in markup
+    assert 'name="nonpublic"' in markup
+    assert 'name="name"' not in markup
+    assert 'name="abbr"' not in markup


### PR DESCRIPTION
For agencies, we import a bunch of data from itdashboard.gov, so we'll
separate out readonly from editable fields.

For agency groups, we make the "agencies" field a horizontal filter so that
it's a bit more manageable.

Builds off #347 

Should resolve #339 
Looks like:

<img width="1013" alt="screen shot 2017-05-30 at 1 23 12 pm" src="https://cloud.githubusercontent.com/assets/326918/26597668/bd1576fc-4540-11e7-8e3e-ebc7b342d455.png">
<img width="1027" alt="screen shot 2017-05-30 at 1 23 31 pm" src="https://cloud.githubusercontent.com/assets/326918/26597667/bcff7348-4540-11e7-9e2b-f18428c2d7f3.png">
<img width="1035" alt="screen shot 2017-05-30 at 1 10 45 pm" src="https://cloud.githubusercontent.com/assets/326918/26597669/bd1a852a-4540-11e7-8879-6e98809a188d.png">
