### PR TITLE
Capitalization and unfiltered results language corrections

### DIFF
--- a/ui/__tests__/components/thing-counters.test.jsx
+++ b/ui/__tests__/components/thing-counters.test.jsx
@@ -51,6 +51,21 @@ describe('<ThingCounter />', () => {
     expect(result.find("div")).toHaveLength(1);
     expect(result.find(".alert .p1 .m1 .border")).toHaveLength(0);
   });
+  it('states two total results when there are two total results, even with an empty parameter present', () => {
+    const context = { router: mockRouter({ query: { topics_id__in: ''} }) };
+    const result = makeReqThing(2, context)
+    expect(result.text()).toMatch(/2 requirements\./);
+    expect(result.find("div")).toHaveLength(1);
+    expect(result.find(".alert .p1 .m1 .border")).toHaveLength(0);
+  });
+  it('states two total results when there are two total results, even with multiple empty parameters present', () => {
+    const context = { router: mockRouter({
+          query: { topics_id__in: '', red_id: ''} }) };
+    const result = makeReqThing(2, context)
+    expect(result.text()).toMatch(/2 requirements\./);
+    expect(result.find("div")).toHaveLength(1);
+    expect(result.find(".alert .p1 .m1 .border")).toHaveLength(0);
+  });
 
 });
 

--- a/ui/components/policies/policies-view.jsx
+++ b/ui/components/policies/policies-view.jsx
@@ -5,8 +5,8 @@ import Policy from './policy-view';
 import ThingCounter from '../thing-counters';
 
 export default function PoliciesView({ policies, count, topicsIds }) {
-  const singular = 'Policy';
-  const plural = 'Policies';
+  const singular = 'policy';
+  const plural = 'policies';
 
   return (
     <div>

--- a/ui/components/thing-counters.jsx
+++ b/ui/components/thing-counters.jsx
@@ -1,13 +1,24 @@
 import React from 'react';
 
+function isUnfiltered(query) {
+  const queryKeys = Object.keys(query);
+  if (queryKeys.length === 0) {
+      return true;
+  }
+  if (queryKeys.length === 1 && queryKeys[0] === 'page') {
+      return true;
+  }
+  delete query.page;
+  return Object.values(query).every(x => x === ''); // true if all empty.
+}
+
 export default function ThingCounter({ count, singular, plural }, { router }) {
   const query = router.location.query;
-  const queryKeys = Object.keys(query);
   const noun = count === 1 ? singular : plural;
   const verb = count === 1 ? 'matches' : 'match';
   const classes = count === 0 ? 'alert p1 m1 border' : '';
 
-  const unfiltered = queryKeys.length === 0 || (queryKeys.length === 1 && queryKeys[0] === 'page');
+  const unfiltered = isUnfiltered(query);
   const searchText = unfiltered ? '.' : ` ${verb} your search.`;
 
   const noMatches = `No ${noun} ${verb} your search, try removing some filters to see more results.`;

--- a/ui/components/thing-counters.jsx
+++ b/ui/components/thing-counters.jsx
@@ -1,13 +1,6 @@
 import React from 'react';
 
 function isUnfiltered(query) {
-  const queryKeys = Object.keys(query);
-  if (queryKeys.length === 0) {
-    return true;
-  }
-  if (queryKeys.length === 1 && queryKeys[0] === 'page') {
-    return true;
-  }
   const noPage = Object.assign({}, query);
   delete noPage.page;
   return Object.values(noPage).every(x => x === ''); // true if all empty.

--- a/ui/components/thing-counters.jsx
+++ b/ui/components/thing-counters.jsx
@@ -3,13 +3,14 @@ import React from 'react';
 function isUnfiltered(query) {
   const queryKeys = Object.keys(query);
   if (queryKeys.length === 0) {
-      return true;
+    return true;
   }
   if (queryKeys.length === 1 && queryKeys[0] === 'page') {
-      return true;
+    return true;
   }
-  delete query.page;
-  return Object.values(query).every(x => x === ''); // true if all empty.
+  const noPage = Object.assign({}, query);
+  delete noPage.page;
+  return Object.values(noPage).every(x => x === ''); // true if all empty.
 }
 
 export default function ThingCounter({ count, singular, plural }, { router }) {


### PR DESCRIPTION
Sometimes when we search /
We only think we're looking /
For the correct things.

Correct capitalization, add more rigor about detecting unfiltered queries.