### PR TITLE
Add header/footer/disclaimer

### DIFF
--- a/ui/__tests__/components/disclaimer.test.js
+++ b/ui/__tests__/components/disclaimer.test.js
@@ -1,0 +1,29 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import Disclaimer from '../../components/disclaimer';
+
+
+describe('<Disclaimer />', () => {
+  function expectToBeClosed(el) {
+    expect(el.text()).toMatch(/See more/);
+    expect(el.find('.usa-disclaimer-text').length).toEqual(
+      el.find('noscript .usa-disclaimer-text').length);
+  }
+  function expectToBeOpen(el) {
+    expect(el.text()).toMatch(/See less/);
+    expect(el.find('.usa-disclaimer-text').length).not.toEqual(
+      el.find('noscript .usa-disclaimer-text').length);
+  }
+
+  it('starts closed but can be toggled', () => {
+    const el = mount(React.createElement(Disclaimer));
+    expectToBeClosed(el);
+
+    el.find('button').simulate('click');
+    expectToBeOpen(el);
+
+    el.find('button').simulate('click');
+    expectToBeClosed(el);
+  });
+});

--- a/ui/assets/css/_footer.scss
+++ b/ui/assets/css/_footer.scss
@@ -6,4 +6,9 @@
     font-size: 1.375rem;
     font-weight: normal;
   }
+
+  a {
+    color: $color-white;
+  }
+
 }

--- a/ui/assets/css/_header.scss
+++ b/ui/assets/css/_header.scss
@@ -6,6 +6,14 @@
   line-height: 0.9375rem;
 }
 
+button.usa-disclaimer {
+  border: 0;
+}
+
+.usa-disclaimer-text {
+  padding-bottom: 1em;
+}
+
 .navbar {
   background-color: $color-primary-darkest;
 }

