### PR TITLE
Comment out Agency UI.

### DIFF
--- a/ui/__tests__/components/policies/container.test.js
+++ b/ui/__tests__/components/policies/container.test.js
@@ -19,18 +19,12 @@ describe('<PoliciesContainer />', () => {
 
   it('has a topics filter controls', () => {
     const controls = result.prop('filterControls');
-    expect(controls).toHaveLength(2);
+    expect(controls).toHaveLength(1);
     expect(controls[0].props.heading).toEqual('Topics');
-    expect(controls[1].props.heading).toEqual('Agencies');
 
-    let autocompleter = controls[0].props.autocompleter;
+    const autocompleter = controls[0].props.autocompleter;
     expect(autocompleter.props.insertParam).toEqual('requirements__topics__id__in');
     expect(autocompleter.props.lookup).toEqual('topics');
-
-    autocompleter = controls[1].props.autocompleter;
-    expect(autocompleter.props.insertParam).toEqual(
-      'requirements__all_agencies__id__in');
-    expect(autocompleter.props.lookup).toEqual('agencies');
   });
 
 

--- a/ui/__tests__/components/requirements/container.test.js
+++ b/ui/__tests__/components/requirements/container.test.js
@@ -19,17 +19,12 @@ describe('<RequirementsContainer />', () => {
 
   it('has a topics filter controls', () => {
     const controls = result.prop('filterControls');
-    expect(controls).toHaveLength(2);
+    expect(controls).toHaveLength(1);
     expect(controls[0].props.heading).toEqual('Topics');
-    expect(controls[1].props.heading).toEqual('Agencies');
 
-    let autocompleter = controls[0].props.autocompleter;
+    const autocompleter = controls[0].props.autocompleter;
     expect(autocompleter.props.insertParam).toEqual('topics__id__in');
     expect(autocompleter.props.lookup).toEqual('topics');
-
-    autocompleter = controls[1].props.autocompleter;
-    expect(autocompleter.props.insertParam).toEqual('all_agencies__id__in');
-    expect(autocompleter.props.lookup).toEqual('agencies');
   });
 
   describe('its tabs', () => {

--- a/ui/components/policies/container.js
+++ b/ui/components/policies/container.js
@@ -43,6 +43,7 @@ export function PoliciesContainer({ location: { query }, pagedPolicies }) {
       heading: 'Topics',
       key: 'topic',
     }),
+    /* Add this back once the data's cleaned up
     React.createElement(FilterListView, {
       autocompleter: React.createElement(Autocompleter, {
         insertParam: fieldNames.agencies,
@@ -52,6 +53,7 @@ export function PoliciesContainer({ location: { query }, pagedPolicies }) {
       heading: 'Agencies',
       key: 'agency',
     }),
+    */
   ];
   const tabs = [
     requirementsTab(query),

--- a/ui/components/requirements/container.js
+++ b/ui/components/requirements/container.js
@@ -43,6 +43,7 @@ export function RequirementsContainer({ location: { query }, pagedReqs }) {
       heading: 'Topics',
       key: 'topic',
     }),
+    /* Add this back once the data's cleaned up
     React.createElement(FilterListView, {
       autocompleter: React.createElement(Autocompleter, {
         insertParam: fieldNames.agencies,
@@ -52,6 +53,7 @@ export function RequirementsContainer({ location: { query }, pagedReqs }) {
       heading: 'Agencies',
       key: 'agency',
     }),
+    */
   ];
   const tabs = [
     React.createElement(


### PR DESCRIPTION
As we don't have data yet, temporarily hide these inputs from the user-facing
UI.