### PR TITLE
Accessibility tweaks

### DIFF
--- a/ui/__tests__/components/filters/fallback-view.test.js
+++ b/ui/__tests__/components/filters/fallback-view.test.js
@@ -6,6 +6,7 @@ import FallbackView from '../../../components/filters/fallback-view';
 
 describe('<FallbackView /> form', () => {
   const props = {
+    'aria-labelledby': 'some_id',
     insertParam: 'someParam',
     lookup: 'topics',
     pathname: '/policies',

--- a/ui/__tests__/components/filters/selector.test.js
+++ b/ui/__tests__/components/filters/selector.test.js
@@ -17,10 +17,12 @@ describe('<Selector />', () => {
     router.push = jest.fn();
 
     const el = shallow(
-      React.createElement(
-        Selector,
-        { lookup: 'topics', insertParam: 'insertHere', pathname: '/some/path/' }),
-      { context: { router } });
+      React.createElement(Selector, {
+        'aria-labelledby': 'some_id',
+        insertParam: 'insertHere',
+        lookup: 'topics',
+        pathname: '/some/path/',
+      }), { context: { router } });
     expect(el.children()).toHaveLength(2);
 
     const autocompleter = el.childAt(1);

--- a/ui/assets/css/_req-filter-ui.scss
+++ b/ui/assets/css/_req-filter-ui.scss
@@ -9,7 +9,7 @@
 
   .remove-filter-link {
     background: url('/static/img/remove-btn.svg') no-repeat center;
-    color: $color-white;
+    color: $color-gray-dark;
     padding: 0 0.25rem;
     text-decoration: none;
     text-indent: -9999px;

--- a/ui/assets/css/_search-autocomplete.scss
+++ b/ui/assets/css/_search-autocomplete.scss
@@ -13,3 +13,10 @@
   cursor: pointer;
   text-indent: -9999px;
 }
+
+.Select-clear,
+.Select-placeholder,
+.Select-value-icon,
+.Select-value-label {
+  color: $color-gray;
+}

--- a/ui/assets/css/_search-autocomplete.scss
+++ b/ui/assets/css/_search-autocomplete.scss
@@ -6,12 +6,10 @@
 }
 
 .add-filter-button {
-  background: url('/static/img/add-icon.svg') no-repeat center;
   background-color: $color-primary;
   border-color: $color-primary;
   color: $color-white;
   cursor: pointer;
-  text-indent: -9999px;
 }
 
 .Select-clear,

--- a/ui/components/filters/fallback-view.jsx
+++ b/ui/components/filters/fallback-view.jsx
@@ -2,13 +2,15 @@ import React from 'react';
 
 import { redirectWhiteList } from '../../redirects';
 
-export default function FallbackView({ insertParam, lookup, pathname, query }) {
+export default function FallbackView(props) {
+  const { insertParam, lookup, pathname, query } = props;
   return (
     <form action={`/search-redirect/${lookup}/`} method="GET">
       <input type="hidden" name="insertParam" value={insertParam} />
       <input type="hidden" name="redirectPathname" value={pathname} />
       <div className="flex clearfix relative">
         <input
+          aria-labelledby={props['aria-labelledby']}
           type="text"
           name="q"
           className="filter-lookup-field rounded-left p1 border col col-9"
@@ -25,6 +27,7 @@ export default function FallbackView({ insertParam, lookup, pathname, query }) {
   );
 }
 FallbackView.propTypes = {
+  'aria-labelledby': React.PropTypes.string.isRequired,
   insertParam: React.PropTypes.string,
   lookup: React.PropTypes.string.isRequired,
   pathname: React.PropTypes.oneOf(redirectWhiteList).isRequired,

--- a/ui/components/filters/fallback-view.jsx
+++ b/ui/components/filters/fallback-view.jsx
@@ -17,11 +17,12 @@ export default function FallbackView(props) {
         />
         { Object.keys(query).map(key =>
           <input key={key} type="hidden" name={`redirectQuery__${key}`} value={query[key]} />)}
-        <input
+        <button
           type="submit"
-          value="Add"
           className="add-filter-button border rounded-right p1 col col-3"
-        />
+        >
+          <img alt="Add" src="/static/img/add-icon.svg" />
+        </button>
       </div>
     </form>
   );

--- a/ui/components/filters/list-view.jsx
+++ b/ui/components/filters/list-view.jsx
@@ -1,19 +1,15 @@
 import React from 'react';
 
-export default function FilterListView({ heading, selector }) {
+export default function FilterListView({ heading, headingLabel, selector }) {
   return (
     <div className="filter-ui my2">
-      <div className="filter-section-header bold">{heading}</div>
+      <div className="filter-section-header bold" id={headingLabel}>{heading}</div>
       {selector}
     </div>
   );
 }
 FilterListView.propTypes = {
-  heading: React.PropTypes.string,
-  selector: React.PropTypes.node,
+  heading: React.PropTypes.string.isRequired,
+  headingLabel: React.PropTypes.string.isRequired,
+  selector: React.PropTypes.node.isRequired,
 };
-FilterListView.defaultProps = {
-  heading: '',
-  selector: null,
-};
-

--- a/ui/components/filters/selector.js
+++ b/ui/components/filters/selector.js
@@ -9,17 +9,23 @@ import { apiNameField, makeOptionLoader } from '../../lookup-search';
 import { redirectQuery } from '../../redirects';
 
 
-export default function Selector({ insertParam, lookup, pathname }, { router }) {
+export default function Selector(props, { router }) {
+  const { insertParam, lookup, pathname } = props;
   const onChange = (entry) => {
     const query = redirectQuery(router.location.query, insertParam, entry.value);
     const paramStr = querystring.stringify(query);
     router.push(`${pathname}?${paramStr}`);
   };
 
-  const fallback = React.createElement(
-    FallbackView,
-    { insertParam, lookup, pathname, query: router.location.query });
+  const fallback = React.createElement(FallbackView, {
+    'aria-labelledby': props['aria-labelledby'],
+    insertParam,
+    lookup,
+    pathname,
+    query: router.location.query,
+  });
   const autocompleter = React.createElement(Async, {
+    'aria-labelledby': props['aria-labelledby'],
     loadOptions: makeOptionLoader(lookup),
     onChange,
     tabIndex: '0',
@@ -28,6 +34,7 @@ export default function Selector({ insertParam, lookup, pathname }, { router }) 
   return React.createElement(ConditionalRender, {}, fallback, autocompleter);
 }
 Selector.propTypes = {
+  'aria-labelledby': React.PropTypes.string.isRequired,
   lookup: React.PropTypes.oneOf(Object.keys(apiNameField)).isRequired,
   insertParam: React.PropTypes.string.isRequired,
   pathname: React.PropTypes.string.isRequired,

--- a/ui/components/homepage/topic-autocomplete.js
+++ b/ui/components/homepage/topic-autocomplete.js
@@ -11,7 +11,7 @@ export default class TopicAutocomplete extends React.Component {
   }
 
   render() {
-    return React.createElement(Async, {
+    const props = Object.assign({}, this.props, {
       joinValues: true,
       loadOptions: makeOptionLoader('topics'),
       multi: true,
@@ -20,5 +20,6 @@ export default class TopicAutocomplete extends React.Component {
       placeholder: 'Shared services, IT management, ...',
       value: this.state.value,
     });
+    return React.createElement(Async, props);
   }
 }

--- a/ui/components/homepage/view.jsx
+++ b/ui/components/homepage/view.jsx
@@ -12,10 +12,11 @@ export default function Homepage() {
         <div className="sm-col-12 md-col-6 mx-auto center">
           <h2 className="h1">Find policies and requirements that apply to your agency.</h2>
           <div className="filter px4">
-            <h3 className="h3">What topics are you interested in?</h3>
+            <h3 className="h3" id="topics_label">What topics are you interested in?</h3>
             <ConditionalRender>
               <div className="form-field">
                 <FallbackView
+                  aria-labelledby="topics_label"
                   insertParam="topics__id__in"
                   lookup="topics"
                   pathname="/requirements"
@@ -23,7 +24,7 @@ export default function Homepage() {
               </div>
               <form method="GET" action="/requirements">
                 <div className="form-field">
-                  <TopicAutocomplete />
+                  <TopicAutocomplete aria-labelledby="topics_label" />
                 </div>
                 <div className="form-field">
                   <input

--- a/ui/components/pagers.jsx
+++ b/ui/components/pagers.jsx
@@ -14,11 +14,11 @@ export default function Pagers({ count }, { router }) {
 
   if (pageInt > 1) {
     const modifiedQuery = Object.assign({}, query, { page: pageInt - 1 });
-    prevPage = <Link to={{ pathname, query: modifiedQuery }}>&lt;</Link>;
+    prevPage = <Link aria-label="Previous page" to={{ pathname, query: modifiedQuery }}>&lt;</Link>;
   }
   if (nextOffset < count) {
     const modifiedQuery = Object.assign({}, query, { page: pageInt + 1 });
-    nextPage = <Link to={{ pathname, query: modifiedQuery }}>&gt;</Link>;
+    nextPage = <Link aria-label="Next page" to={{ pathname, query: modifiedQuery }}>&gt;</Link>;
   }
   return (
     <div>

--- a/ui/components/policies/container.js
+++ b/ui/components/policies/container.js
@@ -36,8 +36,10 @@ export function PoliciesContainer({ location: { query }, pagedPolicies }) {
   const filterControls = [
     React.createElement(FilterListView, {
       heading: 'Topics',
+      headingLabel: 'topics_label',
       key: 'topic',
       selector: React.createElement(Selector, {
+        'aria-labelledby': 'topics_label',
         insertParam: fieldNames.topics,
         lookup: 'topics',
         pathname: '/policies',

--- a/ui/components/policies/policy-view.jsx
+++ b/ui/components/policies/policy-view.jsx
@@ -24,7 +24,7 @@ export default function Policy({ policy, topicsIds }) {
         <div className="clearfix">
           <span className="requirements-links col col-6">
             <div className="circle-bg border gray-border center p1">
-              <Link to={relevantReqs} className={countClass}>
+              <Link aria-label="Relevant requirements" to={relevantReqs} className={countClass}>
                 {relevantReqCount}
               </Link>
             </div> of&nbsp;

--- a/ui/components/requirements/container.js
+++ b/ui/components/requirements/container.js
@@ -36,8 +36,10 @@ export function RequirementsContainer({ location: { query }, pagedReqs }) {
   const filterControls = [
     React.createElement(FilterListView, {
       heading: 'Topics',
+      headingLabel: 'topics_label',
       key: 'topic',
       selector: React.createElement(Selector, {
+        'aria-labelledby': 'topics_label',
         insertParam: fieldNames.topics,
         lookup: 'topics',
         pathname: '/requirements',

--- a/ui/components/search/search.jsx
+++ b/ui/components/search/search.jsx
@@ -31,13 +31,9 @@ export default class Search extends React.Component {
             className="search-input p1 gray-border"
           />
           { this.hiddenFields() }
-          <input
-            aria-label="Submit search"
-            type="image"
-            src="/static/img/search-icon.svg"
-            value="Submit"
-            className="search-submit p1 gray-border"
-          />
+          <button type="submit" className="search-submit p1 gray-border">
+            <img alt="Submit search" src="/static/img/search-icon.svg" />
+          </button>
         </form>
       </div>
     );

--- a/ui/components/search/search.jsx
+++ b/ui/components/search/search.jsx
@@ -24,6 +24,7 @@ export default class Search extends React.Component {
       <div className="search-form pr2 no-print">
         <form method="GET" action={this.actionPath()} className="mb0 flex items-center">
           <input
+            aria-label="Search term"
             name={this.inputName()}
             type="text"
             placeholder="Search"
@@ -31,6 +32,7 @@ export default class Search extends React.Component {
           />
           { this.hiddenFields() }
           <input
+            aria-label="Submit search"
             type="image"
             src="/static/img/search-icon.svg"
             value="Submit"


### PR DESCRIPTION
Partial solution to #308:
* Tie labels to input elements via aria-label/labelledby
* Add contrast to autocomplete element, some unseen links
* Swap a css image and an image input w/ a button+img
* Add aria-labels for uninformative links.

This doesn't solve:
* [Severe] Elements with ARIA roles must ensure required owned elements are present (1)
    * I'm trying to get a sense from #g-accessibility whether or not this is actually significant --[an "accessible" autocomplete](https://haltersweb.github.io/Accessibility/autocomplete.html) has the same error.
* [Warning] The web page should have a title that describes topic or purpose (1)
    * This will be resolved w/ #407 (nice)
* [Warning] These elements are focusable but either invisible or obscured by another element (1)
    * I think this is a false positive as it _is_ visible