### PR TITLE
Fix route typo.

### DIFF
--- a/ui/components/policies/policies-view.js
+++ b/ui/components/policies/policies-view.js
@@ -17,7 +17,7 @@ export default function PoliciesView({ policies, count, topicsIds }) {
           <Policy key={policy.id} policy={policy} topicsIds={topicsIds} />,
         )}
       </ul>
-      <PagersContainer count={count} route="polices" />
+      <PagersContainer count={count} route="policies" />
     </div>
   );
 }


### PR DESCRIPTION
This is a short-term fix for a typo'd route name. For a longer-term solution,
we should use our prop-type checking to validate the route.