### PR TITLE
Fix Node version error around Object.values

### DIFF
--- a/ui/components/thing-counters.jsx
+++ b/ui/components/thing-counters.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 function isUnfiltered(query) {
   const noPage = Object.assign({}, query);
   delete noPage.page;
-  return Object.values(noPage).every(x => x === ''); // true if all empty.
+  const values = Object.keys(noPage).map(key => noPage[key]);
+  return values.every(x => x === ''); // true if all empty.
 }
 
 export default function ThingCounter({ count, singular, plural }, { router }) {


### PR DESCRIPTION
Always push your code /
Right before the team demo /
(No `values` support).

Accommodate an older Node version than I thought we were using.