### PR TITLE
Add the office name to the Django admin.

### DIFF
--- a/reqs/models.py
+++ b/reqs/models.py
@@ -91,6 +91,9 @@ class PolicyTypes(Enum):
 class Office(models.Model):
     name = models.CharField(max_length=256)
 
+    def __str__(self):
+        return self.name
+
 
 class Policy(models.Model):
     class Meta:


### PR DESCRIPTION
Django models should always have a __str__; otherwise, when the model is in a
select field, it'll just say, e.g. "Agency Object".

Compare:

## Old
<img width="387" alt="screen shot 2017-06-09 at 4 13 13 pm" src="https://user-images.githubusercontent.com/326918/26992905-b376b868-4d2e-11e7-803f-c01beb4926e4.png">

## New
<img width="332" alt="screen shot 2017-06-09 at 4 14 04 pm" src="https://user-images.githubusercontent.com/326918/26992908-b74d0820-4d2e-11e7-9176-b30356ebc3e7.png">
