### PR TITLE
Remove the navigation tabs from policies results.

### DIFF
--- a/ui/__tests__/pages/policies.test.js
+++ b/ui/__tests__/pages/policies.test.js
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { PoliciesContainer, RequirementsTab } from '../../pages/policies';
+import { PoliciesContainer } from '../../pages/policies';
 
 describe('<PoliciesContainer />', () => {
   const pagedPolicies = {
@@ -20,14 +20,9 @@ describe('<PoliciesContainer />', () => {
     expect(selector.props.lookup).toEqual('topics');
   });
 
-  it('has one tabs with correct types', () => {
+  it('has no tabs', () => {
     const tabs = result.prop('tabs');
-    expect(tabs).toHaveLength(1);
-
-    const [policyTab] = tabs;
-
-    expect(policyTab.props.active).toBeTruthy();
-    expect(policyTab.props.tabName).toBe('Policies');
+    expect(tabs).toBeNull();
   });
 
   it('has correct pageContent', () => {
@@ -43,33 +38,5 @@ describe('<PoliciesContainer />', () => {
     expect(selectedFilters.props.fieldNames).toHaveProperty('policies');
     expect(selectedFilters.props.fieldNames).toHaveProperty('search');
     expect(selectedFilters.props.fieldNames).toHaveProperty('topics');
-  });
-});
-
-
-describe('<RequirementsTab />', () => {
-  const router = {
-    pathname: '',
-    query: {
-      issuance__gt: '2015-01-01',
-      requirements__verb__icontains: 'must',
-      requirements__topics__id__in: '1,6,9',
-      page: '5',
-    },
-  };
-  const result = shallow(<RequirementsTab router={router} />);
-
-  it('is a configured TabView', () => {
-    expect(result.name()).toBe('TabView');
-    expect(result.prop('active')).toBeFalsy();
-    expect(result.prop('route')).toBe('requirements');
-    expect(result.prop('tabName')).toBe('Requirements');
-  });
-  it('transforms the query', () => {
-    expect(result.prop('params')).toEqual({
-      policy__issuance__gt: '2015-01-01',
-      verb__icontains: 'must',
-      topics__id__in: '1,6,9',
-    });
   });
 });

--- a/ui/__tests__/pages/requirements.test.js
+++ b/ui/__tests__/pages/requirements.test.js
@@ -21,15 +21,14 @@ describe('<RequirementsContainer />', () => {
   });
 
   it('has two tabs with correct types', () => {
-    const tabs = result.prop('tabs');
-    expect(tabs).toHaveLength(2);
+    const tabs = shallow(result.prop('tabs'));
 
-    const [reqTab, policyTab] = tabs;
+    expect(tabs.find('TabView')).toHaveLength(1);
+    const tabView = tabs.find('TabView').first();
+    expect(tabView.prop('active')).toBeTruthy();
+    expect(tabView.prop('tabName')).toBe('Requirements');
 
-    expect(reqTab.props.active).toBeTruthy();
-    expect(reqTab.props.tabName).toBe('Requirements');
-
-    expect(policyTab.type.displayName).toEqual('withRoute(PoliciesTab)');
+    expect(tabs.find('withRoute(PoliciesTab)')).toHaveLength(1);
   });
 
   it('has correct pageContent', () => {

--- a/ui/components/search-filter-view.js
+++ b/ui/components/search-filter-view.js
@@ -10,12 +10,7 @@ export default function SearchFilterView(
         {filterControls}
       </div>
       <div className="main col col-10 pl4 border-left max-width-3">
-        <div className="tab-container no-print">
-          <span className="mr4">View:</span>
-          <ul className="organize-tabs list-reset inline-block">
-            {tabs}
-          </ul>
-        </div>
+        { tabs }
         { selectedFilters }
         {/* page counts here */}
         { pageContent }
@@ -28,11 +23,11 @@ SearchFilterView.propTypes = {
   filterControls: PropTypes.arrayOf(PropTypes.node),
   pageContent: PropTypes.node,
   selectedFilters: PropTypes.node,
-  tabs: PropTypes.arrayOf(PropTypes.node),
+  tabs: PropTypes.node,
 };
 SearchFilterView.defaultProps = {
   filterControls: [],
   pageContent: null,
   selectedFilters: null,
-  tabs: [],
+  tabs: null,
 };

--- a/ui/pages/policies.js
+++ b/ui/pages/policies.js
@@ -4,30 +4,10 @@ import React from 'react';
 import wrapPage from '../components/app-wrapper';
 import PoliciesView from '../components/policies/policies-view';
 import SearchFilterView from '../components/search-filter-view';
-import TabView from '../components/tab-view';
 import ExistingFilters from '../components/filters/existing-container';
 import FilterListView from '../components/filters/list-view';
 import SelectorContainer from '../components/filters/selector';
 import { policiesData } from '../util/api/queries';
-
-export function RequirementsTab({ router }) {
-  const policyQuery = router.query;
-  // Transform filter keys into the format expected by requirements
-  const reqQuery = {};
-  Object.keys(policyQuery).forEach((key) => {
-    if (key.startsWith('requirements__')) {
-      reqQuery[key.slice('requirements__'.length)] = policyQuery[key];
-    } else if (!['page', 'ordering', 'format'].includes(key)) {
-      reqQuery[`policy__${key}`] = policyQuery[key];
-    }
-  });
-  return <TabView active={false} params={reqQuery} route="requirements" tabName="Requirements" />;
-}
-RequirementsTab.propTypes = {
-  router: PropTypes.shape({
-    query: PropTypes.shape({}).isRequired,
-  }).isRequired,
-};
 
 const fieldNames = {
   agencies: 'requirements__all_agencies__id__in',
@@ -76,9 +56,6 @@ export function PoliciesContainer({
           topics={existingTopics}
         />
       }
-      tabs={[
-        <TabView active tabName="Policies" key="Policies" />,
-      ]}
     />
   );
 }

--- a/ui/pages/requirements.js
+++ b/ui/pages/requirements.js
@@ -59,6 +59,15 @@ export function RequirementsContainer({
       }
     />,
   ];
+  const tabs = (
+    <div className="tab-container no-print">
+      <span className="mr4">View:</span>
+      <ul className="organize-tabs list-reset inline-block">
+        <TabView active tabName="Requirements" key="Requirements" />
+        <PoliciesTabWithRouter key="Policies" />
+      </ul>
+    </div>
+  );
   return (
     <SearchFilterView
       filterControls={filterControls}
@@ -72,10 +81,7 @@ export function RequirementsContainer({
           topics={existingTopics}
         />
       }
-      tabs={[
-        <TabView active tabName="Requirements" key="Requirements" />,
-        <PoliciesTabWithRouter key="Policies" />,
-      ]}
+      tabs={tabs}
     />
   );
 }


### PR DESCRIPTION
Per feedback from @carodew, the partial navigation tabs on the policies
results page were confusing and no longer provided use. This removes them by
moving their markup into the requirements listing page.

It also removes the RequirementsTab component as that is no longer in use.