### PR TITLE
Move source-map-support back to a production lib.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -758,6 +758,16 @@
       "from": "setprototypeof@1.0.3",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
     },
+    "source-map": {
+      "version": "0.5.7",
+      "from": "source-map@>=0.5.6 <0.6.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "from": "source-map-support@>=0.4.17 <0.5.0",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz"
+    },
     "spawn-sync": {
       "version": "1.0.15",
       "from": "spawn-sync@>=1.0.15 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "nodemon": "^1.11.0",
     "react-test-renderer": "^15.6.1",
     "sass-loader": "^6.0.5",
-    "source-map-support": "^0.4.17",
     "style-loader": "^0.18.2",
     "webpack": "^3.5.6",
     "webpack-node-externals": "^1.6.0"
@@ -71,6 +70,7 @@
     "react-router": "^3.0.5",
     "react-select": "^1.0.0-rc.5",
     "serialize-javascript": "^1.4.0",
+    "source-map-support": "^0.4.17",
     "uswds": "^0.14.0",
     "validator": "^8.1.0"
   },


### PR DESCRIPTION
We had moved source-map-support out of the production libs because it was only
referenced in webpack. Unfortunately, that reference actually inserts a
_string_ into the resulting file, which imports source-map-support, meaning it
_is_ needed for production.

This will fix broken deploys (locally, we have the dev dependencies
installed).