### PR TITLE
Add a blacklist of "masked" impacted entities.

### DIFF
--- a/ui/__tests__/components/requirements/requirements.test.jsx
+++ b/ui/__tests__/components/requirements/requirements.test.jsx
@@ -42,4 +42,20 @@ describe('<Requirement />', () => {
     expect(six.prop('to').query.topics__id__in).toEqual(6);
     expect(eight.prop('to').pathname).toEqual('/requirements');
   });
+
+  it('filters out values in the "applies to" field', () => {
+    const hasEntity = Object.assign({}, baseReq, {
+      impacted_entity: 'A Value that has NA in it',
+    });
+    const hasNA = Object.assign({}, baseReq, {
+      impacted_entity: '   nA',
+    });
+
+    let result = mount(<Requirement requirement={hasEntity} />);
+    expect(result.find('.applies-to').first().text()).toEqual(
+      'Applies to: A Value that has NA in it');
+
+    result = mount(<Requirement requirement={hasNA} />);
+    expect(result.find('.applies-to')).toHaveLength(0);
+  });
 });

--- a/ui/components/requirements/requirement.jsx
+++ b/ui/components/requirements/requirement.jsx
@@ -75,6 +75,19 @@ PolicyLink.propTypes = {
   }).isRequired,
 };
 
+const badEntities = [
+  'NA', 'N/A', 'Not Applicable', 'None', 'None Specified', 'unknown', 'TBA',
+  'Cannot determine-Ask Mindy',
+].map(e => e.toLowerCase());
+/* Temporary "solution" to bad data: filter it out on the front end */
+export function filterAppliesTo(text) {
+  const normalized = (text || '').toLowerCase().trim();
+  if (badEntities.includes(normalized)) {
+    return null;
+  }
+  return text;
+}
+
 
 export default function Requirement({ requirement }) {
   // We could have multiple lines with the same text, so can't use a stable ID
@@ -107,8 +120,7 @@ export default function Requirement({ requirement }) {
           <Metadata
             className="applies-to mr2"
             name="Applies to"
-            value={requirement.impacted_entity}
-            nullValue="Applies to: unknown"
+            value={filterAppliesTo(requirement.impacted_entity)}
           />
           <Metadata
             className="issuing-body"


### PR DESCRIPTION
Per a request from OMB, we want to temporarily hide impacted entity meta data
when it is one of a handful of values. OMB wants to keep the information for
manual cleanup and analysis.

This also removes the default ("unknown") as it was part of the requested
blacklist.

@tadhg-ohiggins what do you think about this? It's pretty straight forward and achieves the requested ends. I'm not keen on the precedent, but not terribly opinionated.