### PR TITLE
Start CircleCI conversion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,55 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+        - image: circleci/python:3.6.2
+      
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - setup_remote_docker
+
+      - run:
+          name: Setup "holder" container for file storage
+          command: |
+            docker create -v /usr/src/app -w /usr/src/app/ --name holder python:3.6.2 sleep 100d
+            docker cp . holder:/usr/src/app
+            docker start holder
+      - run:
+          name: Generate circle-specific docker configs
+          command: |
+            docker exec holder pip install pyyaml
+            docker exec holder python ./devops/transform_circle.py docker-compose.yml holder > docker-compose-circle.yml
+
+      - run:
+          name: UI Tests
+          environment:
+            COMPOSE_FILE: docker-compose-circle.yml
+          command: docker-compose run --rm npm test
+      - run:
+          name: Build UI
+          environment:
+            COMPOSE_FILE: docker-compose-circle.yml
+          command: |
+            docker-compose run --rm webpack
+            docker cp holder:/usr/src/app/ui-dist ./ui-dist
+      - run:
+          name: API Unit tests
+          environment:
+            COMPOSE_FILE: docker-compose-circle.yml
+          command: docker-compose run --rm py.test
+      - run:
+          name: API Flake8
+          environment:
+            COMPOSE_FILE: docker-compose-circle.yml
+          command: docker-compose run --rm flake8
+      - run:
+          name: API Bandit
+          environment:
+            COMPOSE_FILE: docker-compose-circle.yml
+          command: docker-compose run --rm bandit -r ereqs_admin reqs omb_eregs -s B101   # skip asserts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,12 @@ jobs:
             COMPOSE_FILE: docker-compose-circle.yml
           command: docker-compose run --rm bandit -r ereqs_admin reqs omb_eregs -s B101   # skip asserts
 
+      - run:
+          name: Submit UI Coverage
+          environment:
+            COMPOSE_FILE: docker-compose-circle.yml
+          command: docker-compose run --rm --no-deps -e CODECLIMATE_REPO_TOKEN npm run submit-coverage
+
       - deploy:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,3 +53,15 @@ jobs:
           environment:
             COMPOSE_FILE: docker-compose-circle.yml
           command: docker-compose run --rm bandit -r ereqs_admin reqs omb_eregs -s B101   # skip asserts
+
+      - deploy:
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              export CF_USERNAME=$CF_USERNAME_DEV
+              export CF_PASSWORD=$CF_PASSWORD_DEV
+              ./devops/circle-deploy.sh dev
+            elif [ "${CIRCLE_BRANCH}" == "release" ]; then
+              export CF_USERNAME=$CF_USERNAME_PROD
+              export CF_PASSWORD=$CF_PASSWORD_PROD
+              ./devops/circle-deploy.sh prod
+            fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,7 @@ before_deploy:
 - cf install-plugin -f ~/autopilot-linux
 deploy:
   - provider: script
-    script: devops/deploy.sh dev
-    skip_cleanup: true
-    on:
-      branch: master
-  - provider: script
     script: devops/deploy.sh prod
     skip_cleanup: true
     on:
       branch: release
-after_success:
-- docker-compose run --rm dev npm install codeclimate-test-reporter
-- docker-compose run --rm -e CODECLIMATE_REPO_TOKEN=$CODECLIMATE_REPO_TOKEN dev ./node_modules/.bin/codeclimate-test-reporter < ui/lcov.info

--- a/devops/circle-deploy.sh
+++ b/devops/circle-deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Grab the necessary libs and then deploy from CircleCI
+
+export PATH=$HOME:$PATH
+curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&source=github" | tar -zx
+wget "https://github.com/contraband/autopilot/releases/download/0.0.3/autopilot-linux"
+chmod a+x autopilot-linux
+mv cf $HOME
+mv autopilot-linux $HOME
+cf install-plugin -f ~/autopilot-linux
+./devops/deploy.sh $1

--- a/devops/deploy.sh
+++ b/devops/deploy.sh
@@ -12,17 +12,10 @@ if [ ! -f $MANIFEST ]; then
   exit
 fi
 
-if [ $SPACE == 'dev' ] && [ -n "$CF_USERNAME_DEV" ] && [ -n "$CF_PASSWORD_DEV" ]; then
-  cf login -a $API -u $CF_USERNAME_DEV -p $CF_PASSWORD_DEV
-elif [ $SPACE == 'prod' ] && [ -n "$CF_USERNAME_PROD" ] && [ -n "$CF_PASSWORD_PROD" ]; then
-  cf login -a $API -u $CF_USERNAME_PROD -p $CF_PASSWORD_PROD
-elif [ -n "$CF_USERNAME" ] && [ -n "$CF_PASSWORD" ]; then
+if [ -n "$CF_USERNAME" ] && [ -n "$CF_PASSWORD" ]; then
   cf login -a $API -u $CF_USERNAME -p $CF_PASSWORD
 fi
 cf target -o $ORG -s $SPACE
 
-# Note that this may deploy the app twice until
-# https://github.com/contraband/autopilot/pull/24
-# is included in the plugin
 cf zero-downtime-push api -f $MANIFEST
 cf zero-downtime-push ui -f $MANIFEST

--- a/devops/integration-compose.yml
+++ b/devops/integration-compose.yml
@@ -13,7 +13,7 @@ services:
       - prod-api
       - proxy
   selenium-py.test:
-    image: python:3.5.3
+    image: python:3.6.2
     volumes:
       - $PWD:/usr/src/app
     working_dir: /usr/src/app

--- a/devops/transform_circle.py
+++ b/devops/transform_circle.py
@@ -1,0 +1,23 @@
+import argparse
+
+import yaml
+
+
+def convert(compose_config, container_name):
+    for service in compose_config.get('services', {}).values():
+        if 'volumes' in service:
+            service['volumes_from'] = [f'container:{container_name}']
+            del service['volumes']
+
+
+parser = argparse.ArgumentParser(
+    description="Transform docker-compose yaml to CircleCI-compatible files")
+parser.add_argument('compose_yaml', type=argparse.FileType('rb'))
+parser.add_argument('container_name')
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    compose_config = yaml.safe_load(args.compose_yaml)
+    convert(compose_config, args.container_name)
+    print(yaml.dump(compose_config))    # noqa - correct behavior

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     volumes:
       - database_data:/var/lib/postgresql/data
   python: &PYTHON     # This command is out of order to aid with config reuse
-    image: python:3.5.3
+    image: python:3.6.2
     volumes:
       - $PWD:/usr/src/app
     working_dir: /usr/src/app

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
+    "submit-coverage": "codeclimate-test-reporter < ui/lcov.info",
     "start": "node ui-dist/server.js"
   },
   "repository": {
@@ -24,6 +25,7 @@
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.23.0",
     "basscss-sass": "^4.0.0",
+    "codeclimate-test-reporter": "^0.5.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.28.4",
     "deps-ok": "^1.2.0",

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.3
+python-3.6.2


### PR DESCRIPTION
In this first step, we run all of our tests in CircleCI and begin deploying with it. Most of the code is copied from the Travis file or atf-eregs.

We need to get a nightly build running (#455) before we can turn off Travis entirely.