### PR TITLE
Remove the current search field from inputs.

### DIFF
--- a/ui/__tests__/components/search/search.test.js
+++ b/ui/__tests__/components/search/search.test.js
@@ -1,0 +1,33 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Search from '../../../components/search/search';
+
+
+describe('<Search />', () => {
+  it('creates hidden fields for query parameters', () => {
+    const context = { router: { location: {
+      pathname: '/policies',
+      query: {
+        requirements__req_text__search: 'text here',  // policy-page param
+        req_text__search: 'more text',  // requirement-page param
+        page: '14',
+        some: 'param',
+        someOther: 'parameter',
+      },
+    } } };
+    const rendered = shallow(React.createElement(Search), { context });
+    const hidden = rendered.find('[type="hidden"]');
+    expect(hidden).toHaveLength(3);
+
+    const values = {};
+    hidden.forEach((h) => {
+      values[h.prop('name')] = h.prop('value');
+    });
+    expect(values).toEqual({
+      req_text__search: 'more text',  // requirement-page param is kept
+      some: 'param',
+      someOther: 'parameter',
+    });
+  });
+});

--- a/ui/components/search/search.jsx
+++ b/ui/components/search/search.jsx
@@ -5,7 +5,7 @@ export default class Search extends React.Component {
     const query = this.context.router.location.query;
     const modifiedQuery = Object.assign({}, query);
     delete modifiedQuery.page;
-    delete modifiedQuery.req_text__search;
+    delete modifiedQuery[this.inputName()];
     return Object.keys(modifiedQuery).map(k =>
       <input type="hidden" key={k} name={k} value={modifiedQuery[k]} />);
   }


### PR DESCRIPTION
As we want to keep the user on the same page/with the same filters when they
search, we create hidden input values to match their current query. We weren't
deleting the _existing_ search parameter when viewing policies (though we were
if viewing requirements).

Should resolve #384 