### PR TITLE
Initial document-viewing page

### DIFF
--- a/ui/__tests__/components/nodeRenderers/fallback.test.js
+++ b/ui/__tests__/components/nodeRenderers/fallback.test.js
@@ -1,0 +1,40 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Fallback from '../../../components/nodeRenderers/fallback';
+
+const ORIGINALENV = { ...process.env };
+beforeEach(() => {
+  process.env = {};
+});
+afterEach(() => {
+  process.env = ORIGINALENV;
+});
+
+describe('<Fallback />', () => {
+  it('includes text, children, id when not in dev mode', () => {
+    const docNode = { identifier: 'aaa_1__bbb_2', text: 'An example' };
+    const result = shallow(
+      <Fallback docNode={docNode}>
+        <span id="child">A child</span>
+      </Fallback>);
+    expect(result.text()).toMatch(/An example/);
+    expect(result.prop('id')).toBe('aaa_1__bbb_2');
+    expect(result.prop('style')).toBeUndefined();
+    expect(result.prop('title')).toBeUndefined();
+    expect(result.find('#child')).toHaveLength(1);
+  });
+  it('includes that plus title text and a background when in dev mode', () => {
+    process.env.NODE_ENV = 'development';
+    const docNode = { identifier: 'aaa_1__bbb_2', text: 'An example' };
+    const result = shallow(
+      <Fallback docNode={docNode}>
+        <span id="child">A child</span>
+      </Fallback>);
+    expect(result.text()).toMatch(/An example/);
+    expect(result.prop('id')).toBe('aaa_1__bbb_2');
+    expect(result.prop('style')).toEqual({ backgroundColor: 'pink' });
+    expect(result.prop('title')).toBe('aaa_1__bbb_2');
+    expect(result.find('#child')).toHaveLength(1);
+  });
+});

--- a/ui/__tests__/components/nodeRenderers/heading.test.js
+++ b/ui/__tests__/components/nodeRenderers/heading.test.js
@@ -1,0 +1,26 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Heading from '../../../components/nodeRenderers/heading';
+
+describe('<Heading />', () => {
+  it('includes node text and identifier', () => {
+    const docNode = { identifier: 'aaa_1__bbb_2', text: 'More more' };
+    const result = shallow(<Heading docNode={docNode} />);
+    expect(result.prop('id')).toBe('aaa_1__bbb_2');
+    expect(result.text()).toBe('More more');
+  });
+  it('generates an h1 when there are no sections', () => {
+    const docNode = { identifier: 'aaa_1__bbb_2__ccc_3', text: '' };
+    const result = shallow(<Heading docNode={docNode} />);
+    expect(result.name()).toBe('h1');
+  });
+  it('generates an h4 if there are three sections', () => {
+    const docNode = {
+      identifier: 'root_1__sec_4__sec_a__appendix_A__sec_3__heading_1',
+      text: '',
+    };
+    const result = shallow(<Heading docNode={docNode} />);
+    expect(result.name()).toBe('h4');
+  });
+});

--- a/ui/__tests__/components/nodeRenderers/para.test.js
+++ b/ui/__tests__/components/nodeRenderers/para.test.js
@@ -1,0 +1,25 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Paragraph from '../../../components/nodeRenderers/para';
+
+describe('<Paragraph />', () => {
+  const docNode = { identifier: 'aaa_1__bbb_2__ccc_3', text: 'Textextext' };
+  it('includes the identifier', () => {
+    const result = shallow(<Paragraph docNode={docNode} />);
+    expect(result.prop('id')).toBe('aaa_1__bbb_2__ccc_3');
+  });
+  it('includes node text', () => {
+    const paragraphs = shallow(<Paragraph docNode={docNode} />).find('p');
+    expect(paragraphs).toHaveLength(1);
+    expect(paragraphs.first().text()).toBe('Textextext');
+  });
+  it('includes children', () => {
+    const result = shallow(
+      <Paragraph docNode={docNode}>
+        <thing1 /><thing2>contents</thing2>
+      </Paragraph>);
+    expect(result.find('thing1')).toHaveLength(1);
+    expect(result.find('thing2')).toHaveLength(1);
+  });
+});

