### PR TITLE
Use root-relative url for search when unsure.

### DIFF
--- a/ui/components/search/search.jsx
+++ b/ui/components/search/search.jsx
@@ -16,7 +16,7 @@ export default class Search extends React.Component {
 
   actionPath() {
     const path = this.context.router.location.pathname;
-    return (path.includes('policies') || path.includes('requirements')) ? path : 'requirements/';
+    return (path.includes('policies') || path.includes('requirements')) ? path : '/requirements/';
   }
 
   render() {


### PR DESCRIPTION
When a user is on a non-policies/requirements page (the home page,
search-redirect pages, the privacy page), the header search bar needs to
redirect the user to the "requirements" page. Unfortunately, we were using a
relative url, which meant deeply nested pages (search-redirects) would
redirect to, e.g.  `/search-redirect/topics/requirements/` rather than
`/requirements/`.

This resolves by using a root-relative url.