### PR TITLE
Remove add permission for agencies.

### DIFF
--- a/reqs/admin.py
+++ b/reqs/admin.py
@@ -85,6 +85,10 @@ class AgencyAdmin(VersionAdmin):
     readonly_fields = ['name', 'abbr']
     search_fields = ['name']
 
+    def has_add_permission(self, request):
+        """Don't allow users to add Agencies."""
+        return False
+
 
 @admin.register(AgencyGroup)
 class AgencyGroupAdmin(VersionAdmin):

--- a/reqs/tests/admin_tests.py
+++ b/reqs/tests/admin_tests.py
@@ -168,3 +168,8 @@ def test_agency_form(admin_client):
     assert 'name="nonpublic"' in markup
     assert 'name="name"' not in markup
     assert 'name="abbr"' not in markup
+
+
+def test_agency_cannot_be_added(admin_client):
+    resp = admin_client.get('/admin/reqs/agency/add/')
+    assert resp.status_code == 403


### PR DESCRIPTION
As agencies are populated via an import script, we should remove the ability
for admins to create new instances.