### PR TITLE
One component per file

### DIFF
--- a/ui/__tests__/components/error.test.js
+++ b/ui/__tests__/components/error.test.js
@@ -1,8 +1,7 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import ErrorView, { FourOhFour, UnexpectedError, UserError } from '../../components/error';
-
+import ErrorView from '../../components/error';
 
 describe('<ErrorView />', () => {
   it('renders a 404', () => {
@@ -20,45 +19,5 @@ describe('<ErrorView />', () => {
     const result = shallow(<ErrorView statusCode={1234} />);
     expect(result.name()).toBe('UnexpectedError');
     expect(result.prop('statusCode')).toBe(1234);
-  });
-});
-
-describe('<FourOhFour />', () => {
-  it('has expected milestones', () => {
-    const wrapped = shallow(<FourOhFour />);
-    expect(wrapped.name()).toBe('HeaderFooter');
-    const text = wrapped.childAt(0).text();
-    expect(text).toMatch(/We can’t find the page/); // note the smart quote
-    expect(text).toMatch(/contact us/);
-    expect(text).toMatch(/Return home/);
-  });
-});
-
-describe('<UserError />', () => {
-  it('has expected milestones', () => {
-    const wrapped = shallow(<UserError message="This is my message" />);
-    expect(wrapped.name()).toBe('HeaderFooter');
-    const text = wrapped.childAt(0).text();
-    expect(text).toMatch(/Invalid Request/);
-    expect(text).toMatch(/This is my message/);
-    expect(text).toMatch(/Return home/);
-  });
-});
-
-describe('<UnexpectedError />', () => {
-  it('has the correct status code', () => {
-    const text = shallow(<UnexpectedError statusCode={502} />).text();
-    expect(text).toMatch(/Bad Gateway/);
-    expect(text).not.toMatch(/Unexpected error/);
-    expect(text).toMatch(/homepage/);
-    expect(text).toMatch(/contact us/);
-  });
-
-  it('works without a status code', () => {
-    const text = shallow(<UnexpectedError />).text();
-    expect(text).not.toMatch(/Bad Gateway/);
-    expect(text).toMatch(/Unexpected error/);
-    expect(text).toMatch(/homepage/);
-    expect(text).toMatch(/contact us/);
   });
 });

--- a/ui/__tests__/components/errors/four-oh-four-error.test.js
+++ b/ui/__tests__/components/errors/four-oh-four-error.test.js
@@ -1,0 +1,15 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import FourOhFour from '../../../components/errors/four-oh-four-error';
+
+describe('<FourOhFour />', () => {
+  it('has expected milestones', () => {
+    const wrapped = shallow(<FourOhFour />);
+    expect(wrapped.name()).toBe('HeaderFooter');
+    const text = wrapped.childAt(0).text();
+    expect(text).toMatch(/We can’t find the page/); // note the smart quote
+    expect(text).toMatch(/contact us/);
+    expect(text).toMatch(/Return home/);
+  });
+});

--- a/ui/__tests__/components/errors/unexpected-error.test.js
+++ b/ui/__tests__/components/errors/unexpected-error.test.js
@@ -1,0 +1,22 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import UnexpectedError from '../../../components/errors/unexpected-error';
+
+describe('<UnexpectedError />', () => {
+  it('has the correct status code', () => {
+    const text = shallow(<UnexpectedError statusCode={502} />).text();
+    expect(text).toMatch(/Bad Gateway/);
+    expect(text).not.toMatch(/Unexpected error/);
+    expect(text).toMatch(/homepage/);
+    expect(text).toMatch(/contact us/);
+  });
+
+  it('works without a status code', () => {
+    const text = shallow(<UnexpectedError />).text();
+    expect(text).not.toMatch(/Bad Gateway/);
+    expect(text).toMatch(/Unexpected error/);
+    expect(text).toMatch(/homepage/);
+    expect(text).toMatch(/contact us/);
+  });
+});

--- a/ui/__tests__/components/errors/user-error.test.js
+++ b/ui/__tests__/components/errors/user-error.test.js
@@ -1,0 +1,15 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import UserError from '../../../components/errors/user-error';
+
+describe('<UserError />', () => {
+  it('has expected milestones', () => {
+    const wrapped = shallow(<UserError message="This is my message" />);
+    expect(wrapped.name()).toBe('HeaderFooter');
+    const text = wrapped.childAt(0).text();
+    expect(text).toMatch(/Invalid Request/);
+    expect(text).toMatch(/This is my message/);
+    expect(text).toMatch(/Return home/);
+  });
+});

--- a/ui/__tests__/components/filters/existing-container.test.js
+++ b/ui/__tests__/components/filters/existing-container.test.js
@@ -1,15 +1,13 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import ExistingFiltersContainer, { RemoveLinkContainer, RemoveSearchContainer } from '../../../components/filters/existing-container';
-
+import ExistingFiltersContainer from '../../../components/filters/existing-container';
 
 describe('<ExistingFiltersContainer />', () => {
   it('contains the correct remove links', () => {
     const params = {
       topics: [{ id: 4, name: 'A' }, { id: 8, name: 'B' }],
-      policies: [
-        { id: 1, title: 'C' }, { id: 3, title: 'D' }, { id: 5, title: 'E' }],
+      policies: [{ id: 1, title: 'C' }, { id: 3, title: 'D' }, { id: 5, title: 'E' }],
       agencies: [{ id: 9, name: 'F' }],
       fieldNames: { agencies: 'aaa', policies: 'ppp', search: 'sss', topics: 'ttt' },
       route: '',
@@ -21,41 +19,15 @@ describe('<ExistingFiltersContainer />', () => {
 
     expect(links).toHaveLength(6);
     expect(links.map(l => l.prop('heading'))).toEqual([
-      'Topic', 'Topic', 'Policy', 'Policy', 'Policy', 'Agency']);
+      'Topic',
+      'Topic',
+      'Policy',
+      'Policy',
+      'Policy',
+      'Agency',
+    ]);
     expect(links.map(l => l.prop('idToRemove'))).toEqual([4, 8, 1, 3, 5, 9]);
 
     expect(result.find('withRoute(RemoveSearchContainer)')).toHaveLength(1);
-  });
-});
-
-describe('<RemoveLinkContainer />', () => {
-  it('calculates the correct link', () => {
-    const params = {
-      existing: [1, 7, 10],
-      field: 'someField',
-      heading: 'FieldName',
-      idToRemove: 7,
-      name: 'A Value',
-      route: 'policies',
-      router: { query: { page: '3', some: 'stuff', someField: '1,7,10' } },
-    };
-    const result = shallow(<RemoveLinkContainer {...params} />);
-
-    expect(result.prop('route')).toEqual('policies');
-    expect(result.prop('params')).toEqual({ some: 'stuff', someField: '1,10' });
-  });
-});
-
-describe('<RemoveSearchContainer />', () => {
-  it('calculates the correct link', () => {
-    const params = {
-      field: 'someField',
-      route: 'homepage',
-      router: { query: { page: '3', some: 'stuff', someField: 'My Search Term' } },
-    };
-    const result = shallow(<RemoveSearchContainer {...params} />);
-
-    expect(result.prop('route')).toEqual('homepage');
-    expect(result.prop('params')).toEqual({ some: 'stuff' });
   });
 });

--- a/ui/__tests__/components/filters/remove-link-container.test.js
+++ b/ui/__tests__/components/filters/remove-link-container.test.js
@@ -1,0 +1,22 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { RemoveLinkContainer } from '../../../components/filters/remove-link-container';
+
+describe('<RemoveLinkContainer />', () => {
+  it('calculates the correct link', () => {
+    const params = {
+      existing: [1, 7, 10],
+      field: 'someField',
+      heading: 'FieldName',
+      idToRemove: 7,
+      name: 'A Value',
+      route: 'policies',
+      router: { query: { page: '3', some: 'stuff', someField: '1,7,10' } },
+    };
+    const result = shallow(<RemoveLinkContainer {...params} />);
+
+    expect(result.prop('route')).toEqual('policies');
+    expect(result.prop('params')).toEqual({ some: 'stuff', someField: '1,10' });
+  });
+});

--- a/ui/__tests__/components/filters/remove-search-container.test.js
+++ b/ui/__tests__/components/filters/remove-search-container.test.js
@@ -1,0 +1,18 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { RemoveSearchContainer } from '../../../components/filters/remove-search-container';
+
+describe('<RemoveSearchContainer />', () => {
+  it('calculates the correct link', () => {
+    const params = {
+      field: 'someField',
+      route: 'homepage',
+      router: { query: { page: '3', some: 'stuff', someField: 'My Search Term' } },
+    };
+    const result = shallow(<RemoveSearchContainer {...params} />);
+
+    expect(result.prop('route')).toEqual('homepage');
+    expect(result.prop('params')).toEqual({ some: 'stuff' });
+  });
+});

--- a/ui/__tests__/components/requirements/metadata.test.js
+++ b/ui/__tests__/components/requirements/metadata.test.js
@@ -1,15 +1,12 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { Metadata } from '../../../components/requirements/requirement';
+import Metadata from '../../../components/requirements/metadata';
 
 describe('<Metadata />', () => {
   const basic = shallow(
-    <Metadata
-      className="something-hyphenated"
-      name="IAmAKey"
-      value="IAmAValue"
-    />);
+    <Metadata className="something-hyphenated" name="IAmAKey" value="IAmAValue" />,
+  );
   it('renders', () => {
     expect(basic.type()).toBe('div');
   });
@@ -26,17 +23,13 @@ describe('<Metadata />', () => {
       name="IAmAKey"
       value="IAmAValue"
       separator=" I separate things "
-    />);
+    />,
+  );
   it('has the right text content with separator', () => {
     expect(separated.text()).toMatch('IAmAKey I separate things IAmAValue');
   });
 
-  const noValue = shallow(
-    <Metadata
-      className="something-hyphenated"
-      name="IAmAKey"
-      value=""
-    />);
+  const noValue = shallow(<Metadata className="something-hyphenated" name="IAmAKey" value="" />);
   it('returns null when value and nullValue are null', () => {
     expect(noValue.type()).toBe(null);
   });
@@ -47,7 +40,8 @@ describe('<Metadata />', () => {
       name="IAmAKey"
       value=""
       nullValue="Show this instead"
-    />);
+    />,
+  );
   it('renders if nullValue is present', () => {
     expect(noValueAlt.type()).toBe('div');
   });

--- a/ui/__tests__/components/requirements/policy-link.test.js
+++ b/ui/__tests__/components/requirements/policy-link.test.js
@@ -1,0 +1,13 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import PolicyLink from '../../../components/requirements/policy-link';
+
+describe('<PolicyLink />', () => {
+  it('renders using title_with_number from the policy prop', () => {
+    const policy = { id: 10, title_with_number: 'fake-text' };
+    const rendered = shallow(<PolicyLink policy={policy} />);
+    const link = rendered.find('a');
+    expect(link.text()).toEqual('fake-text');
+  });
+});

--- a/ui/components/error.js
+++ b/ui/components/error.js
@@ -1,64 +1,9 @@
-import HTTPStatus from 'http-status';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import HeaderFooter from './header-footer';
-
-export function FourOhFour() {
-  return (
-    <HeaderFooter>
-      <section className="py3">
-        <div className="landing-section gold-border pb2">
-          <h1 className="h2">
-            We can&rsquo;t find the page you&rsquo;re looking for.
-          </h1>
-          <p className="content">
-            Visit our <a href="/">homepage</a>
-            {' '}or <a href="mailto:ofcio@omb.eop.gov">contact us</a>
-            {' '}if you need additional help.
-          </p>
-          <div className="my3">
-            <a className="button-like" href="/">Return home</a>
-          </div>
-        </div>
-        <hr className="stars-divider" />
-      </section>
-    </HeaderFooter>
-  );
-}
-
-export function UserError({ message }) {
-  return (
-    <HeaderFooter>
-      <section className="py3">
-        <div className="landing-section gold-border pb2">
-          <h1 className="h2">Invalid Request</h1>
-          <p className="content">{ message }</p>
-          <div className="my3">
-            <a className="button-like" href="/">Return home</a>
-          </div>
-        </div>
-        <hr className="stars-divider" />
-      </section>
-    </HeaderFooter>
-  );
-}
-UserError.propTypes = { message: PropTypes.string.isRequired };
-
-export function UnexpectedError({ statusCode }) {
-  return (
-    <section>
-      <h1>{ HTTPStatus[statusCode] || 'Unexpected error' }</h1>
-      <p>
-        Visit our <a href="/">homepage</a>
-        {' '}or <a href="mailto:ofcio@omb.eop.gov">contact us</a>
-        {' '}if you need additional help.
-      </p>
-    </section>
-  );
-}
-UnexpectedError.propTypes = { statusCode: PropTypes.number };
-UnexpectedError.defaultProps = { statusCode: 0 };
+import FourOhFour from './errors/four-oh-four-error';
+import UnexpectedError from './errors/unexpected-error';
+import UserError from './errors/user-error';
 
 export default function ErrorView({ err, statusCode }) {
   if (statusCode === 404) {

--- a/ui/components/errors/four-oh-four-error.js
+++ b/ui/components/errors/four-oh-four-error.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import HeaderFooter from '../header-footer';
+
+export default function FourOhFour() {
+  return (
+    <HeaderFooter>
+      <section className="py3">
+        <div className="landing-section gold-border pb2">
+          <h1 className="h2">We can&rsquo;t find the page you&rsquo;re looking for.</h1>
+          <p className="content">
+            Visit our <a href="/">homepage</a> or <a href="mailto:ofcio@omb.eop.gov">contact us</a>{' '}
+            if you need additional help.
+          </p>
+          <div className="my3">
+            <a className="button-like" href="/">
+              Return home
+            </a>
+          </div>
+        </div>
+        <hr className="stars-divider" />
+      </section>
+    </HeaderFooter>
+  );
+}

--- a/ui/components/errors/unexpected-error.js
+++ b/ui/components/errors/unexpected-error.js
@@ -1,0 +1,18 @@
+import HTTPStatus from 'http-status';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default function UnexpectedError({ statusCode }) {
+  return (
+    <section>
+      <h1>{HTTPStatus[statusCode] || 'Unexpected error'}</h1>
+      <p>
+        Visit our <a href="/">homepage</a> or <a href="mailto:ofcio@omb.eop.gov">contact us</a> if
+        you need additional help.
+      </p>
+    </section>
+  );
+}
+
+UnexpectedError.propTypes = { statusCode: PropTypes.number };
+UnexpectedError.defaultProps = { statusCode: 0 };

--- a/ui/components/errors/user-error.js
+++ b/ui/components/errors/user-error.js
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import HeaderFooter from '../header-footer';
+
+export default function UserError({ message }) {
+  return (
+    <HeaderFooter>
+      <section className="py3">
+        <div className="landing-section gold-border pb2">
+          <h1 className="h2">Invalid Request</h1>
+          <p className="content">{message}</p>
+          <div className="my3">
+            <a className="button-like" href="/">
+              Return home
+            </a>
+          </div>
+        </div>
+        <hr className="stars-divider" />
+      </section>
+    </HeaderFooter>
+  );
+}
+
+UserError.propTypes = { message: PropTypes.string.isRequired };

--- a/ui/components/filters/existing-container.js
+++ b/ui/components/filters/existing-container.js
@@ -1,81 +1,34 @@
-import { withRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import FilterRemoveView from './remove-view';
-
-export function RemoveLinkContainer(
-  { existing, field, heading, idToRemove, name, route, router }) {
-  const remaining = existing.filter(id => id !== idToRemove);
-  const modifiedQuery = Object.assign({}, router.query, {
-    [field]: remaining.join(','),
-  });
-  delete modifiedQuery.page;
-
-  return React.createElement(FilterRemoveView, {
-    heading,
-    name,
-    params: modifiedQuery,
-    route,
-  });
-}
-RemoveLinkContainer.propTypes = {
-  existing: PropTypes.arrayOf(PropTypes.number).isRequired,
-  field: PropTypes.string.isRequired,
-  heading: PropTypes.string.isRequired,
-  idToRemove: PropTypes.number.isRequired,
-  name: PropTypes.string.isRequired,
-  route: PropTypes.string.isRequired,
-  router: PropTypes.shape({
-    query: PropTypes.shape({}).isRequired,
-  }).isRequired,
-};
-const RemoveLinkWithRouter = withRouter(RemoveLinkContainer);
-
-export function RemoveSearchContainer({ field, route, router }) {
-  const { query } = router;
-  const existing = query[field];
-  if (!existing) {
-    return null;
-  }
-
-  const modifiedQuery = Object.assign({}, query);
-  delete modifiedQuery[field];
-  delete modifiedQuery.page;
-
-  return React.createElement(FilterRemoveView, {
-    heading: 'Search',
-    name: existing,
-    params: modifiedQuery,
-    route,
-  });
-}
-RemoveSearchContainer.propTypes = {
-  field: PropTypes.string.isRequired,
-  route: PropTypes.string.isRequired,
-  router: PropTypes.shape({
-    query: PropTypes.shape({}).isRequired,
-  }).isRequired,
-};
-const RemoveSearchWithRouter = withRouter(RemoveSearchContainer);
+/* eslint-disable import/no-named-as-default */
+import RemoveLinkContainer from './remove-link-container';
+import RemoveSearchContainer from './remove-search-container';
+/* eslint-enable import/no-named-as-default */
 
 export default function ExistingFiltersContainer({
-  agencies, fieldNames, policies, route, topics }) {
+  agencies,
+  fieldNames,
+  policies,
+  route,
+  topics,
+}) {
   const topicIds = topics.map(topic => topic.id);
-  const topicFilters = topics.map(topic => React.createElement(
-    RemoveLinkWithRouter, {
-      existing: topicIds,
-      field: fieldNames.topics,
-      heading: 'Topic',
-      idToRemove: topic.id,
-      key: topic.id,
-      name: topic.name,
-      route,
-    }));
+  const topicFilters = topics.map(topic => (
+    <RemoveLinkContainer
+      existing={topicIds}
+      field={fieldNames.topics}
+      heading="Topic"
+      idToRemove={topic.id}
+      key={topic.id}
+      name={topic.name}
+      route={route}
+    />
+  ));
 
   const policyIds = policies.map(policy => policy.id);
   const policyFilters = policies.map(policy => (
-    <RemoveLinkWithRouter
+    <RemoveLinkContainer
       existing={policyIds}
       field={fieldNames.policies}
       heading="Policy"
@@ -83,48 +36,53 @@ export default function ExistingFiltersContainer({
       key={policy.id}
       name={policy.title_with_number}
       route={route}
-    />));
+    />
+  ));
 
   const searchFilters = [
-    React.createElement(RemoveSearchWithRouter, {
-      field: fieldNames.search,
-      key: 'search',
-      route,
-    }),
+    <RemoveSearchContainer field={fieldNames.search} key="search" route={route} />,
   ];
 
   const agencyIds = agencies.map(agency => agency.id);
-  const agencyFilters = agencies.map(agency => React.createElement(
-    RemoveLinkWithRouter, {
-      existing: agencyIds,
-      field: fieldNames.agencies,
-      heading: 'Agency',
-      idToRemove: agency.id,
-      key: agency.id,
-      name: agency.name,
-    }));
+  const agencyFilters = agencies.map(agency => (
+    <RemoveLinkContainer
+      existing={agencyIds}
+      field={fieldNames.agencies}
+      heading="Agency"
+      idToRemove={agency.id}
+      key={agency.id}
+      name={agency.name}
+    />
+  ));
 
   const filters = [].concat(topicFilters, policyFilters, agencyFilters, searchFilters);
 
-  return React.createElement('ol', { className: 'list-reset' }, filters);
+  return <ol className="list-reset">{filters}</ol>;
 }
+
 ExistingFiltersContainer.propTypes = {
-  agencies: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.number,
-    name: PropTypes.string,
-  })).isRequired,
+  agencies: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
+    }),
+  ).isRequired,
   fieldNames: PropTypes.shape({
     policies: PropTypes.string,
     search: PropTypes.string,
     topics: PropTypes.string,
   }).isRequired,
-  policies: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.number,
-    title: PropTypes.string,
-  })).isRequired,
+  policies: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      title: PropTypes.string,
+    }),
+  ).isRequired,
   route: PropTypes.string.isRequired,
