### PR TITLE
Create versions in import/sync scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Let's also load the requirements and agency data from OMB:
 docker-compose run --rm manage.py fetch_csv
 docker-compose run --rm manage.py import_reqs data.csv
 docker-compose run --rm manage.py sync_agencies
-docker-compose run --rm manage.py createinitialrevisions
 ```
 
 This may emit some warnings for improper input. The next time you visit the

--- a/devops/run_api.sh
+++ b/devops/run_api.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 ./manage.py migrate --noinput
-./manage.py createinitialrevisions
 if [ -n "$DEBUG" ]; then
   ./manage.py runserver 0.0.0.0:$PORT
 else

--- a/reqs/tests/import_reqs_tests.py
+++ b/reqs/tests/import_reqs_tests.py
@@ -1,8 +1,10 @@
+import random
 from datetime import date
 from unittest.mock import Mock
 
 import pytest
 from django.core.management import call_command
+from django.utils.crypto import get_random_string
 from model_mommy import mommy
 
 from reqs.management.commands import import_reqs
@@ -136,12 +138,38 @@ def test_priority_split(text, result):
     assert import_reqs.priority_split(text, ';', ',') == result
 
 
+def policy_row_factory(**kwargs):
+    """Generate random data in a policy-row format"""
+    row = dict(
+        policyNumber=str(random.randint(100, 999)),                 # nosec
+        policyTitle=get_random_string(32),
+        uriPolicyId='http://example.com/' + get_random_string(10),
+        ombPolicyId=get_random_string(32),
+        policyType=random.choice([t.value for t in PolicyTypes]),   # nosec
+        policyIssuanceYear=date(
+            random.randint(1950, 2016),                             # nosec
+            random.randint(1, 12),                                  # nosec
+            random.randint(1, 28)).strftime('%m/%d/%Y'),            # nosec
+        policySunset='NA',
+        issuingBody=get_random_string(10)
+    )
+    row.update(kwargs)
+    return row
+
+
 @pytest.mark.django_db
 def test_policy_from_row():
-    row = {'policyNumber': '123', 'policyTitle': 'title 1',
-           'uriPolicyId': 'http://example.com/a', 'ombPolicyId': 'policy',
-           'policyType': 'Memo', 'policyIssuanceYear': '12/20/2001',
-           'policySunset': 'NA', 'issuingBody': 'IBIB'}
+    row = policy_row_factory(
+        policyNumber='123',
+        policyTitle='title 1',
+        uriPolicyId='http://example.com/a',
+        ombPolicyId='policy',
+        policyType='Memo',
+        policyIssuanceYear='12/20/2001',
+        policySunset='NA',
+        issuingBody='IBIB'
+    )
+
     policy_proc = import_reqs.PolicyProcessor()
     policy = policy_proc.from_row(row)
     assert policy.policy_number == 123
@@ -158,10 +186,7 @@ def test_policy_from_row():
 @pytest.mark.django_db
 def test_policy_from_row_duplicate():
     assert Policy.objects.count() == 0
-    row = {'policyNumber': '123', 'policyTitle': 'title 1',
-           'uriPolicyId': 'http://example.com/a', 'ombPolicyId': 'policy',
-           'policyType': 'Memo', 'policyIssuanceYear': '12/20/2001',
-           'policySunset': 'NA', 'issuingBody': 'IBIB'}
+    row = policy_row_factory(policyNumber='123', policyTitle='title 1')
     import_reqs.PolicyProcessor().from_row(row)
     assert Policy.objects.count() == 1
     assert Policy.objects.get(policy_number=123).title == 'title 1'
@@ -205,10 +230,7 @@ def test_repeat_row():
 @pytest.mark.django_db
 def test_no_matching_policy_type():
     """If the policy type isn't found, raise an exception"""
-    row = {'policyNumber': '123', 'policyTitle': 'title 1',
-           'uriPolicyId': 'http://example.com/a', 'ombPolicyId': 'policy',
-           'policyType': 'IAmAnOutlier', 'policyIssuanceYear': '12/20/2001',
-           'policySunset': 'NA', 'issuingBody': 'IBIB'}
+    row = policy_row_factory(policyType='IAmAnOutlier')
     policy_proc = import_reqs.PolicyProcessor()
     with pytest.raises(ValueError):
         policy_proc.from_row(row)
@@ -249,14 +271,9 @@ def test_varying_policy_headers(opfid_field, uri_field):
     Test that we can handle a variety of names for fields (in this case, the
     OMB Policy ID field).
     """
-    row = {
-        'issuingBody': 'IBIB',
-        'policyIssuanceYear': '12/20/2001',
-        'policyNumber': '123',
-        'policySunset': 'NA',
-        'policyTitle': 'title 1',
-        'policyType': 'Guidance',
-    }
+    row = policy_row_factory(policyNumber='123')
+    del row['uriPolicyId']
+    del row['ombPolicyId']
     row[opfid_field] = "some identifier"
     row[uri_field] = "http://example.com/a"
     policy_proc = import_reqs.PolicyProcessor()

--- a/reqs/tests/sync_agencies_tests.py
+++ b/reqs/tests/sync_agencies_tests.py
@@ -1,8 +1,11 @@
+from unittest.mock import Mock
+
 import pytest
+from django.core.management import call_command
 from model_mommy import mommy
 from reversion.models import Version
 
-from reqs.management.commands.sync_agencies import Command
+from reqs.management.commands import sync_agencies
 from reqs.models import Agency, AgencyGroup
 
 
@@ -11,7 +14,7 @@ def test_create_system_groups():
     """We create agency groups *if they do not already exist*. When creating,
     we generate a version"""
     AgencyGroup.objects.create(slug='cfo-act', name='Alt CFO')
-    cmd = Command()
+    cmd = sync_agencies.Command()
     cmd.create_system_groups()
 
     assert AgencyGroup.objects.count() == 3
@@ -25,7 +28,7 @@ def test_create_system_groups():
 
 @pytest.mark.django_db
 def test_sync_row_new():
-    cmd = Command()
+    cmd = sync_agencies.Command()
     cmd.create_system_groups()
     cmd.sync_row({
         'agencyAbbreviation': None,
@@ -45,8 +48,6 @@ def test_sync_row_new():
     group_slugs = {g.slug for g in agency.groups.all()}
     assert group_slugs == {'cfo-act'}
     assert Version.objects.get_for_object(agency).count() == 1
-    group_version = Version.objects.get_for_object(agency.groups.get()).first()
-    assert group_version.field_dict['agencies'] == [agency.pk]
 
 
 @pytest.mark.django_db
@@ -54,7 +55,7 @@ def test_sync_row_existing():
     mommy.make(Agency, omb_agency_code='90210')
     assert Agency.objects.count() == 1
 
-    cmd = Command()
+    cmd = sync_agencies.Command()
     cmd.create_system_groups()
     cmd.sync_row({
         'agencyAbbreviation': 'BH',
@@ -74,6 +75,22 @@ def test_sync_row_existing():
     group_slugs = {g.slug for g in agency.groups.all()}
     assert group_slugs == {'cio-council', 'executive'}
     assert Version.objects.get_for_object(agency).count() == 1
-    for group in agency.groups.all():
-        group_version = Version.objects.get_for_object(group).first()
-        assert group_version.field_dict['agencies'] == [agency.pk]
+
+
+@pytest.mark.django_db
+def test_group_versions(monkeypatch):
+    """Avoid creating dozens of versions per agency group."""
+    monkeypatch.setattr(sync_agencies, 'requests', Mock())
+    sync_agencies.requests.get.return_value.json.return_value = dict(result=[
+        dict(agencyAbbreviation=c, agencyCode=c, agencyName=c, agencyType=c,
+             CFO_Act='1', CIO_Council='')
+        for c in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    ])
+
+    call_command('sync_agencies')
+
+    cfo = AgencyGroup.objects.get(slug='cfo-act')
+    versions = Version.objects.get_for_object(cfo)
+    assert versions.count() == 2    # one for creation, one final
+    assert len(versions[0].field_dict['agencies']) == 26
+    assert versions[1].field_dict['agencies'] == []


### PR DESCRIPTION
This is step 2 of fixes around #374; it creates versions when importing/synchronizing Policies, Requirements, Topics, Agencies, and AgencyGroups.

This PR also includes a somewhat unrelated test refactor which converts some test data into a factory method -- I ended up not needing this, but figured it wouldn't hurt to keep.