### PR TITLE
Account for bad policy id

### DIFF
--- a/ui/__tests__/components/app-wrapper.test.js
+++ b/ui/__tests__/components/app-wrapper.test.js
@@ -1,0 +1,66 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import wrapPage from '../../components/app-wrapper';
+
+
+describe('wrapPage()', () => {
+  const ExamplePage = () => <div>Content</div>;
+
+  describe('getInitialProps()', () => {
+    it('passes fetched data', async () => {
+      const dataFn = jest.fn(async () => ({ some: 'data' }));
+      const Wrapped = wrapPage(ExamplePage, dataFn);
+      const results = await Wrapped.getInitialProps({ a: 'context' });
+
+      expect(results).toEqual({ some: 'data' });
+      expect(dataFn).toHaveBeenCalledWith({ a: 'context' });
+    });
+    it('handles errors', async () => {
+      const err = new Error('oy');
+      const dataFn = jest.fn(async () => { throw err; });
+      const Wrapped = wrapPage(ExamplePage, dataFn);
+      const results = await Wrapped.getInitialProps();
+
+      expect(results).toEqual({ err });
+    });
+    it('allows fetched data to trigger a 404', async () => {
+      const dataFn = jest.fn(async () => ({ statusCode: 404 }));
+      const Wrapped = wrapPage(ExamplePage, dataFn);
+      const results = await Wrapped.getInitialProps();
+
+      expect(results).toEqual({ statusCode: 404 });
+    });
+  });
+  describe('render()', () => {
+    const Wrapped = wrapPage(ExamplePage, jest.fn());
+    it('renders content if no error', () => {
+      const result = shallow(<Wrapped arg1="some value" />);
+
+      expect(result.name()).toBe('HeaderFooter');
+      expect(result.find('ExamplePage')).toHaveLength(1);
+      expect(result.find('ExamplePage').first().prop('arg1')).toBe('some value');
+    });
+    it('renders an error, with no explicit status code', () => {
+      const err = new Error('oh noes');
+      const result = shallow(<Wrapped err={err} />);
+
+      expect(result.name()).toBe('ErrorView');
+      expect(result.find('ErrorView')).toHaveLength(1);
+      expect(result.find('ErrorView').first().props()).toEqual({
+        err,
+        statusCode: null,
+      });
+    });
+    it('renders an error, with an explicit status code', () => {
+      const result = shallow(<Wrapped statusCode={404} />);
+
+      expect(result.name()).toBe('ErrorView');
+      expect(result.find('ErrorView')).toHaveLength(1);
+      expect(result.find('ErrorView').first().props()).toEqual({
+        err: null,
+        statusCode: 404,
+      });
+    });
+  });
+});

--- a/ui/__tests__/util/api/queries.test.js
+++ b/ui/__tests__/util/api/queries.test.js
@@ -122,7 +122,7 @@ describe('policyData()', () => {
     expect(endpoints.policies.fetchOne).toHaveBeenCalledWith('3');
   });
   it('returns the correct results', async () => {
-    const results = await policyData({ query: { policyId: '3' } });
+    const results = await policyData({ query: {} });
     expect(results).toEqual({
       pagedReqs: { count: 1, results: 'data-goes-here' },
       policy: {
@@ -134,5 +134,16 @@ describe('policyData()', () => {
   it('will pass the page number', async () => {
     await policyData({ query: { page: '5', policyId: '3' } });
     expect(endpoints.requirements.fetch).toHaveBeenCalledWith({ policy_id: '3', page: '5' });
+  });
+  it('passes up 404s', async () => {
+    const err = new Error('Not found');
+    err.response = { status: 404 };
+    endpoints.policies.fetchOne.mockReset();
+    endpoints.policies.fetchOne.mockImplementationOnce(() => {
+      throw err;
+    });
+
+    const result = await policyData({ query: {} });
+    expect(result).toEqual({ statusCode: 404 });
   });
 });

--- a/ui/components/app-wrapper.js
+++ b/ui/components/app-wrapper.js
@@ -3,7 +3,7 @@ import NProgress from 'nprogress';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import ErrorPage from './error';
+import ErrorView from './error';
 import HeaderFooter from './header-footer';
 
 
@@ -22,21 +22,25 @@ Router.onRouteChangeStart = NProgress.start;
 export default function wrapPage(Page, dataFn, headerFooterParams) {
   const hfParams = headerFooterParams || { showSearch: true };
   function WrappedPage(props) {
-    if (props.err) return <ErrorPage err={props.err} />;
+    if (props.err || props.statusCode) {
+      return <ErrorView err={props.err} statusCode={props.statusCode} />;
+    }
     return <HeaderFooter {...hfParams}><Page {...props} /></HeaderFooter>;
   }
 
   WrappedPage.propTypes = {
     err: PropTypes.shape({}),
+    statusCode: PropTypes.number,
   };
 
   WrappedPage.defaultProps = {
     err: null,
+    statusCode: null,
   };
 
-  WrappedPage.getInitialProps = (ctx) => {
+  WrappedPage.getInitialProps = async (ctx) => {
     try {
-      return dataFn(ctx).catch(err => ({ err }));
+      return await dataFn(ctx);
     } catch (err) {
       return { err };
     }

--- a/ui/util/api/queries.js
+++ b/ui/util/api/queries.js
@@ -137,10 +137,16 @@ export async function policyData({ query }) {
     page: query.page || '1',
   };
 
-  const [pagedReqs, policy] = await Promise.all([
-    endpoints.requirements.fetch(reqQuery),
-    endpoints.policies.fetchOne(query.policyId),
-  ]);
-
-  return { pagedReqs, policy: formatIssuance(policy) };
+  try {
+    const [pagedReqs, policy] = await Promise.all([
+      endpoints.requirements.fetch(reqQuery),
+      endpoints.policies.fetchOne(query.policyId),
+    ]);
+    return { pagedReqs, policy: formatIssuance(policy) };
+  } catch (err) {
+    if (err.response && err.response.status === 404) {
+      return { statusCode: 404 };
+    }
+    throw err;
+  }
 }

--- a/ui/util/api/queries.js
+++ b/ui/util/api/queries.js
@@ -11,9 +11,10 @@ const NUM_POLICIES = 4;
 const DATE_FORMAT = 'MMMM D, YYYY';
 
 export function formatIssuance(policy) {
-  return Object.assign({}, policy, {
+  return {
+    ...policy,
     issuance_pretty: moment(policy.issuance).format(DATE_FORMAT),
-  });
+  };
 }
 
 export async function homepageData() {


### PR DESCRIPTION
If requesting a policy detail page for a policy which doesn't exist, we should return a 404 rather than a 500.

Resolves #557 