### PR TITLE
Improve styles, text on lookup search page.

### DIFF
--- a/ui/__tests__/components/lookup-search.test.jsx
+++ b/ui/__tests__/components/lookup-search.test.jsx
@@ -83,4 +83,20 @@ describe('<LookupSearch />', () => {
       query: { some: 'field', page: '4' },
     });
   });
+
+  it('has a pager if there are results', () => {
+    const result = shallow(<LookupSearch {...params} />);
+    expect(result.find('Pagers')).toHaveLength(1);
+    expect(result.text()).not.toMatch(/No topics found/);
+  });
+
+  it('does not have a pager if there are no results', () => {
+    const modifiedParams = Object.assign({}, params, {
+      pagedEntries: { count: 0, results: [] },
+      routes: [{ path: 'search-redirect' }, { path: 'thingies' }],
+    });
+    const result = shallow(<LookupSearch {...modifiedParams} />);
+    expect(result.find('Pagers')).toHaveLength(0);
+    expect(result.text()).toMatch(/No thingies found/);
+  });
 });

--- a/ui/components/lookup-search.jsx
+++ b/ui/components/lookup-search.jsx
@@ -76,17 +76,23 @@ Entry.propTypes = {
 export function LookupSearch({ routes, location, pagedEntries }) {
   const lookup = routes[routes.length - 1].path;
   const params = cleanParams(location.query);
+  let pager;
+  if (pagedEntries.count) {
+    pager = <Pagers location={location} count={pagedEntries.count} />;
+  } else {
+    pager = <div>No {lookup} found.</div>;
+  }
 
   return (
-    <div>
+    <div className="max-width-4 mx-auto my3">
       <div>
-        <Link to={params.redirect}>Return</Link>
+        <Link to={params.redirect}>Return to view requirements</Link>
       </div>
       <ul>
         { pagedEntries.results.map(entry =>
           <Entry key={entry.id} lookup={lookup} location={location} entry={entry} />) }
       </ul>
-      <Pagers location={location} count={pagedEntries.count} />
+      { pager }
     </div>
   );
 }


### PR DESCRIPTION
If a user doesn't have JavaScript enabled (or acts before the autocompleteres
are finished loading), they will get to the LookupSearch page. This changeset
improves that page's interface by adding some more whitespace and indicating
when no search results are found.

Should resolve #434 

Looks like:
## Searching for "i"
<img width="1274" alt="screen shot 2017-09-12 at 5 12 34 pm" src="https://user-images.githubusercontent.com/326918/30348523-ba448298-97dd-11e7-85aa-35a130649c20.png">


## Searching for "skjndaskjndkajs"
<img width="1270" alt="screen shot 2017-09-12 at 5 11 41 pm" src="https://user-images.githubusercontent.com/326918/30348527-bd2a3142-97dd-11e7-94b4-a4c60dd40bbc.png">
