### PR TITLE
Extend VersionAdmin with schema mismatch warnings.

### DIFF
--- a/ereqs_admin/revision_admin.py
+++ b/ereqs_admin/revision_admin.py
@@ -1,0 +1,49 @@
+import json
+
+from django.contrib import messages
+from django.core import serializers
+from reversion.admin import VersionAdmin
+
+
+CERTAIN_WARNING = """
+    This version was created before the current fields were finalized. Please
+    carefully review the data before reverting.
+    """
+HEDGED_WARNING = """
+    This version may have been created before the current fields were
+    finalized. Please carefully review the data before reverting.
+    """
+
+
+def schema_mismatch(version, example):
+    """Does the serialized version contain the same fields as the example
+    model instance?"""
+    def fields(dictionary):
+        return set(dictionary[0]['fields'])
+
+    # Use the same machinery that reversions uses
+    curr_fields = fields(serializers.serialize('python', [example]))
+    version_fields = fields(json.loads(version.serialized_data))
+    return curr_fields != version_fields
+
+
+def alert_if_mismatch(request, version):
+    """Users should be notified if the version they're reverting has a
+    different schema than the current."""
+    example = version._model.objects.first()
+    if not example:
+        messages.warning(request, HEDGED_WARNING)
+    elif schema_mismatch(version, example):
+        messages.warning(request, CERTAIN_WARNING)
+
+
+class EReqsVersionAdmin(VersionAdmin):
+    """Extends VersionAdmin by adding a warning to the admin screen when
+    trying to revert a version with a schema mismatch."""
+    # @override
+    def _reversion_revisionform_view(
+            self, request, version, template_name, extra_context=None):
+        alert_if_mismatch(request, version)
+
+        return super()._reversion_revisionform_view(
+            request, version, template_name, extra_context)

--- a/ereqs_admin/tests/revision_admin_tests.py
+++ b/ereqs_admin/tests/revision_admin_tests.py
@@ -1,0 +1,60 @@
+import json
+
+import reversion
+from model_mommy import mommy
+from reversion.models import Version
+
+from ereqs_admin import revision_admin
+from reqs.models import Policy
+
+
+def policy_with_version():
+    policy = mommy.prepare(Policy)
+    with reversion.create_revision():
+        policy.save()
+    return policy, Version.objects.get_for_object(policy)[0]
+
+
+def test_schema_matches(admin_client):
+    policy, version = policy_with_version()
+    resp = admin_client.get('/admin/reqs/policy/{0}/history/{1}/'.format(
+        policy.pk, version.pk)).content.decode('utf-8')
+    assert revision_admin.CERTAIN_WARNING not in resp
+    assert revision_admin.HEDGED_WARNING not in resp
+
+
+def test_field_deleted(admin_client):
+    policy, version = policy_with_version()
+    data = json.loads(version.serialized_data)
+    del data[0]['fields']['public']
+    version.serialized_data = json.dumps(data)
+    version.save()
+
+    resp = admin_client.get('/admin/reqs/policy/{0}/history/{1}/'.format(
+        policy.pk, version.pk)).content.decode('utf-8')
+    assert revision_admin.CERTAIN_WARNING in resp
+    assert revision_admin.HEDGED_WARNING not in resp
+
+
+def test_field_added(admin_client):
+    policy, version = policy_with_version()
+    data = json.loads(version.serialized_data)
+    data[0]['fields']['a_new_field'] = 1234
+    version.serialized_data = json.dumps(data)
+    version.save()
+
+    resp = admin_client.get('/admin/reqs/policy/{0}/history/{1}/'.format(
+        policy.pk, version.pk)).content.decode('utf-8')
+    assert revision_admin.CERTAIN_WARNING in resp
+    assert revision_admin.HEDGED_WARNING not in resp
+
+
+def test_no_comparison(admin_client):
+    """If there are no models in the database anymore, we can't compare."""
+    policy, version = policy_with_version()
+    policy.delete()
+
+    resp = admin_client.get('/admin/reqs/policy/recover/{0}/'.format(
+        version.pk)).content.decode('utf-8')
+    assert revision_admin.CERTAIN_WARNING not in resp
+    assert revision_admin.HEDGED_WARNING in resp

--- a/reqs/admin.py
+++ b/reqs/admin.py
@@ -1,8 +1,8 @@
 from django import forms
 from django.contrib import admin
 from django.core.exceptions import ValidationError
-from reversion.admin import VersionAdmin
 
+from ereqs_admin.revision_admin import EReqsVersionAdmin
 from reqs.models import Agency, AgencyGroup, Office, Policy, Requirement, Topic
 
 
@@ -22,7 +22,7 @@ class PolicyForm(forms.ModelForm):
 
 
 @admin.register(Policy)
-class PolicyAdmin(VersionAdmin):
+class PolicyAdmin(EReqsVersionAdmin):
     form = PolicyForm
     search_fields = ['title', 'omb_policy_id']
     list_filter = ['policy_type', 'policy_status', 'public']
@@ -30,17 +30,17 @@ class PolicyAdmin(VersionAdmin):
 
 
 @admin.register(Topic)
-class TopicAdmin(VersionAdmin):
+class TopicAdmin(EReqsVersionAdmin):
     search_fields = ['name']
 
 
 @admin.register(Office)
-class OfficeAdmin(VersionAdmin):
+class OfficeAdmin(EReqsVersionAdmin):
     search_fields = ['name']
 
 
 @admin.register(Requirement)
-class RequirementAdmin(VersionAdmin):
+class RequirementAdmin(EReqsVersionAdmin):
     search_fields = ['req_id', 'req_text']
     filter_horizontal = ['agencies', 'agency_groups', 'topics']
     fields = [
@@ -64,7 +64,7 @@ class RequirementAdmin(VersionAdmin):
 
 
 @admin.register(Agency)
-class AgencyAdmin(VersionAdmin):
+class AgencyAdmin(EReqsVersionAdmin):
     fieldsets = (
         ('Editable fields', {'fields': ['public']}),
         ('Imported fields', {
@@ -84,7 +84,7 @@ class AgencyAdmin(VersionAdmin):
 
 
 @admin.register(AgencyGroup)
-class AgencyGroupAdmin(VersionAdmin):
+class AgencyGroupAdmin(EReqsVersionAdmin):
     fields = ['name', 'agencies']
     filter_horizontal = ['agencies']
     search_fields = ['name']


### PR DESCRIPTION
When users save models, a copy of all the model's fields is stored in a
version history. As the database schema changes, that version becomes less
compatible. We can warn the user when this occurs, though, by comparing the
fields that would serialize now to the fields stored in the database.

There's a nasty snag where the serialized field names don't quite match up
when comparing the names on an unsaved Django model. This works around that by
grabbing a model from the database and showing a slightly different warning
when that's not possible.

Pretty easy to change the message text if we don't like this version.