-  topics: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.number,
-    name: PropTypes.string,
-  })).isRequired,
+  topics: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
+    }),
+  ).isRequired,
 };

--- a/ui/components/filters/remove-link-container.js
+++ b/ui/components/filters/remove-link-container.js
@@ -1,0 +1,29 @@
+import { withRouter } from 'next/router';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import FilterRemoveView from './remove-view';
+
+export function RemoveLinkContainer({ existing, field, heading, idToRemove, name, route, router }) {
+  const remaining = existing.filter(id => id !== idToRemove);
+  const modifiedQuery = Object.assign({}, router.query, {
+    [field]: remaining.join(','),
+  });
+  delete modifiedQuery.page;
+
+  return <FilterRemoveView heading={heading} name={name} params={modifiedQuery} route={route} />;
+}
+
+RemoveLinkContainer.propTypes = {
+  existing: PropTypes.arrayOf(PropTypes.number).isRequired,
+  field: PropTypes.string.isRequired,
+  heading: PropTypes.string.isRequired,
+  idToRemove: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  route: PropTypes.string.isRequired,
+  router: PropTypes.shape({
+    query: PropTypes.shape({}).isRequired,
+  }).isRequired,
+};
+
+export default withRouter(RemoveLinkContainer);

--- a/ui/components/filters/remove-search-container.js
+++ b/ui/components/filters/remove-search-container.js
@@ -1,0 +1,28 @@
+import { withRouter } from 'next/router';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import FilterRemoveView from './remove-view';
+
+export function RemoveSearchContainer({ field, route, router }) {
+  const { query } = router;
+  const existing = query[field];
+  if (!existing) {
+    return null;
+  }
+
+  const modifiedQuery = Object.assign({}, query);
+  delete modifiedQuery[field];
+  delete modifiedQuery.page;
+  return <FilterRemoveView heading="Search" name={existing} params={modifiedQuery} route={route} />;
+}
+
+RemoveSearchContainer.propTypes = {
+  field: PropTypes.string.isRequired,
+  route: PropTypes.string.isRequired,
+  router: PropTypes.shape({
+    query: PropTypes.shape({}).isRequired,
+  }).isRequired,
+};
+
+export default withRouter(RemoveSearchContainer);

