### PR TITLE
Prevent multiple migrations in prod.

### DIFF
--- a/api/ereqs_admin/management/commands/cf_migrate.py
+++ b/api/ereqs_admin/management/commands/cf_migrate.py
@@ -1,0 +1,12 @@
+from cfenv import AppEnv
+from django.core import management
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = 'Only migrate the database once'     # noqa
+
+    def handle(self, *args, **options):
+        env = AppEnv()
+        if env.index is None or env.index == 0:
+            management.call_command('migrate', '--noinput')

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./manage.py migrate --noinput
+./manage.py cf_migrate
 if [ -n "$DEBUG" ]; then
   ./manage.py runserver 0.0.0.0:"$PORT"
 else


### PR DESCRIPTION
We run multiple `api` servers in production, but we only want one of them to
be responsible for migrating our database (lest one instance's migration will
prevent the other from starting). This changeset adds a management command
which migrates the database only on the first instance when on cloud.gov, and
every time when not (e.g. local development).

Should resolve #422 