### PR TITLE
Add the metadata on the policy page

### DIFF
--- a/ui/__tests__/components/homepage/new-policy-view.test.js
+++ b/ui/__tests__/components/homepage/new-policy-view.test.js
@@ -3,7 +3,6 @@ import React from 'react';
 
 import NewPolicyView from '../../../components/homepage/new-policy-view';
 
-
 describe('<NewPolicyView />', () => {
   const policy = {
     id: 42,

--- a/ui/__tests__/components/policy/req.test.js
+++ b/ui/__tests__/components/policy/req.test.js
@@ -1,4 +1,4 @@
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 
 import Req from '../../../components/policy/req';
@@ -12,24 +12,24 @@ describe('<Req />', () => {
   };
 
   it('includes meta data when highlighted', () => {
-    const normalText = mount(
+    const normalText = shallow(
       <Req href="" onClick={jest.fn()} req={req} />,
-    ).text();
-    const hlText = mount(
+    ).html();
+    const hlText = shallow(
       <Req highlighted href="" onClick={jest.fn()} req={req} />,
-    ).text();
+    ).html();
 
     expect(normalText).toMatch(/Some text here/);
-    expect(normalText).not.toMatch(/123.45/);
+    expect(normalText).not.toMatch(/>123.45</);
     expect(hlText).toMatch(/Some text here/);
-    expect(hlText).toMatch(/123.45/);
+    expect(hlText).toMatch(/Requirement ID: 123.45/);
   });
 
   it('includes topiclinks with data when highlighted', () => {
     req.topics = [{ id: 1, name: 'link 1' }, { id: 2, name: 'link 2' }];
-    const normalText = mount(
+    const normalText = shallow(
       <Req highlighted href="" onClick={jest.fn()} req={req} />,
-    ).find('.topics').text();
+    ).find('.topics').html();
 
     expect(normalText).toMatch(/link 1/);
     expect(normalText).toMatch(/link 2/);

--- a/ui/__tests__/components/policy/req.test.js
+++ b/ui/__tests__/components/policy/req.test.js
@@ -25,6 +25,16 @@ describe('<Req />', () => {
     expect(hlText).toMatch(/123.45/);
   });
 
+  it('includes topiclinks with data when highlighted', () => {
+    req.topics = [{id: 1, name: 'link 1'}, {id: 2, name: 'link 2'}];
+    const normalText = mount(
+      <Req highlighted href="" onClick={jest.fn()} req={req} />,
+    ).find('.topics').text();
+
+    expect(normalText).toMatch(/link 1/);
+    expect(normalText).toMatch(/link 2/);
+  });
+
   it('includes an anchor with the correct data', () => {
     const onClick = jest.fn();
     req.req_id = '1.1';

--- a/ui/__tests__/components/policy/req.test.js
+++ b/ui/__tests__/components/policy/req.test.js
@@ -2,7 +2,6 @@ import { shallow, mount } from 'enzyme';
 import React from 'react';
 
 import Req from '../../../components/policy/req';
-import Metadata from '../../../components/requirements/metadata';
 
 describe('<Req />', () => {
   const req = {
@@ -27,11 +26,8 @@ describe('<Req />', () => {
 
   it('includes an anchor with the correct data', () => {
     const onClick = jest.fn();
-    const req = {
-      req_id: '1.1',
-      req_text: 'Text goes here',
-      topics: [],
-    };
+    req.req_id = '1.1';
+    req.req_text = 'Text goes here';
     const anchors = shallow(
       <Req href="/some/location" onClick={onClick} req={req} />,
     ).find('a');

--- a/ui/__tests__/components/policy/req.test.js
+++ b/ui/__tests__/components/policy/req.test.js
@@ -26,9 +26,9 @@ describe('<Req />', () => {
   });
 
   it('includes topiclinks with data when highlighted', () => {
-    req.topics = [{ id: 1, name: 'link 1' }, { id: 2, name: 'link 2' }];
+    const topiclinksReq = { ...req, topics: [{ id: 1, name: 'link 1' }, { id: 2, name: 'link 2' }] };
     const normalText = shallow(
-      <Req highlighted href="" onClick={jest.fn()} req={req} />,
+      <Req highlighted href="" onClick={jest.fn()} req={topiclinksReq} />,
     ).find('.topics').html();
 
     expect(normalText).toMatch(/link 1/);
@@ -37,10 +37,9 @@ describe('<Req />', () => {
 
   it('includes an anchor with the correct data', () => {
     const onClick = jest.fn();
-    req.req_id = '1.1';
-    req.req_text = 'Text goes here';
+    const anchorReq = { ...req, req_id: '1.1', req_text: 'Text goes here' };
     const anchors = shallow(
-      <Req href="/some/location" onClick={onClick} req={req} />,
+      <Req href="/some/location" onClick={onClick} req={anchorReq} />,
     ).find('a');
     expect(anchors).toHaveLength(1);
 

--- a/ui/__tests__/components/policy/req.test.js
+++ b/ui/__tests__/components/policy/req.test.js
@@ -10,6 +10,7 @@ describe('<Req />', () => {
     topics: [],
     policy: [],
   };
+
   it('includes meta data when highlighted', () => {
     const normalText = mount(
       <Req href="" onClick={jest.fn()} req={req} />,

--- a/ui/__tests__/components/policy/req.test.js
+++ b/ui/__tests__/components/policy/req.test.js
@@ -1,19 +1,21 @@
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import React from 'react';
 
 import Req from '../../../components/policy/req';
+import Metadata from '../../../components/requirements/metadata';
 
 describe('<Req />', () => {
+  const req = {
+    req_id: '123.45',
+    req_text: 'Some text here',
+    topics: [],
+    policy: [],
+  };
   it('includes meta data when highlighted', () => {
-    const req = {
-      req_id: '123.45',
-      req_text: 'Some text here',
-      topics: [],
-    };
-    const normalText = shallow(
+    const normalText = mount(
       <Req href="" onClick={jest.fn()} req={req} />,
     ).text();
-    const hlText = shallow(
+    const hlText = mount(
       <Req highlighted href="" onClick={jest.fn()} req={req} />,
     ).text();
 

--- a/ui/__tests__/components/policy/req.test.js
+++ b/ui/__tests__/components/policy/req.test.js
@@ -26,7 +26,7 @@ describe('<Req />', () => {
   });
 
   it('includes topiclinks with data when highlighted', () => {
-    req.topics = [{id: 1, name: 'link 1'}, {id: 2, name: 'link 2'}];
+    req.topics = [{ id: 1, name: 'link 1' }, { id: 2, name: 'link 2' }];
     const normalText = mount(
       <Req highlighted href="" onClick={jest.fn()} req={req} />,
     ).find('.topics').text();

--- a/ui/__tests__/components/requirements/topic-link.test.js
+++ b/ui/__tests__/components/requirements/topic-link.test.js
@@ -12,7 +12,7 @@ describe('<TopicLink />', () => {
     expect(basic.type()).toBe('li');
   });
   it('has the right route', () => {
-    expect(basic.find('LinkRoutes').props().route).toMatch('requirements');
+    expect(basic.find('LinkRoutes').prop('route')).toMatch('requirements');
   });
   it('has the right text content', () => {
     expect(basic.find('a').text()).toMatch('hello link 1');
@@ -23,7 +23,7 @@ describe('<TopicLink />', () => {
     <TopicLink topic={topic} />,
   );
   it('has the correct route', () => {
-    expect(definedRoute.find('LinkRoutes').props().route).toMatch('policies');
+    expect(definedRoute.find('LinkRoutes').prop('route')).toMatch('policies');
   });
   it('has the new content values', () => {
     expect(definedRoute.find('a').text()).toMatch('hello link 2');

--- a/ui/__tests__/components/requirements/topic-link.test.js
+++ b/ui/__tests__/components/requirements/topic-link.test.js
@@ -1,0 +1,31 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import TopicLink from '../../../components/requirements/topic-link';
+
+describe('<TopicLink />', () => {
+  let topic = { id: 1, name: 'hello link 1' };
+  const basic = shallow(
+    <TopicLink topic={topic} />,
+  );
+  it('renders', () => {
+    expect(basic.type()).toBe('li');
+  });
+  it('has the right route', () => {
+    expect(basic.find('LinkRoutes').props().route).toMatch('requirements');
+  });
+  it('has the right text content', () => {
+    expect(basic.find('a').text()).toMatch('hello link 1');
+  });
+
+  topic = { id: 2, name: 'hello link 2', route: 'policies' };
+  const definedRoute = shallow(
+    <TopicLink topic={topic} />,
+  );
+  it('has the correct route', () => {
+    expect(definedRoute.find('LinkRoutes').props().route).toMatch('policies');
+  });
+  it('has the new content values', () => {
+    expect(definedRoute.find('a').text()).toMatch('hello link 2');
+  });
+});

--- a/ui/components/homepage/new-policy-view.js
+++ b/ui/components/homepage/new-policy-view.js
@@ -1,13 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from '../../routes';
+import { policyLinkTag } from '../requirements/policy-link';
 
 export default function NewPolicyView({ policy }) {
+  const policyLink = policyLinkTag(policy);
   return (
     <li className="inline-block col col-6 pr2 mb2">
-      <Link route="policies" params={{ id__in: policy.id }}>
-        <a>{ policy.title_with_number }</a>
-      </Link>
+      { policyLink }
       <div className="h5">
         { policy.issuing_body }, { policy.issuance_pretty }
       </div>

--- a/ui/components/policy/req.js
+++ b/ui/components/policy/req.js
@@ -12,23 +12,11 @@ export default function Req({ highlighted, href, onClick, req }) {
       <div className="req col col-4">
         <Metadata className="requirement-id" name="Requirement ID" value={req.req_id} />
         <Metadata
-          className="issuance"
-          name="Policy issuance"
-          value={req.policy.issuance}
-        />
-        <Metadata
           className="applies-to mr2"
           name="Applies to"
           value={filterAppliesTo(req.impacted_entity)}
         />
         <Metadata className="issuing-body" name="Issuing body" value={req.issuing_body} />
-        <Metadata
-          className="sunset-date"
-          name="Sunset date"
-          value={req.policy.sunset}
-          nullValue="Sunset date: none"
-          separator=" by "
-        />
         <div className="topics metadata">
           <span>Topics: </span>
           <ul className="topics-list list-reset inline">

--- a/ui/components/policy/req.js
+++ b/ui/components/policy/req.js
@@ -1,15 +1,64 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import Metadata from '../requirements/metadata';
+import PolicyLink from '../requirements/policy-link';
+import TopicLink from '../requirements/topic-link';
+
+const badEntities = [
+  'NA',
+  'N/A',
+  'Not Applicable',
+  'None',
+  'None Specified',
+  'unknown',
+  'TBA',
+  'Cannot determine-Ask Mindy',
+].map(e => e.toLowerCase());
+
+export function filterAppliesTo(text) {
+  const normalized = (text || '').toLowerCase().trim();
+  if (badEntities.includes(normalized)) {
+    return null;
+  }
+  return text;
+}
+
 export default function Req({ highlighted, href, onClick, req }) {
   let meta = null;
   if (highlighted) {
     meta = (
-      <div className="col col-4">
-        Number: { req.req_id }
-        <ul>
-          { req.topics.map(t => <li key={t.id}>{t.name}</li>) }
-        </ul>
+      <div className="req col col-4">
+        <Metadata className="requirement-id" name="Requirement ID" value={req.req_id} />
+        <Metadata
+          className="omb-policy-id"
+          name="OMB Policy ID"
+          value={req.policy.omb_policy_id}
+        />
+        <Metadata
+          className="issuance"
+          name="Policy issuance"
+          value={req.policy.issuance}
+        />
+        <Metadata
+          className="applies-to mr2"
+          name="Applies to"
+          value={filterAppliesTo(req.impacted_entity)}
+        />
+        <Metadata className="issuing-body" name="Issuing body" value={req.issuing_body} />
+        <Metadata
+          className="sunset-date"
+          name="Sunset date"
+          value={req.policy.sunset}
+          nullValue="Sunset date: none"
+          separator=" by "
+        />
+        <div className="topics metadata">
+          <span>Topics: </span>
+          <ul className="topics-list list-reset inline">
+            {req.topics.map(topic => <TopicLink key={topic.id} topic={topic} />)}
+          </ul>
+        </div>
       </div>
     );
   }

--- a/ui/components/policy/req.js
+++ b/ui/components/policy/req.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import {filterAppliesTo} from '../requirements/requirement';
 import Metadata from '../requirements/metadata';
-import PolicyLink from '../requirements/policy-link';
 import TopicLink from '../requirements/topic-link';
 
 const badEntities = [
@@ -16,25 +16,12 @@ const badEntities = [
   'Cannot determine-Ask Mindy',
 ].map(e => e.toLowerCase());
 
-export function filterAppliesTo(text) {
-  const normalized = (text || '').toLowerCase().trim();
-  if (badEntities.includes(normalized)) {
-    return null;
-  }
-  return text;
-}
-
 export default function Req({ highlighted, href, onClick, req }) {
   let meta = null;
   if (highlighted) {
     meta = (
       <div className="req col col-4">
         <Metadata className="requirement-id" name="Requirement ID" value={req.req_id} />
-        <Metadata
-          className="omb-policy-id"
-          name="OMB Policy ID"
-          value={req.policy.omb_policy_id}
-        />
         <Metadata
           className="issuance"
           name="Policy issuance"
@@ -56,7 +43,7 @@ export default function Req({ highlighted, href, onClick, req }) {
         <div className="topics metadata">
           <span>Topics: </span>
           <ul className="topics-list list-reset inline">
-            {req.topics.map(topic => <TopicLink key={topic.id} topic={topic} />)}
+            {req.topics.map(topic => <TopicLink key={topic.id} topic={topic} route="policies" />)}
           </ul>
         </div>
       </div>
@@ -72,6 +59,7 @@ export default function Req({ highlighted, href, onClick, req }) {
     </div>
   );
 }
+
 Req.propTypes = {
   highlighted: PropTypes.bool,
   href: PropTypes.string.isRequired,
@@ -87,6 +75,7 @@ Req.propTypes = {
     ).isRequired,
   }).isRequired,
 };
+
 Req.defaultProps = {
   highlighted: false,
 };

--- a/ui/components/policy/req.js
+++ b/ui/components/policy/req.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {filterAppliesTo} from '../requirements/requirement';
+import { filterAppliesTo } from '../requirements/requirement';
 import Metadata from '../requirements/metadata';
 import TopicLink from '../requirements/topic-link';
 
@@ -32,7 +32,7 @@ export default function Req({ highlighted, href, onClick, req }) {
         <div className="topics metadata">
           <span>Topics: </span>
           <ul className="topics-list list-reset inline">
-            {req.topics.map(topic => <TopicLink key={topic.id} topic={topic} route="route" />)}
+            {req.topics.map(topic => <TopicLink key={topic.id} topic={topic} route="policies" />)}
           </ul>
         </div>
       </div>

--- a/ui/components/policy/req.js
+++ b/ui/components/policy/req.js
@@ -32,6 +32,7 @@ export default function Req({ highlighted, href, onClick, req }) {
         <div className="topics metadata">
           <span>Topics: </span>
           <ul className="topics-list list-reset inline">
+            {req.topics.map(topic => <TopicLink key={topic.id} topic={topic} route="route" />)}
           </ul>
         </div>
       </div>
@@ -59,6 +60,7 @@ Req.propTypes = {
       PropTypes.shape({
         id: PropTypes.number.isRequired,
         name: PropTypes.string.isRequired,
+        route: PropTypes.string,
       }),
     ).isRequired,
   }).isRequired,

--- a/ui/components/policy/req.js
+++ b/ui/components/policy/req.js
@@ -5,17 +5,6 @@ import {filterAppliesTo} from '../requirements/requirement';
 import Metadata from '../requirements/metadata';
 import TopicLink from '../requirements/topic-link';
 
-const badEntities = [
-  'NA',
-  'N/A',
-  'Not Applicable',
-  'None',
-  'None Specified',
-  'unknown',
-  'TBA',
-  'Cannot determine-Ask Mindy',
-].map(e => e.toLowerCase());
-
 export default function Req({ highlighted, href, onClick, req }) {
   let meta = null;
   if (highlighted) {
@@ -43,7 +32,6 @@ export default function Req({ highlighted, href, onClick, req }) {
         <div className="topics metadata">
           <span>Topics: </span>
           <ul className="topics-list list-reset inline">
-            {req.topics.map(topic => <TopicLink key={topic.id} topic={topic} route="policies" />)}
           </ul>
         </div>
       </div>

--- a/ui/components/requirements/policy-link.js
+++ b/ui/components/requirements/policy-link.js
@@ -3,13 +3,19 @@ import React from 'react';
 
 import { Link } from '../../routes';
 
+export function policyLinkTag(policy) {
+  return (
+    <Link route="policies" params={{ id__in: policy.id }}>
+      <a>{policy.title_with_number}</a>
+    </Link>
+  );
+}
+
 export default function PolicyLink({ policy }) {
   return (
     <div className="policy-title metadata">
       Policy title:{' '}
-      <Link route="policies" params={{ id__in: policy.id }}>
-        <a>{policy.title_with_number}</a>
-      </Link>
+      { policyLinkTag(policy) }
     </div>
   );
 }

--- a/ui/components/requirements/requirement.js
+++ b/ui/components/requirements/requirement.js
@@ -15,6 +15,7 @@ const badEntities = [
   'TBA',
   'Cannot determine-Ask Mindy',
 ].map(e => e.toLowerCase());
+
 /* Temporary "solution" to bad data: filter it out on the front end */
 export function filterAppliesTo(text) {
   const normalized = (text || '').toLowerCase().trim();

--- a/ui/components/requirements/requirement.js
+++ b/ui/components/requirements/requirement.js
@@ -58,13 +58,6 @@ export default function Requirement({ requirement }) {
             value={filterAppliesTo(requirement.impacted_entity)}
           />
           <Metadata className="issuing-body" name="Issuing body" value={requirement.issuing_body} />
-          <Metadata
-            className="sunset-date"
-            name="Sunset date"
-            value={requirement.policy.sunset}
-            nullValue="Sunset date: none"
-            separator=" by "
-          />
           <div className="topics metadata">
             <span>Topics: </span>
             <ul className="topics-list list-reset inline">
@@ -77,15 +70,16 @@ export default function Requirement({ requirement }) {
   );
 }
 
+const topicProps = PropTypes.arrayOf(
+  PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+    route: PropTypes.string,
+  }),
+);
 Requirement.propTypes = {
   requirement: PropTypes.shape({
-    topics: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.number,
-        name: PropTypes.string,
-        route: PropTypes.string,
-      }),
-    ),
+    topics: topicProps,
     policy: PropTypes.shape({
       sunset: PropTypes.string,
     }),

--- a/ui/components/requirements/requirement.js
+++ b/ui/components/requirements/requirement.js
@@ -58,6 +58,13 @@ export default function Requirement({ requirement }) {
             value={filterAppliesTo(requirement.impacted_entity)}
           />
           <Metadata className="issuing-body" name="Issuing body" value={requirement.issuing_body} />
+          <Metadata
+            className="sunset-date"
+            name="Sunset date"
+            value={requirement.policy.sunset}
+            nullValue="Sunset date: none"
+            separator=" by "
+          />
           <div className="topics metadata">
             <span>Topics: </span>
             <ul className="topics-list list-reset inline">

--- a/ui/components/requirements/requirement.js
+++ b/ui/components/requirements/requirement.js
@@ -83,6 +83,7 @@ Requirement.propTypes = {
       PropTypes.shape({
         id: PropTypes.number,
         name: PropTypes.string,
+        route: PropTypes.string,
       }),
     ),
     policy: PropTypes.shape({

--- a/ui/components/requirements/requirements-view.js
+++ b/ui/components/requirements/requirements-view.js
@@ -22,12 +22,13 @@ export default function RequirementsView({ requirements, count }) {
     </div>
   );
 }
+const requirementProps = PropTypes.shape({
+  id: PropTypes.number,
+  title: PropTypes.string,
+  relevant_reqs: PropTypes.number,
+});
 RequirementsView.propTypes = {
-  requirements: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.number,
-    title: PropTypes.string,
-    relevant_reqs: PropTypes.number,
-  })),
+  requirements: PropTypes.arrayOf(requirementProps),
   count: PropTypes.number,
 };
 RequirementsView.defaultProps = {

--- a/ui/components/requirements/topic-link.js
+++ b/ui/components/requirements/topic-link.js
@@ -5,7 +5,7 @@ import { Link } from '../../routes';
 
 export default function TopicLink({ topic }) {
   const route = topic.route ? topic.route : 'requirements';
-  return(
+  return (
     <li className="inline">
       <Link route={route} params={{ topics__id__in: topic.id }}>
         <a>{topic.name}</a>

--- a/ui/components/requirements/topic-link.js
+++ b/ui/components/requirements/topic-link.js
@@ -4,8 +4,8 @@ import React from 'react';
 import { Link } from '../../routes';
 
 export default function TopicLink({ topic }) {
-  const route = (topic.route) ? topic.route : 'requirements';
-  return (
+  const route = topic.route ? topic.route : 'requirements';
+  return(
     <li className="inline">
       <Link route={route} params={{ topics__id__in: topic.id }}>
         <a>{topic.name}</a>

--- a/ui/components/requirements/topic-link.js
+++ b/ui/components/requirements/topic-link.js
@@ -14,10 +14,12 @@ export default function TopicLink({ topic }) {
   );
 }
 
+const topicParams = {
+  id: PropTypes.number,
+  name: PropTypes.string,
+  route: PropTypes.string,
+};
+
 TopicLink.propTypes = {
-  topic: PropTypes.shape({
-    id: PropTypes.number,
-    name: PropTypes.string,
-    route: PropTypes.string,
-  }).isRequired,
+  topic: PropTypes.shape(topicParams).isRequired,
 };

--- a/ui/components/requirements/topic-link.js
+++ b/ui/components/requirements/topic-link.js
@@ -4,9 +4,10 @@ import React from 'react';
 import { Link } from '../../routes';
 
 export default function TopicLink({ topic }) {
+  const route = (topic.route) ? topic.route : 'requirements';
   return (
     <li className="inline">
-      <Link route="requirements" params={{ topics__id__in: topic.id }}>
+      <Link route={route} params={{ topics__id__in: topic.id }}>
         <a>{topic.name}</a>
       </Link>
     </li>
@@ -17,5 +18,6 @@ TopicLink.propTypes = {
   topic: PropTypes.shape({
     id: PropTypes.number,
     name: PropTypes.string,
+    route: PropTypes.string,
   }).isRequired,
 };


### PR DESCRIPTION
# Reference 

https://github.com/18F/omb-eregs/issues/549

# What

Move the `MetaData` components found in the requirements page over into the `Policy` page.

<img width="1285" alt="screen shot 2017-10-13 at 3 05 15 pm" src="https://user-images.githubusercontent.com/1332366/31562042-fd965082-b027-11e7-8121-6f657175aac1.png">