--- a/ui/__tests__/components/nodeRenderers/policy.test.js
+++ b/ui/__tests__/components/nodeRenderers/policy.test.js
@@ -1,0 +1,20 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Policy from '../../../components/nodeRenderers/policy';
+
+describe('<Policy />', () => {
+  const docNode = { identifier: 'aaa_1__bbb_2' };
+  it('includes the identifier', () => {
+    const result = shallow(<Policy docNode={docNode} />);
+    expect(result.prop('id')).toBe('aaa_1__bbb_2');
+  });
+  it('includes children', () => {
+    const result = shallow(
+      <Policy docNode={docNode}>
+        <childA /><childB /><childA />
+      </Policy>);
+    expect(result.find('childA')).toHaveLength(2);
+    expect(result.find('childB')).toHaveLength(1);
+  });
+});

--- a/ui/__tests__/components/nodeRenderers/sec.test.js
+++ b/ui/__tests__/components/nodeRenderers/sec.test.js
@@ -1,0 +1,25 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Section from '../../../components/nodeRenderers/sec';
+
+describe('<Section />', () => {
+  const docNode = { identifier: 'aaa_1__bbb_2' };
+  it('includes an identifier', () => {
+    const result = shallow(<Section docNode={docNode} />);
+    expect(result.prop('id')).toBe('aaa_1__bbb_2');
+  });
+  it('has some padding', () => {
+    const style = shallow(<Section docNode={docNode} />).prop('style');
+    expect(style).toBeTruthy();
+    expect(style.paddingLeft).toBeTruthy();
+    expect(style.paddingRight).toBeTruthy();
+  });
+  it('includes children', () => {
+    const result = shallow(
+      <Section docNode={docNode}>
+        <childA />
+      </Section>);
+    expect(result.find('childA')).toHaveLength(1);
+  });
+});