--- a/ui/components/disclaimer.jsx
+++ b/ui/components/disclaimer.jsx
@@ -3,16 +3,19 @@ import React from 'react';
 
 const Disclaimer = () => (
   <div className="overflow-auto">
-    <div className="flex items-center usa-disclaimer">
-      <img
-        className="pr1"
-        alt="US flag"
-        width="20"
-        height="13"
-        src="/static/img/usa-flag.png"
-      />
+    <div className="flex items-center justify-between usa-disclaimer">
       <div>
+        <img
+          className="pr1"
+          alt="US flag"
+          width="20"
+          height="13"
+          src="/static/img/usa-flag.png"
+        />
         An official website of the United States government
+      </div>
+      <div>
+        This site is currently in beta. See more &#9660;
       </div>
     </div>
   </div>

--- a/ui/components/disclaimer.jsx
+++ b/ui/components/disclaimer.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-var styles = {
-	paddingBottom:'1em'
+const styles = {
+  paddingBottom: '1em',
 };
 
 const Disclaimer = () => (
@@ -18,19 +18,18 @@ const Disclaimer = () => (
         An official website of the United States government
       </div>
       <div>
-        <a href="javascript:void(0)">{/*This site is currently in beta.*/} See less {/*&#9660;*/}&#9650;</a>
+        <span className="todo">See less &#9650;</span>
       </div>
     </div>
     <div className="flex items-center justify-center usa-disclaimer" style={styles}>
       <div className="hidden">
-        <span className="t-bold">This site is currently in beta</span>&nbsp;{/*| More information can be given.*/}
+        <span className="t-bold">This site is currently in beta</span>
         <div className="toggle" aria-hidden="false">
-          <span className="t-block">Questions or comments? Email&nbsp;<a href="mailto:ofcio@omb.eop.gov">ofcio@omb.eop.gov</a>.</span>
+          <span className="t-block">
+            Questions or comments?
+            Email&nbsp;<a href="mailto:ofcio@omb.eop.gov">ofcio@omb.eop.gov</a>.
+          </span>
         </div>
-        {/*<div className="toggle-text" aria-expanded="true">
-          <button className="less" aria-hidden="false" tabIndex={0}>Show less <i className="icon-small--arrow-up-border" /></button>
-          <button className="more" aria-hidden="true" tabIndex={0}>Show more <i className="icon-small--arrow-down-border" /></button>
-        </div>*/}
       </div>
     </div>
   </div>

--- a/ui/components/disclaimer.jsx
+++ b/ui/components/disclaimer.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 
+var styles = {
+	paddingBottom:'1em'
+};
 
 const Disclaimer = () => (
   <div className="overflow-auto">
@@ -15,7 +18,19 @@ const Disclaimer = () => (
         An official website of the United States government
       </div>
       <div>
-        This site is currently in beta. See more &#9660;
+        <a href="javascript:void(0)">{/*This site is currently in beta.*/} See less {/*&#9660;*/}&#9650;</a>
+      </div>
+    </div>
+    <div className="flex items-center justify-center usa-disclaimer" style={styles}>
+      <div className="hidden">
+        <span className="t-bold">This site is currently in beta</span>&nbsp;{/*| More information can be given.*/}
+        <div className="toggle" aria-hidden="false">
+          <span className="t-block">Questions or comments? Email&nbsp;<a href="mailto:ofcio@omb.eop.gov">ofcio@omb.eop.gov</a>.</span>
+        </div>
+        {/*<div className="toggle-text" aria-expanded="true">
+          <button className="less" aria-hidden="false" tabIndex={0}>Show less <i className="icon-small--arrow-up-border" /></button>
+          <button className="more" aria-hidden="true" tabIndex={0}>Show more <i className="icon-small--arrow-down-border" /></button>
+        </div>*/}
       </div>
     </div>
   </div>

--- a/ui/components/disclaimer.jsx
+++ b/ui/components/disclaimer.jsx
@@ -1,38 +1,59 @@
 import React from 'react';
 
-const styles = {
-  paddingBottom: '1em',
-};
+import ConditionalRender from './conditional-render';
 
-const Disclaimer = () => (
-  <div className="overflow-auto">
-    <div className="flex items-center justify-between usa-disclaimer">
-      <div>
-        <img
-          className="pr1"
-          alt="US flag"
-          width="20"
-          height="13"
-          src="/static/img/usa-flag.png"
-        />
-        An official website of the United States government
-      </div>
-      <div>
-        <span className="todo">See less &#9650;</span>
-      </div>
-    </div>
-    <div className="flex items-center justify-center usa-disclaimer" style={styles}>
-      <div className="hidden">
-        <span className="t-bold">This site is currently in beta</span>
-        <div className="toggle" aria-hidden="false">
-          <span className="t-block">
-            Questions or comments?
-            Email&nbsp;<a href="mailto:ofcio@omb.eop.gov">ofcio@omb.eop.gov</a>.
-          </span>
-        </div>
+const explanation = (
+  <div className="flex items-center justify-center usa-disclaimer usa-disclaimer-text">
+    <div className="hidden">
+      <span className="t-bold">This site is currently in beta</span>
+      <div className="toggle" aria-hidden="false">
+        <span className="t-block">
+          Questions or comments?
+          Email&nbsp;<a href="mailto:ofcio@omb.eop.gov">ofcio@omb.eop.gov</a>.
+        </span>
       </div>
     </div>
   </div>
 );
 
-export default Disclaimer;
+export default class Disclaimer extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+    this.state = { open: false };
+  }
+
+  activateLink() {
+    const onClick = () => this.setState({ open: !this.state.open });
+    const text = this.state.open ? 'See less \u25B2' : 'See more \u25BC';
+    return (
+      <ConditionalRender>
+        <noscript />
+        <div>
+          <button onClick={onClick} className="usa-disclaimer">{ text }</button>
+        </div>
+      </ConditionalRender>
+    );
+  }
+
+  render() {
+    return (
+      <div className="overflow-auto">
+        <div className="flex items-center justify-between usa-disclaimer">
+          <div>
+            <img
+              className="pr1"
+              alt="US flag"
+              width="20"
+              height="13"
+              src="/static/img/usa-flag.png"
+            />
+            An official website of the United States government
+          </div>
+          { this.activateLink() }
+        </div>
+        <noscript>{ explanation }</noscript>
+        { this.state.open ? explanation : null }
+      </div>
+    );
+  }
+}

--- a/ui/components/footer.jsx
+++ b/ui/components/footer.jsx
@@ -4,6 +4,11 @@ export default function Footer() {
   return (
     <footer className="global-footer px4 py3">
       <h4>OMB Policy Library</h4>
+        <ul class="list-reset">
+          <li><a href="https://github.com/18F/omb-eregs/">Github</a></li>
+          <li><a href="https://github.com/18F/omb-eregs/issues/">Report issue</a></li>
+          <li><a>Contact us</a></li>
+        </ul>
     </footer>
   );
 }

--- a/ui/components/footer.jsx
+++ b/ui/components/footer.jsx
@@ -4,11 +4,11 @@ export default function Footer() {
   return (
     <footer className="global-footer px4 py3">
       <h4>OMB Policy Library</h4>
-        <ul class="list-reset">
-          <li><a href="https://github.com/18F/omb-eregs/">Github</a></li>
-          <li><a href="https://github.com/18F/omb-eregs/issues/">Report issue</a></li>
-          <li><a href="mailto:ofcio@omb.eop.gov">Contact us</a></li>
-        </ul>
+      <ul className="list-reset">
+        <li><a href="https://github.com/18F/omb-eregs/">Github</a></li>
+        <li><a href="https://github.com/18F/omb-eregs/issues/">Report issue</a></li>
+        <li><a href="mailto:ofcio@omb.eop.gov">Contact us</a></li>
+      </ul>
     </footer>
   );
 }

--- a/ui/components/footer.jsx
+++ b/ui/components/footer.jsx
@@ -7,7 +7,7 @@ export default function Footer() {
         <ul class="list-reset">
           <li><a href="https://github.com/18F/omb-eregs/">Github</a></li>
           <li><a href="https://github.com/18F/omb-eregs/issues/">Report issue</a></li>
-          <li><a>Contact us</a></li>
+          <li><a href="mailto:ofcio@omb.eop.gov">Contact us</a></li>
         </ul>
     </footer>
   );

--- a/ui/components/homepage/view.jsx
+++ b/ui/components/homepage/view.jsx
@@ -55,6 +55,36 @@ export default function Homepage() {
                 and the public. For official OMB guidance, please follow the
                 links to the original memos and policy documents.
             </p>
+            <h3 className="h2">Disclaimer</h3>
+            <p>
+              The information appearing on this website is for general
+              informational purposes only, intended to supplement official
+              resources, including the Office of Management and Budget’s (OMB)
+              website (<a href="https://www.whitehouse.gov/omb">www.whitehouse.gov/omb</a>).
+              This website does not provide legal advice to any individual or
+              entity; establish, modify, or interpret any OMB policies; serve
+              as a decision-making tool or a compliance check-list; or
+              provide a comprehensive set of requirements applicable to
+              agencies. This website should not be cited as the source of any
+              policies or requirements. Consult with your agency’s legal
+              counsel before taking any action based in whole or part on
+              information appearing on this site or any site to which it may
+              be linked. We also urge you to conduct a thorough review of all
+              relevant requirements applicable to you.
+            </p>
+            <p>
+              While OMB strives to make the information on this website as
+              timely and accurate as possible, OMB makes no claims, promises,
+              or guarantees about the accuracy, completeness, or adequacy of
+              the contents of this site, and expressly disclaims liability for
+              errors and omissions in the contents of this site. No warranty
+              of any kind, implied, expressed, or statutory, including but not
+              limited to the warranties of non- infringement of third party
+              rights, title, merchantability, fitness for a particular purpose
+              or freedom from computer virus, is given with respect to the
+              contents of this website or its links to other Internet
+              resources.
+            </p>
           </div>
         </div>
       </section>

--- a/ui/components/navbar.jsx
+++ b/ui/components/navbar.jsx
@@ -4,8 +4,8 @@ import Search from './search/search';
 
 function Navbar() {
   return (
-    <div className="items-center navbar flex">
-      <div className="homepage-link items-center flex clearfix">
+    <div className="overflow-auto">
+      <div className="flex items-center navbar">
         <img
           className="pl2 pr1"
           alt="US flag"
@@ -15,11 +15,9 @@ function Navbar() {
         />
         <a href="/" className="text-decoration-none">
           <h1 className="navbar-title">
-              OMB IT Policy Library <sup>BETA</sup>
+              OMB Policy Library <sup>BETA</sup>
           </h1>
         </a>
-      </div>
-      <div className="items-center header-search flex">
         <Search />
       </div>
     </div>


### PR DESCRIPTION
This builds off @micahtaylor's work to add a beta dropdown in the header, a footer, and updated disclaimer text on the home page. I believe these are the necessary changes for launch (sans removing password).