### PR TITLE
Warn about mismatching data when importing XML.

### DIFF
--- a/api/document/tests/xml_importer/preprocess_test.py
+++ b/api/document/tests/xml_importer/preprocess_test.py
@@ -1,6 +1,12 @@
+from datetime import date
+from unittest.mock import Mock
+
+import pytest
 from lxml import etree
+from model_mommy import mommy
 
 from document.xml_importer import preprocess
+from reqs.models import Policy
 
 
 def test_standardize_content():
@@ -42,3 +48,29 @@ def test_clean_content():
     assert aroot.findtext('./childA/content') == 'More    text'
     content_xml = etree.tounicode(aroot.find('./content')).strip()
     assert content_xml == '<content>Some text <br/></content>'
+
+
+@pytest.mark.parametrize('diff_policy_num', (False, True))
+@pytest.mark.parametrize('diff_title', (False, True))
+@pytest.mark.parametrize('diff_published', (False, True))
+def test_warn_about_mismatches(monkeypatch, diff_policy_num, diff_title,
+                               diff_published):
+    monkeypatch.setattr(preprocess, 'logger', Mock())
+    policy = mommy.prepare(Policy, omb_policy_id='M-11', title='AAA',
+                           issuance=date(2001, 1, 1))
+    policy_num = 'N-22' if diff_policy_num else 'M-11'
+    title = 'BBB' if diff_title else 'AAA'
+    published = date(2002, 2, 2) if diff_published else date(2001, 1, 1)
+    xml = etree.fromstring(f"""
+    <root>
+        <preamble>
+            <policyNum> {policy_num}</policyNum>
+            <subject>{title} </subject>
+            <published> {published.isoformat()} </published>
+        </preamble>
+    </root>
+    """)
+
+    preprocess.warn_about_mismatches(policy, xml)
+    mismatch_count = sum((diff_policy_num, diff_title, diff_published))
+    assert preprocess.logger.warning.call_count == mismatch_count

--- a/api/document/xml_importer/importer.py
+++ b/api/document/xml_importer/importer.py
@@ -5,7 +5,9 @@ from lxml import etree
 from document.models import DocNode
 from document.tree import XMLAwareCursor
 from document.xml_importer.annotations import derive_annotations
-from document.xml_importer.preprocess import clean_content, standardize_content
+from document.xml_importer.preprocess import (clean_content,
+                                              standardize_content,
+                                              warn_about_mismatches)
 from reqs.models import Policy
 
 logger = logging.getLogger(__name__)
@@ -13,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 def import_xml_doc(policy: Policy, xml: etree.ElementBase):
     DocNode.objects.filter(policy=policy).delete()
+    warn_about_mismatches(policy, xml)
     standardize_content(xml)
     clean_content(xml)
 

--- a/api/document/xml_importer/preprocess.py
+++ b/api/document/xml_importer/preprocess.py
@@ -1,4 +1,11 @@
+import logging
+
+from dateutil import parser as dateutil_parser
 from lxml import etree
+
+from reqs.models import Policy
+
+logger = logging.getLogger(__name__)
 
 
 def standardize_content(xml: etree.ElementBase):
@@ -22,3 +29,31 @@ def clean_content(xml: etree.ElementBase):
             last_child.tail = (last_child.tail or '').rstrip()
         else:
             content_xml.text = content_xml.text.rstrip()
+
+
+def warn_about_mismatches(policy: Policy, xml: etree.ElementBase):
+    """When the elements in the document don't match their fields in the XML,
+    we warn the user."""
+    pairs = [
+        (policy.omb_policy_id, cleanup_string(xml, 'policyNum')),
+        (policy.title, cleanup_string(xml, 'subject')),
+        (policy.issuance, parse_published(xml)),
+    ]
+    for db_val, xml_val in pairs:
+        if db_val != xml_val:
+            logger.warning(
+                'Mismatch between XML and database. DB says %s, XML %s',
+                repr(db_val), repr(xml_val),
+            )
+
+
+def cleanup_string(xml: etree.ElementBase, tag_name: str):
+    return (xml.findtext(f".//{tag_name}") or '').strip()
+
+
+def parse_published(xml: etree.ElementBase):
+    published_txt = (xml.findtext('.//published') or '').strip()
+    try:
+        return dateutil_parser.parse(published_txt).date()
+    except ValueError:
+        logger.warning('Invalid XML published date: %s', published_txt)


### PR DESCRIPTION
We (currently) have two sources of metadata for a document: the document
itself and a Policy object in the database. Unfortunately, this allows for the
same data to be stored in two places (and potentially conflict). We should at
least warn the user when we see this happening.