--- a/ui/__tests__/pages/document.test.js
+++ b/ui/__tests__/pages/document.test.js
@@ -1,0 +1,84 @@
+import { mount, shallow } from 'enzyme';
+import React from 'react';
+
+import { Document } from '../../pages/document';
+
+
+describe('<Document />', () => {
+  it('creates a Document for each node', () => {
+    const docNode = {
+      identifier: 'aaa_1',
+      node_type: 'aaa',
+      children: [
+        {
+          identifier: 'aaa_1__bbb_1',
+          node_type: 'bbb',
+          children: [],
+        },
+        {
+          identifier: 'aaa_1__bbb_2',
+          node_type: 'bbb',
+          children: [],
+        },
+        {
+          identifier: 'aaa_1__bbb_3',
+          node_type: 'bbb',
+          children: [],
+        },
+      ],
+    };
+    const result = mount(<Document docNode={docNode} />);
+    expect(result.find(Document)).toHaveLength(4);
+  });
+  it('handles recursion', () => {
+    const docNode = {
+      identifier: 'aaa_1',
+      node_type: 'aaa',
+      children: [
+        {
+          identifier: 'aaa_1__bbb_1',
+          node_type: 'bbb',
+          children: [
+            {
+              identifier: 'aaa_1__bbb_1__ccc_1',
+              node_type: 'ccc',
+              children: [
+                {
+                  identifier: 'aaa_1__bbb_1__ccc_1__ddd_1',
+                  node_type: 'ddd',
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const result = mount(<Document docNode={docNode} />);
+    expect(result.find(Document)).toHaveLength(4);
+    expect(result.find('Document > Document')).toHaveLength(3);
+    expect(result.find('Document > Document > Document')).toHaveLength(2);
+  });
+  it('uses para, etc.', () => {
+    const docNode = {
+      identifier: 'aaa_1__bbb_1__para_1',
+      node_type: 'para',
+      text: 'Some content',
+      children: [],
+    };
+    const result = shallow(<Document docNode={docNode} />);
+    expect(result.name()).toBe('Paragraph');
+    expect(result.prop('docNode')).toEqual(docNode);
+  });
+  it('uses the Fallback component for other nodes', () => {
+    const docNode = {
+      identifier: 'aaa_1__bbb_1',
+      node_type: 'bbb',
+      text: 'Something',
+      children: [],
+    };
+    const result = shallow(<Document docNode={docNode} />);
+    expect(result.name()).toBe('Fallback');
+    expect(result.prop('docNode')).toEqual(docNode);
+  });
+});

--- a/ui/__tests__/util/api/queries.test.js
+++ b/ui/__tests__/util/api/queries.test.js
@@ -1,5 +1,6 @@
 import {
   cleanSearchParams,
+  documentData,
   formatIssuance,
   homepageData,
   policyData,
@@ -144,6 +145,30 @@ describe('policyData()', () => {
     });
 
     const result = await policyData({ query: {} });
+    expect(result).toEqual({ statusCode: 404 });
+  });
+});
+
+describe('documentData()', () => {
+  beforeEach(() => {
+    endpoints.document.fetchOne.mockImplementationOnce(
+      () => Promise.resolve({ data: 'here' }),
+    );
+  });
+  it('hits the correct url', async () => {
+    const result = await documentData({ query: { policyId: '123' } });
+    expect(endpoints.document.fetchOne).toHaveBeenCalledWith('123');
+    expect(result).toEqual({ docNode: { data: 'here' } });
+  });
+  it('passes up 404s', async () => {
+    const err = new Error('Not found');
+    err.response = { status: 404 };
+    endpoints.document.fetchOne.mockReset();
+    endpoints.document.fetchOne.mockImplementationOnce(() => {
+      throw err;
+    });
+
+    const result = await documentData({ query: {} });
     expect(result).toEqual({ statusCode: 404 });
   });
 });

--- a/ui/components/nodeRenderers/fallback.js
+++ b/ui/components/nodeRenderers/fallback.js
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/* We've been asked to render a node we don't have a renderer for. We'll do
+ * our best but flag it when in development mode */
+export default function Fallback({ children, docNode }) {
+  const params = { id: docNode.identifier };
+  if (process.env.NODE_ENV === 'development') {
+    params.style = { backgroundColor: 'pink' };
+    params.title = docNode.identifier;
+  }
+  return (
+    <div {...params}>
+      <p style={{ margin: 0 }}>{ docNode.text }</p>
+      { children }
+    </div>
+  );
+}
+Fallback.propTypes = {
+  children: PropTypes.node,
+  docNode: PropTypes.shape({
+    identifier: PropTypes.string.isRequired,
+    text: PropTypes.string,
+  }).isRequired,
+};
+Fallback.defaultProps = {
+  children: null,
+};

--- a/ui/components/nodeRenderers/heading.js
+++ b/ui/components/nodeRenderers/heading.js
@@ -1,0 +1,18 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/* An h1/2/3/etc. depending on section depth */
+export default function Heading({ docNode }) {
+  const hLevel = docNode.identifier
+    .split('_')
+    .filter(e => e === 'sec')
+    .length + 1;
+  const Component = `h${hLevel}`;
+  return <Component id={docNode.identifier}>{ docNode.text }</Component>;
+}
+Heading.propTypes = {
+  docNode: PropTypes.shape({
+    identifier: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/ui/components/nodeRenderers/para.js
+++ b/ui/components/nodeRenderers/para.js
@@ -1,0 +1,22 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/* Paragraph of text */
+export default function Paragraph({ children, docNode }) {
+  return (
+    <div id={docNode.identifier}>
+      <p>{docNode.text}</p>
+      { children }
+    </div>
+  );
+}
+Paragraph.propTypes = {
+  children: PropTypes.node,
+  docNode: PropTypes.shape({
+    identifier: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+  }).isRequired,
+};
+Paragraph.defaultProps = {
+  children: null,
+};

--- a/ui/components/nodeRenderers/policy.js
+++ b/ui/components/nodeRenderers/policy.js
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/* Root of a policy document */
+export default function Policy({ children, docNode }) {
+  return <div id={docNode.identifier}>{ children }</div>;
+}
+Policy.propTypes = {
+  children: PropTypes.node,
+  docNode: PropTypes.shape({
+    identifier: PropTypes.string.isRequired,
+  }).isRequired,
+};
+Policy.defaultProps = {
+  children: null,
+};

--- a/ui/components/nodeRenderers/sec.js
+++ b/ui/components/nodeRenderers/sec.js
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/* Uses indentation and border to indicate separate sections */
+export default function Section({ children, docNode }) {
+  const style = {
+    border: '1px solid black',
+    paddingLeft: '1em',
+    paddingRight: '1em',
+  };
+  return <div id={docNode.identifier} style={style}>{children}</div>;
+}
+Section.propTypes = {
+  children: PropTypes.node,
+  docNode: PropTypes.shape({
+    identifier: PropTypes.string.isRequired,
+  }).isRequired,
+};
+Section.defaultProps = {
+  children: null,
+};

--- a/ui/pages/document.js
+++ b/ui/pages/document.js
@@ -1,0 +1,37 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import wrapPage from '../components/app-wrapper';
+import Fallback from '../components/nodeRenderers/fallback';
+import heading from '../components/nodeRenderers/heading';
+import para from '../components/nodeRenderers/para';
+import policy from '../components/nodeRenderers/policy';
+import sec from '../components/nodeRenderers/sec';
+import { documentData } from '../util/api/queries';
+
+const componentMapping = {
+  heading,
+  para,
+  policy,
+  sec,
+};
+
+/* Recursively converts a docNode into React components, depending on each
+ * node's node_type */
+export function Document({ docNode }) {
+  const Component = componentMapping[docNode.node_type] || Fallback;
+  return (
+    <Component docNode={docNode}>
+      { docNode.children.map(c => <Document docNode={c} key={c.identifier} />) }
+    </Component>
+  );
+}
+Document.propTypes = {
+  docNode: PropTypes.shape({
+    children: PropTypes.arrayOf(PropTypes.shape({})), // recursive
+    identifier: PropTypes.string.isRequired,
+    node_type: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default wrapPage(Document, documentData);

--- a/ui/routes.js
+++ b/ui/routes.js
@@ -6,6 +6,7 @@ const routes = Routes()
   .add('search-redirect', '/search-redirect/:lookup(agencies|policies|topics)', 'search-redirect')
   .add('policies')
   .add('policy', '/policy/:policyId(\\d+)/:reqId(\\d+)?', 'policy')
+  .add('document', '/document/:policyId(\\d+)', 'document')
   .add('privacy')
   .add('requirements');
 

--- a/ui/util/api/endpoints.js
+++ b/ui/util/api/endpoints.js
@@ -54,6 +54,7 @@ export class Endpoint {
 
 export default {
   agencies: new Endpoint('agencies/'),
+  document: new Endpoint('document/'),
   policies: new Endpoint('policies/'),
   requirements: new Endpoint('requirements/'),
   topics: new Endpoint('topics/'),

--- a/ui/util/api/queries.js
+++ b/ui/util/api/queries.js
@@ -150,3 +150,15 @@ export async function policyData({ query }) {
     throw err;
   }
 }
+
+export async function documentData({ query }) {
+  try {
+    const docNode = await endpoints.document.fetchOne(query.policyId);
+    return { docNode };
+  } catch (err) {
+    if (err.response && err.response.status === 404) {
+      return { statusCode: 404 };
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
Includes renderers for:
* paragraphs
* headings
* sections

along with some minimal, inline styles to distinguish them. The goal in pushing this up is that we'll have a common base to start dividing up work.

## Looks like
![document-detail](https://user-images.githubusercontent.com/326918/32005300-e7c3b13e-b971-11e7-8e3a-589268bd67f0.gif)
