### PR TITLE
Add Windows support for Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
   python: &PYTHON     # This command is out of order to aid with config reuse
     image: python:3.6.2
     volumes:
-      - $PWD:/usr/src/app:delegated
+      - .:/usr/src/app:delegated
     working_dir: /usr/src/app/api
     stdin_open: true
     tty: true
@@ -78,7 +78,7 @@ services:
   prod: &PROD_UI
     image: node:6
     volumes:
-      - $PWD:/usr/src/app:delegated
+      - .:/usr/src/app:delegated
     working_dir: /usr/src/app/ui
     command: .docker/deps_ok_then npm start
     environment:


### PR DESCRIPTION
The current Docker setup is almost perfect out-of-the-box for Windows, with the exception that it uses the `PWD` environment variable, which doesn't exist on Windows shells like `cmd.exe`.  So this just swaps out the variable for `.`, which I believe works just as well.