### PR TITLE
Rework Search component to be route-based.

### DIFF
--- a/ui/__tests__/components/search/search.test.js
+++ b/ui/__tests__/components/search/search.test.js
@@ -8,17 +8,17 @@ const blankRouter = { pathname: '', query: {} };
 
 describe('<Search />', () => {
   describe('actionPath()', () => {
-    it('returns /policies/ by default', () => {
+    it('returns /policies by default', () => {
       const router = { pathname: '/no-such-path', query: {} };
       const rendered = shallow(<Search router={router} />);
       const actual = rendered.instance().actionPath();
-      expect(actual).toEqual('/policies/');
+      expect(actual).toEqual('/policies');
     });
-    it('returns the pathname if "policies" is in the pathname', () => {
-      const router = { pathname: '/policies', query: {} };
+    it('returns the current path if in our whitelist', () => {
+      const router = { pathname: '/requirements', query: {} };
       const rendered = shallow(<Search router={router} />);
       const actual = rendered.instance().actionPath();
-      expect(actual).toEqual('/policies');
+      expect(actual).toEqual('/requirements');
     });
   });
 
@@ -57,6 +57,15 @@ describe('<Search />', () => {
       someOther: 'parameter',
     });
   });
+  it('does not create hidden fields on other pages', () => {
+    const router = {
+      pathname: '/some-other-page',
+      query: { some: 'value' },
+    };
+    const rendered = shallow(<Search router={router} />);
+    const hidden = rendered.find('[type="hidden"]');
+    expect(hidden).toHaveLength(0);
+  });
 
   describe('if javascript is not enabled', () => {
     it('sets the form action', () => {
@@ -79,7 +88,7 @@ describe('<Search />', () => {
       expect(preventDefault).toHaveBeenCalled();
     });
 
-    it('router.push is called with all relevant fields', () => {
+    it('adds fields to router.push when on a whitelisted page', () => {
       const preventDefault = jest.fn();
       const push = jest.fn();
       const router = {
@@ -99,6 +108,25 @@ describe('<Search />', () => {
           requirements__req_text__search: '',
           topics__id__in: 36,
         },
+      });
+    });
+    it('does not add fields to router.push if not on a whitelist page', () => {
+      const preventDefault = jest.fn();
+      const push = jest.fn();
+      const router = {
+        pathname: '/about-stuff',
+        push,
+        query: {
+          topics__id__in: 36,
+        },
+      };
+      const rendered = shallow(<Search router={router} />);
+      const form = rendered.find('form[action="/policies"]');
+
+      form.simulate('submit', { preventDefault });
+      expect(push).toHaveBeenCalledWith({
+        pathname: '/policies',
+        query: { requirements__req_text__search: '' },
       });
     });
   });

--- a/ui/components/search/search.js
+++ b/ui/components/search/search.js
@@ -2,6 +2,15 @@ import { withRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import routes from '../../routes';
+
+const defaultRoute = 'policies';
+const inputNameMapping = {
+  policies: 'requirements__req_text__search',
+  requirements: 'req_text__search',
+};
+
+
 export class Search extends React.Component {
   constructor(props) {
     super(props);
@@ -11,9 +20,20 @@ export class Search extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
+  currentRoute() {
+    const route = routes.match(this.props.router.pathname).route;
+    if (route) {
+      return route.name;
+    }
+    return null;
+  }
+
   actionPath() {
-    const path = this.props.router.pathname;
-    return path.includes('policies') || path.includes('requirements') ? path : '/policies/';
+    const route = this.currentRoute();
+    if (Object.keys(inputNameMapping).includes(route)) {
+      return `/${route}`;
+    }
+    return `/${defaultRoute}`;
   }
 
   hiddenFields() {
@@ -24,16 +44,20 @@ export class Search extends React.Component {
   }
 
   query() {
-    const query = Object.assign({}, this.props.router.query);
-    delete query.page;
-    delete query[this.inputName()];
+    const route = this.currentRoute();
+    if (Object.keys(inputNameMapping).includes(route)) {
+      const query = { ...this.props.router.query };
+      delete query.page;
+      delete query[this.inputName()];
 
-    return query;
+      return query;
+    }
+    return {};
   }
 
   inputName() {
-    const path = this.props.router.pathname;
-    return path.includes('requirements') ? 'req_text__search' : 'requirements__req_text__search';
+    const route = this.currentRoute();
+    return inputNameMapping[route] || inputNameMapping[defaultRoute];
   }
 
   handleChange(e) {


### PR DESCRIPTION
The Search component was written prior to our Next.js-based routes, which
meant that it was doing all of its logic via substring searches. This
refactors it to instead define a constant for the default route and a mapping
between routes and their parameter names.

In the process, it alters the logic to only keep the query params when the
user is on one of the two whitelisted pages (requirements or policies); query
parameters on other pages aren't relevant.

Should resolve #558 