### PR TITLE
Loosen consistency guarantees in Docker.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
   python: &PYTHON     # This command is out of order to aid with config reuse
     image: python:3.6.2
     volumes:
-      - $PWD:/usr/src/app
+      - $PWD:/usr/src/app:delegated
     working_dir: /usr/src/app/api
     stdin_open: true
     tty: true
@@ -78,7 +78,7 @@ services:
   prod: &PROD_UI
     image: node:6
     volumes:
-      - $PWD:/usr/src/app
+      - $PWD:/usr/src/app:delegated
     working_dir: /usr/src/app/ui
     command: .docker/deps_ok_then npm start
     environment:


### PR DESCRIPTION
Docker for Mac can be very slow when performing file access on a shared
directory due to consistency guarantees. This tweaks our mounted directories
so that there can be a slight delay between synchronization as the benefit of
much faster reads.

This appears to be a solution to #258 in my experience, dropping local admin
load time dropping to roughly what we see in production.

We had tried this solution before, but support wasn't fully baked.