### PR TITLE
Fix bug around error pages, allow empty search

### DIFF
--- a/ui/__tests__/components/lookup-search.test.jsx
+++ b/ui/__tests__/components/lookup-search.test.jsx
@@ -18,7 +18,7 @@ describe('cleanParams()', () => {
     expect(() => cleanParams(query)).not.toThrow();
   });
 
-  ['q', 'insertParam', 'redirectPathname'].forEach((param) => {
+  ['insertParam', 'redirectPathname'].forEach((param) => {
     it(`raises an error when ${param} is not present`, () => {
       const queryCopy = Object.assign({}, query);
       delete queryCopy[param];

--- a/ui/components/lookup-search.jsx
+++ b/ui/components/lookup-search.jsx
@@ -35,9 +35,7 @@ export function cleanParams(query) {
     }
   });
 
-  if (validator.isEmpty(clean.q)) {
-    throw new UserError('Needs a "q" parameter');
-  } else if (validator.isEmpty(clean.insertParam)) {
+  if (validator.isEmpty(clean.insertParam)) {
     throw new UserError('Needs an "insertParam" parameter');
   } else if (!validator.isIn(clean.redirect.pathname, redirectWhiteList)) {
     throw new UserError('Invalid "redirectPathname" parameter');

--- a/ui/server.js
+++ b/ui/server.js
@@ -28,9 +28,11 @@ app.use(doNotCache);
 app.use(morgan('combined'));
 app.use('/static', express.static(path.join('ui-dist', 'static')));
 app.use(passport.initialize());
-app.use(errorHandler);
 
 app.get('*', passport.authenticate(['ip', 'basic'], { session: false }), serverRender);
+
+// Error handler must be after all middleware and handlers
+app.use(errorHandler);
 
 /* Start */
 app.listen(env.port, () => {


### PR DESCRIPTION
To resolve #412, this

1. Fixes error handlers (to test, try raising an error in one of the components)
2. Allows non-JS topic search to be empty