### PR TITLE
Fix value of API_URL in docker-compose.yml to work on Windows.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
   python: &PYTHON     # This command is out of order to aid with config reuse
     image: python:3.6.2
     volumes:
-      - $PWD:/usr/src/app:delegated
+      - .:/usr/src/app:delegated
     working_dir: /usr/src/app/api
     stdin_open: true
     tty: true
@@ -78,7 +78,7 @@ services:
   prod: &PROD_UI
     image: node:6
     volumes:
-      - $PWD:/usr/src/app:delegated
+      - .:/usr/src/app:delegated
     working_dir: /usr/src/app/ui
     command: .docker/deps_ok_then npm start
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
              "access_key_id": "LOCAL_ID",
              "bucket": "pdfs",
              "region": "irrelevant fake region",
-             "endpoint": "http://0.0.0.0:9100",
+             "endpoint": "http://localhost:9100",
              "secret_access_key": "LOCAL_KEY"
            },
            "label": "s3",
@@ -84,7 +84,7 @@ services:
     environment:
       PORT: 9002
       NODE_ENV: production
-      API_URL: 'http://0.0.0.0:9001/'
+      API_URL: 'http://localhost:9001/'
       VCAP_SERVICES: >
         {"config": [{"name": "config", "credentials": {"UI_BASIC_AUTH": {
         }}}]}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
     environment:
       PORT: 8002
       NODE_ENV: development
-      API_URL: 'http://0.0.0.0:8001/'
+      API_URL: 'http://localhost:8001/'
       VCAP_SERVICES: >
         {"config": [{"name": "config", "credentials": {"UI_BASIC_AUTH": {
         }}}]}


### PR DESCRIPTION
This is a follow-up to #592 that fixes a problem on Windows where 0.0.0.0 isn't a valid IP address on Windows browsers (Edge, Chrome, and Firefox all report it as an invalid address).  So this changes `API_URL` to use `localhost` instead, so the front-end's XHR calls on Windows browsers work.