### PR TITLE
Use policy number when displaying policy filter.

### DIFF
--- a/ui/components/filters/existing-container.js
+++ b/ui/components/filters/existing-container.js
@@ -74,16 +74,16 @@ export default function ExistingFiltersContainer({
     }));
 
   const policyIds = policies.map(policy => policy.id);
-  const policyFilters = policies.map(policy => React.createElement(
-    RemoveLinkWithRouter, {
-      existing: policyIds,
-      field: fieldNames.policies,
-      heading: 'Policy',
-      idToRemove: policy.id,
-      key: policy.id,
-      name: policy.title,
-      route,
-    }));
+  const policyFilters = policies.map(policy => (
+    <RemoveLinkWithRouter
+      existing={policyIds}
+      field={fieldNames.policies}
+      heading="Policy"
+      idToRemove={policy.id}
+      key={policy.id}
+      name={policy.title_with_number}
+      route={route}
+    />));
 
   const searchFilters = [
     React.createElement(RemoveSearchWithRouter, {


### PR DESCRIPTION
Resolves #493 by adding the policy number to policy-based filters.

Here's how things look with and without a policy number:

## Policy with number
<img width="743" alt="screen shot 2017-09-29 at 11 00 56 am" src="https://user-images.githubusercontent.com/326918/31022090-c40429ca-a505-11e7-8776-e674e7647d7c.png">
<img width="754" alt="screen shot 2017-09-29 at 11 00 39 am" src="https://user-images.githubusercontent.com/326918/31022088-c3d88bd0-a505-11e7-86e1-2976abc3c877.png">


## Policy without number
<img width="769" alt="screen shot 2017-09-29 at 11 01 24 am" src="https://user-images.githubusercontent.com/326918/31022095-c7d65dd4-a505-11e7-80d6-feeb8ae0dc48.png">
<img width="748" alt="screen shot 2017-09-29 at 11 01 12 am" src="https://user-images.githubusercontent.com/326918/31022096-c7d695f6-a505-11e7-98bc-421d3c5a5237.png">
