### PR TITLE
Add a spinner during AJAX load

### DIFF
--- a/ui/__tests__/components/ajax-loading.test.jsx
+++ b/ui/__tests__/components/ajax-loading.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { AjaxLoadingResolver, wrapWithAjaxLoader } from '../../components/ajax-loading';
+
+describe('wrapWithAjaxLoader', () => {
+  it('creates an AjaxLoadingResolver', () => {
+    const result = React.createElement(
+      wrapWithAjaxLoader(null, { ajax: 'fn' }, 123), { some: 'props' });
+    const el = shallow(result);
+    expect(el.name()).toEqual('AjaxLoadingResolver');
+    expect(el.prop('props')).toEqual({ some: 'props' });
+    expect(el.prop('height')).toEqual(123);
+    expect(el.prop('resolve')).toEqual({ ajax: 'fn' });
+  });
+  it('passes the resolved data', () => {
+    const result = React.createElement(
+      wrapWithAjaxLoader('div', { ajax: 'wouldGoHere' }),
+      { className: 'classy' });
+    const child = shallow(result).prop('children')({ resolved: 'data' });
+
+    const el = shallow(child);
+    expect(el.name()).toEqual('div');
+    expect(el.prop('className')).toEqual('classy');
+    expect(el.prop('resolved')).toEqual('data');
+  });
+});
+
+describe('AjaxLoadingResolver', () => {
+  it('displays a spinner until loaded', () => {
+    const childFn = () => React.createElement('div');
+    // We've overriding methods to be constant, so we won't reference "this"
+    /* eslint-disable class-methods-use-this */
+    class PendingResolver extends AjaxLoadingResolver {
+      isPending() { return true; }
+    }
+    class ResolvedResolver extends AjaxLoadingResolver {
+      isPending() { return false; }
+    }
+    /* eslint-enable class-methods-use-this */
+
+    const spinner = shallow(React.createElement(PendingResolver, {}, childFn));
+    expect(spinner.name()).toEqual('Spinner');
+
+    const resolved = shallow(React.createElement(ResolvedResolver, {}, childFn));
+    expect(resolved.name()).toEqual('div');
+  });
+});

--- a/ui/assets/css/_loading-indicator.scss
+++ b/ui/assets/css/_loading-indicator.scss
@@ -1,0 +1,15 @@
+.loading-indicator {
+  text-align: center;
+
+  .loading-spinner {
+    -webkit-animation: Select-animation-spin 400ms infinite linear;
+    -o-animation: Select-animation-spin 400ms infinite linear;
+    animation: Select-animation-spin 400ms infinite linear;
+    box-sizing: border-box;
+    border-radius: 50%;
+    border-style: solid;
+    border-color: #ccc;
+    border-right-color: #333;
+    display: inline-block;
+  }
+}

--- a/ui/assets/css/main.scss
+++ b/ui/assets/css/main.scss
@@ -24,4 +24,5 @@ and includes any non-semantic helper classes
 @import 'search-autocomplete';
 @import 'policies';
 @import 'homepage';
+@import 'loading-indicator';
 @import 'search';

--- a/ui/components/ajax-loading.js
+++ b/ui/components/ajax-loading.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Resolver } from 'react-resolver';
+
+import Spinner from './spinner';
+
+
+export class AjaxLoadingResolver extends Resolver {
+  /* Resolver's shouldComponentUpdate tries to be efficient by not updating
+   * when there's no data. We *do* want to trigger a render when there's no
+   * data, so we override that method. */
+  shouldComponentUpdate(nextProps, nextState) {
+    // implement the logic present in Resolver's shouldComponentUpdate
+    if (!this.isParentPending() && this.isPending(nextState)) {
+      this.resolve(nextState);
+    }
+    return true;
+  }
+  render() {
+    if (this.isPending()) {
+      return React.createElement(Spinner, this.props);
+    }
+    return super.render();
+  }
+}
+AjaxLoadingResolver.displayName = 'AjaxLoadingResolver';
+
+/* Replace a Component with a wrapped version which shows a Spinner of the
+ * requested height until the data is loaded. */
+export function wrapWithAjaxLoader(Component, ajaxFns, height = 100) {
+  /* Converts provided props into an AjaxLoadingResolver */
+  function Wrapper(props) {
+    /* Combines AJAX properties with explicit properties to render the inner
+     * component */
+    function generateContents(resolvedProps) {
+      return React.createElement(Component, Object.assign({}, props, resolvedProps));
+    }
+    return React.createElement(
+      AjaxLoadingResolver, { props, height, resolve: ajaxFns }, generateContents);
+  }
+
+  return Wrapper;
+}

--- a/ui/components/filters/existing-container.js
+++ b/ui/components/filters/existing-container.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { resolve } from 'react-resolver';
 
 import FilterRemoveView from './remove-view';
