### PR TITLE
Allow documents to be queried by M-number, add policy meta data

### DIFF
--- a/api/document/serializers.py
+++ b/api/document/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from document.models import DocNode
-from reqs.models import Requirement
+from reqs.models import Policy, Requirement
 from reqs.serializers import TopicSerializer
 
 
@@ -23,6 +23,17 @@ class RequirementSerializer(serializers.ModelSerializer):
         )
 
 
+class PolicySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Policy
+        fields = (
+            'issuance',
+            'omb_policy_id',
+            'title',
+            'uri',
+        )
+
+
 class DocCursorSerializer(serializers.ModelSerializer):
     children = serializers.SerializerMethodField()
     requirement = RequirementSerializer(read_only=True)
@@ -37,11 +48,21 @@ class DocCursorSerializer(serializers.ModelSerializer):
         """We want to serialize the wrapped model, not the cursor. However, we
         need to hang on to that cursor for rendering our children."""
         self.context['cursor'] = instance
-        return super().to_representation(instance.model)
+        as_dict = super().to_representation(instance.model)
+        if self.context.get('is_root', True):
+            as_dict.update(self.root_only_attrs(instance))
+        return as_dict
+
+    @staticmethod
+    def root_only_attrs(cursor):
+        return {
+            'policy': PolicySerializer(cursor.model.policy).data
+        }
 
     def get_children(self, instance):
         return self.__class__(
-            self.context['cursor'].children(), many=True
+            self.context['cursor'].children(), many=True,
+            context={**self.context, 'is_root': False},
         ).data
 
     def get_content(self, instance):

--- a/api/document/tests/serializers_test.py
+++ b/api/document/tests/serializers_test.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import pytest
 from model_mommy import mommy
 
@@ -9,7 +11,11 @@ from reqs.models import Policy, Requirement, Topic
 
 def test_end_to_end():
     """Create a tree, then serialize it."""
-    root = DocCursor.new_tree('root', '0')
+    policy = mommy.prepare(
+        Policy, issuance=date(2001, 2, 3), omb_policy_id='M-18-18',
+        title='Some Title', uri='http://example.com/thing.pdf',
+    )
+    root = DocCursor.new_tree('root', '0', policy=policy)
     root.add_child('sect', text='Section 1')
     sect2 = root.add_child('sect')
     pa = sect2.add_child('par', 'a')
@@ -25,6 +31,12 @@ def test_end_to_end():
         'depth': 0,
         'requirement': None,
         'content': [],
+        'policy': {     # Note this field does not appear on children
+            'issuance': '2001-02-03',
+            'omb_policy_id': 'M-18-18',
+            'title': 'Some Title',
+            'uri': 'http://example.com/thing.pdf',
+        },
         'children': [
             {
                 'identifier': 'root_0__sect_1',

--- a/api/document/urls.py
+++ b/api/document/urls.py
@@ -3,6 +3,6 @@ from django.conf.urls import url
 from document.views import TreeView
 
 urlpatterns = [
-    url(r'^(?P<policy_id>[0-9]+)(/(?P<identifier>[a-zA-Z0-9_-]+))?',
+    url(r'^(?P<policy_id>[^/]+)(/(?P<identifier>[a-zA-Z0-9_-]+))?',
         TreeView.as_view()),
 ]

--- a/api/document/views.py
+++ b/api/document/views.py
@@ -28,6 +28,7 @@ class TreeView(RetrieveAPIView):
         else:
             query_args['depth'] = 0
         root_doc = get_object_or_404(optimize(DocNode.objects), **query_args)
+        root_doc.policy = policy    # optimization to prevent hitting db again
         root = DocCursor.load_from_model(root_doc, subtree=False)
         root.add_models(optimize(root_doc.descendants()))
         return root

--- a/api/document/views.py
+++ b/api/document/views.py
@@ -4,6 +4,7 @@ from rest_framework.generics import RetrieveAPIView
 from document.models import DocNode
 from document.serializers import DocCursorSerializer
 from document.tree import DocCursor
+from reqs.views.policies import policy_or_404
 
 
 def optimize(queryset):
@@ -20,7 +21,8 @@ class TreeView(RetrieveAPIView):
     queryset = DocNode.objects.none()   # Used to determine permissions
 
     def get_object(self):
-        query_args = {'policy_id': self.kwargs['policy_id']}
+        policy = policy_or_404(self.kwargs['policy_id'])
+        query_args = {'policy_id': policy.pk}
         if self.kwargs.get('identifier'):
             query_args['identifier'] = self.kwargs['identifier']
         else:

--- a/api/reqs/tests/views_policies_tests.py
+++ b/api/reqs/tests/views_policies_tests.py
@@ -1,10 +1,12 @@
 from collections import namedtuple
 
 import pytest
+from django.http import Http404
 from model_mommy import mommy
 from rest_framework.test import APIClient
 
 from reqs.models import Agency, AgencyGroup, Policy, Requirement, Topic
+from reqs.views import policies as policies_views
 
 PolicySetup = namedtuple('PolicySetup', ('policies', 'reqs'))
 
@@ -180,3 +182,12 @@ def test_pk_id():
     mommy.make(Policy, pk=pk_id)
     response = client.get(path + '.json').json()
     assert response['id'] == pk_id
+
+
+@pytest.mark.django_db
+def test_policy_or_404():
+    policy = mommy.make(Policy, omb_policy_id='AAA-BBB-CCC')
+    assert policies_views.policy_or_404(f"{policy.pk}") == policy
+    assert policies_views.policy_or_404("AAA-BBB-CCC") == policy
+    with pytest.raises(Http404):
+        policies_views.policy_or_404('does-not-exist')

--- a/api/reqs/views/policies.py
+++ b/api/reqs/views/policies.py
@@ -62,6 +62,16 @@ def relevant_reqs_count(params):
     return Subquery(subquery, output_field=IntegerField())
 
 
+def policy_or_404(identifier):
+    queryset = Policy.objects.filter(public=True)
+    policy = queryset.filter(omb_policy_id=identifier).first()
+    if not policy and identifier.isdigit():
+        policy = queryset.filter(pk=identifier).first()
+    if not policy:
+        raise Http404()
+    return policy
+
+
 class PolicyViewSet(viewsets.ModelViewSet):
     queryset = Policy.objects.all()
     serializer_class = PolicySerializer
@@ -80,15 +90,8 @@ class PolicyViewSet(viewsets.ModelViewSet):
     def get_object(self):
         """We'll allow fetching a single object matching multiple
         parameters."""
-        queryset = Policy.objects.filter(public=True)
         identifier = self.kwargs.get('pk')  # the url parameter name
+        policy = policy_or_404(identifier)
+        self.check_object_permissions(self.request, policy)
 
-        obj = queryset.filter(omb_policy_id=identifier).first()
-        if not obj and identifier.isdigit():
-            obj = queryset.filter(pk=identifier).first()
-        if not obj:
-            raise Http404()
-
-        self.check_object_permissions(self.request, obj)
-
-        return obj
+        return policy


### PR DESCRIPTION
This re-uses the policy-id-or-m-number logic @rememberlenny wrote to do the same for whole documents. It also adds policy details to the root of the serialized tree.