--- a/ui/components/filters/remove-view.js
+++ b/ui/components/filters/remove-view.js
@@ -15,12 +15,14 @@ export default function FilterRemoveView({ heading, name, params, route }) {
     </li>
   );
 }
+
 FilterRemoveView.propTypes = {
   heading: PropTypes.string,
   name: PropTypes.string.isRequired,
   params: PropTypes.shape({}).isRequired,
   route: PropTypes.string.isRequired,
 };
+
 FilterRemoveView.defaultProps = {
   heading: '',
 };

--- a/ui/components/requirements/metadata.js
+++ b/ui/components/requirements/metadata.js
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default function Metadata({ className, name, value, nullValue, separator }) {
+  /**
+   * Returns a div element that has className equal to the argument plus 'metadata', and content
+   * that is either <name><separator><value> or, if value is null and nullValue is not, the content
+   * is the nullValue argument.
+   *
+   * If value and nullValue are both null, returns null.
+   */
+  if (!value && !nullValue) {
+    return null;
+  }
+  const classes = className.split(' ');
+  const classString = classes.includes('metadata') ? className : `${classes.join(' ')} metadata`;
+  const content = value ? `${name}${separator}${value}` : nullValue;
+  return <div className={classString}>{`${content}`}</div>;
+}
+
+Metadata.propTypes = {
+  className: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.string,
+  nullValue: PropTypes.string,
+  separator: PropTypes.string,
+};
+
+Metadata.defaultProps = {
+  value: '',
+  nullValue: '',
+  separator: ': ',
+};

