### PR TITLE
404 page and homepage stars

### DIFF
--- a/ui/__tests__/server-render.test.js
+++ b/ui/__tests__/server-render.test.js
@@ -1,0 +1,14 @@
+import { render404 } from '../server-render';
+
+describe('render404', () => {
+  it('includes the search bar', () => {
+    const request = { params: {}, path: '/some/nonexisting/place' };
+    const send = jest.fn();
+    const response = { status: jest.fn(() => ({ send })) };
+
+    render404(request, response);
+    expect(send).toBeCalled();
+    expect(send.mock.calls[0][0]).toMatch('form');
+    expect(send.mock.calls[0][0]).toMatch('req_text__search');
+  });
+});

--- a/ui/assets/css/_base.scss
+++ b/ui/assets/css/_base.scss
@@ -7,6 +7,7 @@ $color-gray-lightest: #fafafa;
 a,
 a:link {
   color: $color-primary;
+  text-decoration: none;
 }
 
 .gray-border {

--- a/ui/assets/css/_button-like.scss
+++ b/ui/assets/css/_button-like.scss
@@ -1,0 +1,8 @@
+.button-like {
+  @extend .rounded;
+  @extend .px3;
+  @extend .py1;
+
+  color: $color-white;
+  background-color: $color-primary;
+}

--- a/ui/assets/css/_homepage.scss
+++ b/ui/assets/css/_homepage.scss
@@ -22,17 +22,6 @@
     line-height: 1.25em;
   }
 
-  .about-inner {
-    border-left: 3px solid $color-gold;
-
-    p {
-      @include font-merriweather();
-      letter-spacing: .5px;
-      line-height: 1.375rem;
-      width: 50vmax;
-    }
-  }
-
   .new-policies {
     background-color: $color-gray-lightest;
     border-top: 1px solid $color-gray-light;

--- a/ui/assets/css/_policies.scss
+++ b/ui/assets/css/_policies.scss
@@ -1,8 +1,4 @@
 .policy-list {
-  a:link {
-    text-decoration: none;
-  }
-
   h2 {
     font-weight: normal;
     font-size: 1.375rem;

--- a/ui/assets/css/_print.css
+++ b/ui/assets/css/_print.css
@@ -27,7 +27,6 @@
   }
 
   .topics-list a, a:link {
-   text-decoration: none;
    color: #111;
   }
 }

--- a/ui/assets/css/_req-filter-ui.scss
+++ b/ui/assets/css/_req-filter-ui.scss
@@ -12,7 +12,6 @@
     background: url('/static/img/remove-btn.svg') no-repeat center;
     color: $color-gray-dark;
     padding: 0 0.25rem;
-    text-decoration: none;
     text-indent: -9999px;
     width: 0.9375rem;
   }

--- a/ui/assets/css/_stars-divider.scss
+++ b/ui/assets/css/_stars-divider.scss
@@ -1,0 +1,16 @@
+.stars-divider {
+  $img-height: 20px;
+  $img-width: 22px;
+
+  background-image: url('/static/img/star.svg'),
+                    url('/static/img/star.svg'),
+                    url('/static/img/star.svg');
+  background-repeat: no-repeat;
+  background-position: 0 top,
+                       $img-width * 2 top,
+                       $img-width * 4 top;
+  border: none;
+  height: $img-height;
+  width: $img-width * 5;  // 3 stars + 2 whitespace
+  margin: 40px auto;
+}

--- a/ui/assets/css/main.scss
+++ b/ui/assets/css/main.scss
@@ -16,6 +16,7 @@
 @import 'footer';
 @import 'print';
 @import 'ie';
+@import 'stars-divider';
 
 // Reusable styles
 @import 'utils/landing';

--- a/ui/assets/css/main.scss
+++ b/ui/assets/css/main.scss
@@ -17,6 +17,7 @@
 @import 'print';
 @import 'ie';
 @import 'stars-divider';
+@import 'button-like';
 
 // Reusable styles
 @import 'utils/landing';

--- a/ui/assets/css/main.scss
+++ b/ui/assets/css/main.scss
@@ -17,6 +17,9 @@
 @import 'print';
 @import 'ie';
 