+import { wrapWithAjaxLoader } from '../ajax-loading';
 import api from '../../api';
 
 export function RemoveLinkContainer(
@@ -133,8 +133,9 @@ function fetchAgencies({ query, fieldNames }) {
   return api.agencies.withIds(query[fieldNames.agencies]);
 }
 
-export default resolve({
-  agencies: fetchAgencies,
-  policies: fetchPolicies,
-  topics: fetchTopics,
-})(ExistingFiltersContainer);
+export default wrapWithAjaxLoader(
+  ExistingFiltersContainer,
+  { agencies: fetchAgencies,
+    policies: fetchPolicies,
+    topics: fetchTopics },
+  50);

--- a/ui/components/homepage/new-policies/container.js
+++ b/ui/components/homepage/new-policies/container.js
@@ -1,8 +1,8 @@
 import moment from 'moment';
 import React from 'react';
-import { resolve } from 'react-resolver';
 
 import api from '../../../api';
+import { wrapWithAjaxLoader } from '../../ajax-loading';
 import NewPolicyView from './view';
 
 const NUM_POLICIES = 4;
@@ -31,6 +31,5 @@ export function fetchRecentPolicies() {
     .then(results => results.slice(0, NUM_POLICIES).map(formatIssuance));
 }
 
-export default resolve({
-  recentPolicies: fetchRecentPolicies,
-})(NewPoliciesContainer);
+export default wrapWithAjaxLoader(
+  NewPoliciesContainer, { recentPolicies: fetchRecentPolicies });

--- a/ui/components/lookup-search.jsx
+++ b/ui/components/lookup-search.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { resolve } from 'react-resolver';
 import { Link } from 'react-router';
 import validator from 'validator';
 
 import { redirectQuery, redirectWhiteList } from '../redirects';
 import { UserError } from '../error-handling';
 import { apiNameField, search } from '../lookup-search';
+import { wrapWithAjaxLoader } from './ajax-loading';
 import Pagers from './pagers';
 
 const redirectQueryPrefix = 'redirectQuery__';
@@ -120,4 +120,4 @@ function fetchData({ routes, location: { query } }) {
   return search(lookup, userParams.q, userParams.page);
 }
 
-export default resolve('pagedEntries', fetchData)(LookupSearch);
+export default wrapWithAjaxLoader(LookupSearch, { pagedEntries: fetchData });

--- a/ui/components/policies/container.js
+++ b/ui/components/policies/container.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { resolve } from 'react-resolver';
 
 import PoliciesView from './policies-view';
 import SearchFilterView from '../search-filter-view';
@@ -7,6 +6,7 @@ import TabView from '../tab-view';
 import ExistingFilters from '../filters/existing-container';
 import FilterListView from '../filters/list-view';
 import Selector from '../filters/selector';
+import { wrapWithAjaxLoader } from '../ajax-loading';
 import api from '../../api';
 
 function requirementsTab(policyQuery) {
@@ -90,7 +90,5 @@ function fetchPolicies({ location: { query } }) {
   return api.policies.fetch(params);
 }
 
-export default resolve({
-  pagedPolicies: fetchPolicies,
-})(PoliciesContainer);
-
+export default wrapWithAjaxLoader(
+  PoliciesContainer, { pagedPolicies: fetchPolicies });

--- a/ui/components/requirements/container.js
+++ b/ui/components/requirements/container.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { resolve } from 'react-resolver';
 
 import RequirementsView from './requirements-view';
+import { wrapWithAjaxLoader } from '../ajax-loading';
 import SearchFilterView from '../search-filter-view';
 import TabView from '../tab-view';
 import ExistingFilters from '../filters/existing-container';
@@ -85,6 +85,5 @@ function fetchRequirements({ location: { query } }) {
   return api.requirements.fetch(query);
 }
 
-export default resolve({
-  pagedReqs: fetchRequirements,
-})(RequirementsContainer);
+export default wrapWithAjaxLoader(
+  RequirementsContainer, { pagedReqs: fetchRequirements });

--- a/ui/components/spinner.jsx
+++ b/ui/components/spinner.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function Spinner({ height }) {
+  const borderWidth = Math.ceil(height / 10);
+  const indicatorStyle = { height: `${height}px` };
+  const spinnerStyle = {
+    borderWidth: `${borderWidth}px`,
+    height: `${height}px`,
+    width: `${height}px`,
+  };
+  return (
+    <div className="loading-indicator p2" style={indicatorStyle}>
+      <span className="loading-spinner" style={spinnerStyle} />
+    </div>
+  );
+}
+Spinner.propTypes = {
+  height: React.PropTypes.number,
+};
+Spinner.defaultProps = {
+  height: 100,
+};


### PR DESCRIPTION
React-resolver doesn't quite give us the tools needed to implement a loading-spinner during AJAX requests, but we can extend their [Resolver](https://github.com/ericclemmons/react-resolver/blob/master/src/Resolver.js) to get there.

Looks like
![spinner](https://user-images.githubusercontent.com/326918/26841859-d5ea4982-4ab8-11e7-8515-8449f5c337d1.gif)

Should resolve #373 