--- a/ui/components/requirements/policy-link.js
+++ b/ui/components/requirements/policy-link.js
@@ -1,0 +1,22 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { Link } from '../../routes';
+
+export default function PolicyLink({ policy }) {
+  return (
+    <div className="policy-title metadata">
+      Policy title:{' '}
+      <Link route="policies" params={{ id__in: policy.id }}>
+        <a>{policy.title_with_number}</a>
+      </Link>
+    </div>
+  );
+}
+
+PolicyLink.propTypes = {
+  policy: PropTypes.shape({
+    id: PropTypes.number,
+    title_with_number: PropTypes.string,
+  }).isRequired,
+};

--- a/ui/components/requirements/requirement.js
+++ b/ui/components/requirements/requirement.js
@@ -1,80 +1,18 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Link } from '../../routes';
-
-export function Metadata({ className, name, value, nullValue, separator }) {
-  /**
-   * Returns a div element that has className equal to the argument plus 'metadata', and content
-   * that is either <name><separator><value> or, if value is null and nullValue is not, the content
-   * is the nullValue argument.
-   *
-   * If value and nullValue are both null, returns null.
-   */
-  if (!value && !nullValue) {
-    return null;
-  }
-  const classes = className.split(' ');
-  const classString = classes.includes('metadata') ? className : `${classes.join(' ')} metadata`;
-  const content = value ? `${name}${separator}${value}` : nullValue;
-  return (
-    <div className={classString}>
-      {`${content}`}
-    </div>);
-}
-
-Metadata.propTypes = {
-  className: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
-  value: PropTypes.string,
-  nullValue: PropTypes.string,
-  separator: PropTypes.string,
-};
-
-Metadata.defaultProps = {
-  value: '',
-  nullValue: '',
-  separator: ': ',
-};
-
-
-function TopicLink({ topic }) {
-  return (
-    <li className="inline">
-      <Link route="requirements" params={{ topics__id__in: topic.id }}>
-        <a>{ topic.name }</a>
-      </Link>
-    </li>
-  );
-}
-TopicLink.propTypes = {
-  topic: PropTypes.shape({
-    id: PropTypes.number,
-    name: PropTypes.string,
-  }).isRequired,
-};
-
-
-function PolicyLink({ policy }) {
-  return (
-    <div className="policy-title metadata">
-      Policy title:
-      {' '}
-      <Link route="policies" params={{ id__in: policy.id }}>
-        <a>{policy.title_with_number}</a>
-      </Link>
-    </div>
-  );
-}
-PolicyLink.propTypes = {
-  policy: PropTypes.shape({
-    id: PropTypes.number,
-    title_with_number: PropTypes.string,
-  }).isRequired,
-};
+import Metadata from './metadata';
+import PolicyLink from './policy-link';
+import TopicLink from './topic-link';
 
 const badEntities = [
-  'NA', 'N/A', 'Not Applicable', 'None', 'None Specified', 'unknown', 'TBA',
+  'NA',
+  'N/A',
+  'Not Applicable',
+  'None',
+  'None Specified',
+  'unknown',
+  'TBA',
   'Cannot determine-Ask Mindy',
 ].map(e => e.toLowerCase());
 /* Temporary "solution" to bad data: filter it out on the front end */
