### PR TITLE
Remove Docker update from CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: generic
 sudo: required
 services:
 - docker
-before_install:
-- sudo apt-get update
-- sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-engine
-- docker --version
 script:
 # JS tests
 - docker-compose run --rm npm test


### PR DESCRIPTION
The new build images on Travis include a current-enough version of Docker and
don't include `docker-engine` in their app repos.