### PR TITLE
Add test:watch command for front end in package.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
         - image: circleci/python:3.6.2
-      
+
     working_directory: ~/repo
 
     steps:
@@ -74,8 +74,7 @@ jobs:
               > ../cc-coverage.python.json
 
             cd ../ui
-            mkdir coverage
-            docker cp holder:/usr/src/app/ui/lcov.info lcov.info
+            docker cp holder:/usr/src/app/ui/coverage/lcov.info lcov.info
             ../cc-test-reporter format-coverage \
               --prefix /usr/src/app/ui --input-type lcov --output - lcov.info \
               | python ../devops/cc_add_prefix.py --prefix ui/ \

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
+coverage/
 .tox/
 .coverage
 .coverage.*

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,12 +1,14 @@
 {
   "name": "omb-eregs",
   "version": "1.0.0",
-  "description": "This repository contains code necessary to run the White House Office of Management and Budget (OMB) instance of [eRegulations](https://eregs.github.io) (a regulation parser, API, and viewer).",
+  "description":
+    "This repository contains code necessary to run the White House Office of Management and Budget (OMB) instance of [eRegulations](https://eregs.github.io) (a regulation parser, API, and viewer).",
   "main": "index.js",
   "scripts": {
     "build": "next build",
     "start": "node server/index.js",
-    "test": "NODE_ENV=test jest"
+    "test": "NODE_ENV=test jest --coverage",
+    "test:watch": "NODE_ENV=test jest --watch"
   },
   "repository": {
     "type": "git",
@@ -72,10 +74,7 @@
     "node": "6.x"
   },
   "jest": {
-    "collectCoverage": true,
-    "coverageDirectory": "./",
-    "coverageReporters": [
-      "lcov"
-    ]
+    "coverageReporters": ["lcov"],
+    "verbose": true
   }
 }


### PR DESCRIPTION
To make it easier to do testing, I added a `test:watch` command to `package.json` so that the tests will run whenever a file changes. This can be run inside of the docker container with:
`docker-compose run --rm npm run test:watch`

I had to change some of the jest configuration to get it to run in the docker container (for some reason the tests would _not_ be re-run if the coverage option was supplied) but I think I replicated all of the functionality by moving it into CLI arguments.