@@ -86,18 +24,20 @@ export function filterAppliesTo(text) {
   return text;
 }
 
-
 export default function Requirement({ requirement }) {
   // We could have multiple lines with the same text, so can't use a stable ID
   /* eslint-disable react/no-array-index-key */
   const reqTexts = requirement.req_text.split('\n').map((line, idx) => (
-    <span key={idx} className="req-text-line mb1">{ line }<br /></span>
+    <span key={idx} className="req-text-line mb1">
+      {line}
+      <br />
+    </span>
   ));
   /* eslint-enable react/no-array-index-key */
   return (
     <div className="req p2 clearfix max-width-3">
       <div className="req-text col col-12">
-        { reqTexts }
+        {reqTexts}
         <div className="clearfix mt3">
           <PolicyLink policy={requirement.policy} />
           <Metadata
@@ -110,21 +50,13 @@ export default function Requirement({ requirement }) {
             name="Policy issuance"
             value={requirement.policy.issuance}
           />
-          <Metadata
-            className="requirement-id"
-            name="Requirement ID"
-            value={requirement.req_id}
-          />
+          <Metadata className="requirement-id" name="Requirement ID" value={requirement.req_id} />
           <Metadata
             className="applies-to mr2"
             name="Applies to"
             value={filterAppliesTo(requirement.impacted_entity)}
           />
-          <Metadata
-            className="issuing-body"
-            name="Issuing body"
-            value={requirement.issuing_body}
-          />
+          <Metadata className="issuing-body" name="Issuing body" value={requirement.issuing_body} />
           <Metadata
             className="sunset-date"
             name="Sunset date"
@@ -135,8 +67,7 @@ export default function Requirement({ requirement }) {
           <div className="topics metadata">
             <span>Topics: </span>
             <ul className="topics-list list-reset inline">
-              { requirement.topics.map(topic =>
-                <TopicLink key={topic.id} topic={topic} />) }
+              {requirement.topics.map(topic => <TopicLink key={topic.id} topic={topic} />)}
             </ul>
           </div>
         </div>
@@ -147,10 +78,12 @@ export default function Requirement({ requirement }) {
 
 Requirement.propTypes = {
   requirement: PropTypes.shape({
-    topics: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.number,
-      name: PropTypes.string,
-    })),
+    topics: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        name: PropTypes.string,
+      }),
+    ),
     policy: PropTypes.shape({
       sunset: PropTypes.string,
     }),

--- a/ui/components/requirements/topic-link.js
+++ b/ui/components/requirements/topic-link.js
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { Link } from '../../routes';
+
+export default function TopicLink({ topic }) {
+  return (
+    <li className="inline">
+      <Link route="requirements" params={{ topics__id__in: topic.id }}>
+        <a>{topic.name}</a>
+      </Link>
+    </li>
+  );
+}
+
+TopicLink.propTypes = {
+  topic: PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+  }).isRequired,
+};


### PR DESCRIPTION
Restructured some of the component files to only have on component in each file. This enables a few things:

1. It is easier to take inventory of all of our component and component names to ensure they are consistent
2. It is easier to know where to find a given component
3. It helps determine what can be DRYed up and refactored

Along the way, I also converted use of `React.createElement()` to JSX where I can ran into it.

Part of #504 