+// Reusable styles
+@import 'utils/landing';
+
 // Components
 @import 'requirements';
 @import 'req-filter-ui';

--- a/ui/assets/css/utils/_landing.scss
+++ b/ui/assets/css/utils/_landing.scss
@@ -1,0 +1,31 @@
+// utils/_landing.scss
+// ==========================================================================
+// "Landing" pages are copy-heavy pages with a centered main column and
+// several re-usable styles.
+
+.landing-section {
+  @extend .sm-col-12;
+  @extend .md-col-6;
+  @extend .mx-auto;
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    font-weight: normal;
+    line-height: 1.25em;
+  }
+
+  .content {
+    @include font-merriweather();
+    letter-spacing: .5px;
+    line-height: 1.375rem;
+    width: 50vmax;
+  }
+}
+
+.gold-border {
+  @extend .px2;
+
+  border-left: 3px solid $color-gold;
+}

--- a/ui/assets/img/star.svg
+++ b/ui/assets/img/star.svg
@@ -1,0 +1,1 @@
+<svg width="22" height="20" viewBox="0 0 22 20" xmlns="http://www.w3.org/2000/svg"><title>Star</title><path d="M11 16.5l-6.466 3.4 1.235-7.2L.54 7.6l7.228-1.05L11 0l3.233 6.55 7.229 1.05-5.231 5.1 1.235 7.2z" fill="#F9C642" fill-rule="evenodd"/></svg>

--- a/ui/components/errors/fourOhFour.jsx
+++ b/ui/components/errors/fourOhFour.jsx
@@ -9,8 +9,22 @@ import Html from '../html';
 export default () => (
   <Html allowDynamic={false}>
     <App>
-      <h1>Page not found</h1>
-      <p>Please check the URL and try again</p>
+      <section className="py3">
+        <div className="landing-section gold-border pb2">
+          <h1 className="h2">
+            We can&rsquo;t find the page you&rsquo;re looking for.
+          </h1>
+          <p className="content">
+            Visit our <a href="/">homepage</a>
+            {' '}or <a href="mailto:ofcio@omb.eop.gov">contact us</a>
+            {' '}if you need additional help.
+          </p>
+          <div className="my3">
+            <a className="button-like" href="/">Return home</a>
+          </div>
+        </div>
+        <hr className="stars-divider" />
+      </section>
     </App>
   </Html>
 );

--- a/ui/components/errors/fourOhFour.jsx
+++ b/ui/components/errors/fourOhFour.jsx
@@ -1,17 +1,16 @@
 import React from 'react';
 
-import DAP from '../dap';
+import App from '../app';
+import Html from '../html';
 
 
+// Prevent the page from loading the dynamic JS, which will display a
+// blank page due to not finding the route.
 export default () => (
-  <html lang="en-US">
-    <head>
-      <title>Page not found</title>
-      <DAP />
-    </head>
-    <body>
+  <Html allowDynamic={false}>
+    <App>
       <h1>Page not found</h1>
       <p>Please check the URL and try again</p>
-    </body>
-  </html>
+    </App>
+  </Html>
 );

