### PR TITLE
Allow Circle builds to be restarted.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,8 @@ jobs:
             ./cc-test-reporter format-coverage --prefix /usr/src/app --input-type coverage.py --output coverage/codeclimate.python.json
             ./cc-test-reporter format-coverage --prefix /usr/src/app --input-type lcov --output coverage/codeclimate.node.json
             ./cc-test-reporter sum-coverage --output coverage/codeclimate.json --parts 2 coverage/codeclimate.*.json
-            ./cc-test-reporter upload-coverage --input coverage/codeclimate.json
+            # allow submission to fail; this occurs on re-builds
+            ./cc-test-reporter upload-coverage --input coverage/codeclimate.json || true
 
       - deploy:
           name: Deploy


### PR DESCRIPTION
Code Climate's coverage reporter will fail if submitting coverage for the same
commit twice. We'll be doing that relatively frequently, however, in both our
nightly builds and if we ever want to restart a failed deploy.

This resolves by allowing the upload step to fail.

For verification, compare the "Submit Coverage" steps in
https://circleci.com/gh/18F/omb-eregs/70 and https://circleci.com/gh/18F/omb-eregs/71