--- a/ui/components/homepage/view.jsx
+++ b/ui/components/homepage/view.jsx
@@ -88,6 +88,8 @@ export default function Homepage() {
         </div>
       </section>
 
+      <hr className="stars-divider" />
+
       <section className="new-policies py3 mb4">
         <div className="landing-section">
           <h3>New policies</h3>

--- a/ui/components/homepage/view.jsx
+++ b/ui/components/homepage/view.jsx
@@ -41,21 +41,21 @@ export default function Homepage() {
 
       <section className="about py3">
         <div className="mx3">
-          <div className="about-inner px2 sm-col-12 md-col-6 mx-auto">
+          <div className="landing-section gold-border">
             <h3 className="h2">About this site</h3>
-            <p>
+            <p className="content">
               The beta OMB Policy Library includes excerpts from policies
               issued by the White House. This project is part of our ongoing
               efforts to make it easier to find and understand policy.
             </p>
-            <p>
+            <p className="content">
               This site does not include a comprehensive list of OMB policies.
               We are adding select policies on a rolling basis and working
               with users to make the site more useful.{' '}
               <a href="mailto:ofcio@omb.eop.gov">Tell us what you think!</a>
             </p>
             <h3 className="h2">Disclaimer</h3>
-            <p>
+            <p className="content">
               The information appearing on this website is for general
               informational purposes only, intended to supplement official
               resources, including the Office of Management and Budget’s (OMB)
@@ -71,7 +71,7 @@ export default function Homepage() {
               be linked. We also urge you to conduct a thorough review of all
               relevant requirements applicable to you.
             </p>
-            <p>
+            <p className="content">
               While OMB strives to make the information on this website as
               timely and accurate as possible, OMB makes no claims, promises,
               or guarantees about the accuracy, completeness, or adequacy of
@@ -89,7 +89,7 @@ export default function Homepage() {
       </section>
 
       <section className="new-policies py3 mb4">
-        <div className="sm-col-12 md-col-6 mx-auto">
+        <div className="landing-section">
           <h3>New policies</h3>
           <NewPoliciesContainerResolver />
         </div>

--- a/ui/components/html.jsx
+++ b/ui/components/html.jsx
@@ -35,7 +35,7 @@ function newRelicTag() {
   /* eslint-enable react/no-danger */
 }
 
-export default function Html({ contents, data }) {
+export default function Html({ children, data }) {
   return (
     <html lang="en-US">
       <head>
@@ -47,7 +47,7 @@ export default function Html({ contents, data }) {
       </head>
       <body>
         <div id="app">
-          { contents }
+          { children }
         </div>
         <script src="/static/ie.js" />
         { scriptTag(data) }
@@ -57,10 +57,10 @@ export default function Html({ contents, data }) {
   );
 }
 Html.defaultProps = {
-  contents: null,
+  children: null,
   data: {},
 };
 Html.propTypes = {
-  contents: PropTypes.node,
+  children: PropTypes.node,
   data: PropTypes.shape({}),
 };

--- a/ui/components/html.jsx
+++ b/ui/components/html.jsx
@@ -35,7 +35,7 @@ function newRelicTag() {
   /* eslint-enable react/no-danger */
 }
 
-export default function Html({ children, data }) {
+export default function Html({ allowDynamic, children, data }) {
   return (
     <html lang="en-US">
       <head>
@@ -51,16 +51,18 @@ export default function Html({ children, data }) {
         </div>
         <script src="/static/ie.js" />
         { scriptTag(data) }
-        <script src="/static/browser.js" />
+        { allowDynamic ? <script src="/static/browser.js" /> : null }
       </body>
     </html>
   );
 }
 Html.defaultProps = {
+  allowDynamic: true,
   children: null,
   data: {},
 };
 Html.propTypes = {
+  allowDynamic: PropTypes.bool,
   children: PropTypes.node,
   data: PropTypes.shape({}),
 };

--- a/ui/server-render.js
+++ b/ui/server-render.js
@@ -20,8 +20,8 @@ function resolveAndRender(renderProps, res) {
   Resolver
     .resolve(() => React.createElement(RouterContext, renderProps))
     .then(({ Resolved, data }) => {
-      const contents = React.createElement(Resolved);
-      const html = React.createElement(Html, { contents, data });
+      const html = React.createElement(
+        Html, { data }, [React.createElement(Resolved)]);
       res.status(200).send(renderToStaticMarkup(html));
     })
     .catch((err) => {


### PR DESCRIPTION
This updates the design of the 404 page. Unfortunately, our existing strategy around accessing the current url (which relies on react-router) doesn't work well for 404 pages. To accommodate, this effectively mocks that extra context out. That isn't a great long term strategy, but I suspect a longer term strategy will be worked out when refactoring for Next.js

It also adds a star-based divider to the homepage (per the latest designs) and extracts some of those styles for use on the 404 page.

## 404
<img width="1272" alt="screen shot 2017-09-20 at 12 13 00 pm" src="https://user-images.githubusercontent.com/326918/30655592-73c7bd8a-9dff-11e7-9924-40387b462763.png">


## Homepage
<img width="1270" alt="screen shot 2017-09-20 at 12 27 29 pm" src="https://user-images.githubusercontent.com/326918/30655588-70ab60ac-9dff-11e7-9d0c-2d87427abe0a.png">
