### PR TITLE
Initial preamble display

### DIFF
--- a/api/document/serializers.py
+++ b/api/document/serializers.py
@@ -29,8 +29,8 @@ class PolicySerializer(serializers.ModelSerializer):
         fields = (
             'issuance',
             'omb_policy_id',
+            'original_url',
             'title',
-            'uri',
         )
 
 

--- a/api/document/tests/serializers_test.py
+++ b/api/document/tests/serializers_test.py
@@ -35,8 +35,8 @@ def test_end_to_end():
         'policy': {     # Note this field does not appear on children
             'issuance': '2001-02-03',
             'omb_policy_id': 'M-18-18',
+            'original_url': 'http://example.com/thing.pdf',
             'title': 'Some Title',
-            'uri': 'http://example.com/thing.pdf',
         },
         'children': [
             {

--- a/ui/__tests__/components/labeled-text.test.js
+++ b/ui/__tests__/components/labeled-text.test.js
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import LabeledText from '../../components/labeled-text';
+
+describe('<LabeledText />', () => {
+  const result = shallow(
+    <LabeledText id="an_id" label="Some Label">Text text</LabeledText>);
+  it('has an accessible id', () => {
+    expect(result.find('label').prop('htmlFor')).toBe('an_id');
+    expect(result.find('span').prop('id')).toBe('an_id');
+  });
+  it('displays a label', () => {
+    expect(result.find('label').text()).toBe('Some Label');
+  });
+  it('includes a span with the text', () => {
+    expect(result.find('span').text()).toBe('Text text');
+  });
+});

--- a/ui/__tests__/components/node-renderers/from.test.js
+++ b/ui/__tests__/components/node-renderers/from.test.js
@@ -1,0 +1,15 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import From from '../../../components/node-renderers/from';
+
+describe('<From />', () => {
+  it('prepares an appropriate LabeledText', () => {
+    const docNode = { marker: 'MmMm', text: 'Some text here' };
+    const result = shallow(<From docNode={docNode} />);
+    expect(result.name()).toEqual('LabeledText');
+    expect(result.prop('id')).toEqual('from');
+    expect(result.prop('label')).toEqual('MmMm');
+    expect(result.children().text()).toEqual('Some text here');
+  });
+});

--- a/ui/__tests__/components/node-renderers/policy.test.js
+++ b/ui/__tests__/components/node-renderers/policy.test.js
@@ -1,3 +1,6 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
 import Policy from '../../../components/node-renderers/policy';
 import {
   itIncludesTheIdentifier,
@@ -7,6 +10,54 @@ import {
 jest.mock('../../../util/render-node');
 
 describe('<Policy />', () => {
-  itIncludesTheIdentifier(Policy);
-  itRendersChildNodes(Policy);
+  const policy = {
+    issuance_pretty: 'March 3, 2003',
+    omb_policy_id: 'M-44-55',
+    original_url: 'http://example.com/thing.pdf',
+    title: 'Magistrate',
+  };
+  itIncludesTheIdentifier(Policy, { policy });
+  itRendersChildNodes(Policy, { policy });
+
+  it('uses the policy for default text', () => {
+    const docNode = {
+      children: [],
+      identifier: '',
+      policy,
+      text: '',
+    };
+    const result = shallow(<Policy docNode={docNode} />);
+    const text = result.text();
+    expect(text).toMatch(/M-44-55/);
+    expect(text).toMatch(/Magistrate/);
+    expect(text).toMatch(/March 3, 2003/);
+
+    expect(result.find('Link').first().prop('href')).toEqual(
+      'http://example.com/thing.pdf');
+  });
+  it('can grab text from subnodes', () => {
+    const docNode = {
+      children: [
+        { children: [], node_type: 'other', text: 'other-text' },
+        { children: [], node_type: 'subject', text: 'subject-here' },
+        { children: [], node_type: 'policyNum', text: 'some-m-number' },
+        { children: [], node_type: 'published', text: 'some date here' },
+        { children: [], node_type: 'policyTitle', text: 'a title!' },
+      ],
+      identifier: '',
+      policy,
+      text: '',
+    };
+
+    const result = shallow(<Policy docNode={docNode} />);
+    const text = result.text();
+    expect(text).not.toMatch(/M-44-55/);
+    expect(text).not.toMatch(/Magistrate/);
+    expect(text).not.toMatch(/March 3, 2003/);
+    expect(text).toMatch(/subject-here/);
+    expect(text).toMatch(/some-m-number/);
+    expect(text).toMatch(/some date here/);
+    expect(text).toMatch(/a title!/);
+    expect(text).not.toMatch(/other-text/); // not specifically searched for
+  });
 });

--- a/ui/__tests__/components/node-renderers/policy.test.js
+++ b/ui/__tests__/components/node-renderers/policy.test.js
@@ -30,10 +30,16 @@ describe('<Policy />', () => {
     const text = result.text();
     expect(text).toMatch(/M-44-55/);
     expect(text).toMatch(/Magistrate/);
-    expect(text).toMatch(/March 3, 2003/);
 
     expect(result.find('Link').first().prop('href')).toEqual(
       'http://example.com/thing.pdf');
+
+    expect(result.find('From')).toHaveLength(0);
+
+    const date = result.find('LabeledText').first();
+    expect(date.prop('id')).toEqual('issuance');
+    expect(date.prop('label')).toEqual('Issued on:');
+    expect(date.children().text()).toEqual('March 3, 2003');
   });
   it('can grab text from subnodes', () => {
     const docNode = {
@@ -43,6 +49,7 @@ describe('<Policy />', () => {
         { children: [], node_type: 'policyNum', text: 'some-m-number' },
         { children: [], node_type: 'published', text: 'some date here' },
         { children: [], node_type: 'policyTitle', text: 'a title!' },
+        { children: [], marker: 'Stuff:', node_type: 'from', text: 'Someone' },
       ],
       identifier: '',
       policy,
@@ -53,11 +60,15 @@ describe('<Policy />', () => {
     const text = result.text();
     expect(text).not.toMatch(/M-44-55/);
     expect(text).not.toMatch(/Magistrate/);
-    expect(text).not.toMatch(/March 3, 2003/);
     expect(text).toMatch(/subject-here/);
     expect(text).toMatch(/some-m-number/);
-    expect(text).toMatch(/some date here/);
     expect(text).toMatch(/a title!/);
     expect(text).not.toMatch(/other-text/); // not specifically searched for
+
+    const from = result.find('From').first();
+    expect(from.prop('docNode')).toEqual(docNode.children[5]);
+
+    const date = result.find('LabeledText').first();
+    expect(date.children().text()).toEqual('some date here');
   });
 });

--- a/ui/__tests__/test-utils/node-renderers.js
+++ b/ui/__tests__/test-utils/node-renderers.js
@@ -3,21 +3,27 @@ import React from 'react';
 
 import renderNode from '../../util/render-node';
 
-export function itIncludesTheIdentifier(Component) {
+export function itIncludesTheIdentifier(Component, extraAttrs) {
   it('includes the identifier', () => {
     const docNode = {
       children: [],
       identifier: 'aaa_1__bbb_2__ccc_3',
       marker: '',
+      ...(extraAttrs || {}),
     };
     const result = shallow(<Component docNode={docNode} />);
     expect(result.prop('id')).toBe('aaa_1__bbb_2__ccc_3');
   });
 }
 
-export function itIncludesNodeText(Component) {
+export function itIncludesNodeText(Component, extraAttrs) {
   it('includes node text', () => {
-    const docNode = { children: [], identifier: '', marker: '' };
+    const docNode = {
+      children: [],
+      identifier: '',
+      marker: '',
+      ...(extraAttrs || {}),
+    };
     const result = shallow(
       <Component docNode={docNode}>
         <span id="some-contents">Textextext</span>
@@ -30,7 +36,7 @@ export function itIncludesNodeText(Component) {
   });
 }
 
-export function itRendersChildNodes(Component) {
+export function itRendersChildNodes(Component, extraAttrs) {
   it('renders child nodes', () => {
     // renderNode must be mocked
     expect(renderNode.mock).not.toBeUndefined();
@@ -41,15 +47,19 @@ export function itRendersChildNodes(Component) {
       () => <child key="2">second child</child>);
 
     const docNode = {
-      children: [{ first: 'child' }, { second: 'child' }],
+      children: [
+        { children: [], node_type: 'first-child' },
+        { children: [], node_type: 'second-child' },
+      ],
       identifier: '',
       marker: '',
+      ...(extraAttrs || {}),
     };
     const result = shallow(<Component docNode={docNode} />);
     expect(result.text()).toMatch(/first child.*second child/);
     expect(result.find('child')).toHaveLength(2);
     expect(renderNode).toHaveBeenCalledTimes(2);
-    expect(renderNode.mock.calls[0][0]).toEqual({ first: 'child' });
-    expect(renderNode.mock.calls[1][0]).toEqual({ second: 'child' });
+    expect(renderNode.mock.calls[0][0].node_type).toEqual('first-child');
+    expect(renderNode.mock.calls[1][0].node_type).toEqual('second-child');
   });
 }

--- a/ui/__tests__/util/api/queries.test.js
+++ b/ui/__tests__/util/api/queries.test.js
@@ -159,13 +159,20 @@ describe('policyData()', () => {
 describe('documentData()', () => {
   beforeEach(() => {
     endpoints.document.fetchOne.mockImplementationOnce(
-      () => Promise.resolve({ data: 'here' }),
+      () => Promise.resolve({ policy: { issuance: '2012-12-12' } }),
     );
   });
   it('hits the correct url', async () => {
     const result = await documentData({ query: { policyId: '123' } });
     expect(endpoints.document.fetchOne).toHaveBeenCalledWith('123');
-    expect(result).toEqual({ docNode: { data: 'here' } });
+    expect(result).toEqual({
+      docNode: {
+        policy: {
+          issuance: '2012-12-12',
+          issuance_pretty: 'December 12, 2012',
+        },
+      },
+    });
   });
   it('passes up 404s', async () => {
     const err = new Error('Not found');

--- a/ui/__tests__/util/document-node.test.js
+++ b/ui/__tests__/util/document-node.test.js
@@ -1,0 +1,49 @@
+import { firstMatch, firstWithNodeType, linearize } from '../../util/document-node';
+
+const exampleNode = {
+  identifier: '1',
+  node_type: 'aaa',
+  children: [
+    { identifier: '2', node_type: 'bbb', children: [] },
+    {
+      identifier: '3',
+      node_type: 'aaa',
+      children: [{ identifier: '4', node_type: 'bbb', children: [] }],
+    },
+    { identifier: '5', node_type: 'ccc', children: [] },
+  ],
+};
+
+describe('linearize()', () => {
+  it('is recursive', () => {
+    const idents = linearize(exampleNode).map(d => d.identifier);
+    expect(idents).toEqual(['1', '2', '3', '4', '5']);
+  });
+});
+
+describe('firstMatch()', () => {
+  it('can match the root', () => {
+    const result = firstMatch(exampleNode, n => n.identifier === '1');
+    expect(result.identifier).toEqual('1');
+  });
+  it('is recursive', () => {
+    const result = firstMatch(exampleNode, n => n.identifier === '4');
+    expect(result.identifier).toEqual('4');
+  });
+  it('grabs only the first', () => {
+    const result = firstMatch(
+      exampleNode, n => parseInt(n.identifier, 10) % 2 === 0);
+    expect(result.identifier).toEqual('2');
+  });
+});
+
+describe('firstWithNodeType()', () => {
+  it('grabs only the first', () => {
+    const result = firstWithNodeType(exampleNode, 'bbb');
+    expect(result.identifier).toEqual('2');
+  });
+  it('returns null when there are no matches', () => {
+    const result = firstWithNodeType(exampleNode, 'doesnt-exist');
+    expect(result).toBeNull();
+  });
+});

--- a/ui/__tests__/util/render-node.test.js
+++ b/ui/__tests__/util/render-node.test.js
@@ -1,6 +1,7 @@
 import FootnoteCitation from '../../components/content-renderers/footnote-citation';
 import PlainText from '../../components/content-renderers/plain-text';
 import Fallback from '../../components/node-renderers/fallback';
+import Noop from '../../components/node-renderers/noop';
 import Paragraph from '../../components/node-renderers/para';
 import renderNode from '../../util/render-node';
 
@@ -64,5 +65,15 @@ describe('renderNode()', () => {
     expect(c3.type).toBe(FootnoteCitation);
     expect(c3.props.content).toEqual(docNode.content[3]);
   });
+  it('does not render preambles', () => {
+    const docNode = {
+      identifier: 'aaa_1__preamble_1',
+      node_type: 'preamble',
+      text: '',
+      content: [],
+      children: [],
+    };
+    const result = renderNode(docNode);
+    expect(result.type).toBe(Noop);
+  });
 });
-

--- a/ui/components/labeled-text.js
+++ b/ui/components/labeled-text.js
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default function LabeledText({ children, id, label }) {
+  return (
+    <div>
+      <label className="bold pr1" htmlFor={id}>{ label }</label>
+      <span id={id}>{ children }</span>
+    </div>
+  );
+}
+LabeledText.propTypes = {
+  children: PropTypes.node.isRequired,
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+};

--- a/ui/components/node-renderers/from.js
+++ b/ui/components/node-renderers/from.js
@@ -1,0 +1,18 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import LabeledText from '../labeled-text';
+
+export default function From({ docNode }) {
+  return (
+    <LabeledText id="from" label={docNode.marker}>
+      { docNode.text }
+    </LabeledText>
+  );
+}
+From.propTypes = {
+  docNode: PropTypes.shape({
+    marker: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/ui/components/node-renderers/noop.js
+++ b/ui/components/node-renderers/noop.js
@@ -1,0 +1,4 @@
+/* A component to avoid rendering content */
+export default function Noop() {
+  return null;
+}

--- a/ui/components/node-renderers/policy.js
+++ b/ui/components/node-renderers/policy.js
@@ -1,12 +1,38 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import { firstWithNodeType } from '../../util/document-node';
 import renderNode from '../../util/render-node';
+import Link from '../link';
+
+export function findNodeText(docNode, nodeType, modelValue) {
+  const containingNode = firstWithNodeType(docNode, nodeType);
+  if (containingNode && containingNode.text.length > 0) {
+    return containingNode.text;
+  }
+  return modelValue;
+}
 
 /* Root of a policy document */
 export default function Policy({ docNode }) {
   return (
     <div className="node-policy" id={docNode.identifier}>
+      <div className="clearfix">
+        <div className="bold">
+          { findNodeText(docNode, 'policyNum', docNode.policy.omb_policy_id) }
+        </div>
+        <div>{ findNodeText(docNode, 'policyTitle', '') }</div>
+        <h2 className="h1">
+          { findNodeText(docNode, 'subject', docNode.policy.title) }
+        </h2>
+        <div><Link href={docNode.policy.original_url}>See original</Link></div>
+        <div>
+          <label className="bold pr1" htmlFor="issuance">Issued on:</label>
+          <span id="issuance">
+            { findNodeText(docNode, 'published', docNode.policy.issuance_pretty) }
+          </span>
+        </div>
+      </div>
       { docNode.children.map(renderNode) }
     </div>
   );
@@ -15,5 +41,11 @@ Policy.propTypes = {
   docNode: PropTypes.shape({
     children: PropTypes.arrayOf(PropTypes.shape({})).isRequired, // recursive
     identifier: PropTypes.string.isRequired,
+    policy: PropTypes.shape({
+      issuance_pretty: PropTypes.string.isRequired,
+      omb_policy_id: PropTypes.string.isRequired,
+      original_url: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+    }).isRequired,
   }).isRequired,
 };

--- a/ui/components/node-renderers/policy.js
+++ b/ui/components/node-renderers/policy.js
@@ -3,9 +3,11 @@ import React from 'react';
 
 import { firstWithNodeType } from '../../util/document-node';
 import renderNode from '../../util/render-node';
+import LabeledText from '../labeled-text';
 import Link from '../link';
+import From from './from';
 
-export function findNodeText(docNode, nodeType, modelValue) {
+function findNodeText(docNode, nodeType, modelValue) {
   const containingNode = firstWithNodeType(docNode, nodeType);
   if (containingNode && containingNode.text.length > 0) {
     return containingNode.text;
@@ -13,8 +15,10 @@ export function findNodeText(docNode, nodeType, modelValue) {
   return modelValue;
 }
 
+
 /* Root of a policy document */
 export default function Policy({ docNode }) {
+  const fromNode = firstWithNodeType(docNode, 'from');
   return (
     <div className="node-policy" id={docNode.identifier}>
       <div className="clearfix">
@@ -26,12 +30,10 @@ export default function Policy({ docNode }) {
           { findNodeText(docNode, 'subject', docNode.policy.title) }
         </h2>
         <div><Link href={docNode.policy.original_url}>See original</Link></div>
-        <div>
-          <label className="bold pr1" htmlFor="issuance">Issued on:</label>
-          <span id="issuance">
-            { findNodeText(docNode, 'published', docNode.policy.issuance_pretty) }
-          </span>
-        </div>
+        { fromNode ? <From docNode={fromNode} /> : null }
+        <LabeledText id="issuance" label="Issued on:">
+          { findNodeText(docNode, 'published', docNode.policy.issuance_pretty) }
+        </LabeledText>
       </div>
       { docNode.children.map(renderNode) }
     </div>

--- a/ui/util/api/queries.js
+++ b/ui/util/api/queries.js
@@ -171,6 +171,7 @@ export async function policyData({ query }) {
 export async function documentData({ query }) {
   return propagate404(async () => {
     const docNode = await endpoints.document.fetchOne(query.policyId);
+    docNode.policy = formatIssuance(docNode.policy);
     return { docNode };
   });
 }

--- a/ui/util/document-node.js
+++ b/ui/util/document-node.js
@@ -1,0 +1,22 @@
+export function linearize(docNode) {
+  return docNode.children.reduce(
+    (soFar, nextNode) => soFar.concat(linearize(nextNode)), [docNode]);
+}
+
+export function firstMatch(docNode, filterFn) {
+  if (filterFn(docNode)) {
+    return docNode;
+  }
+  // Use for loop so we can short-circuit
+  for (let idx = 0; idx < docNode.children.length; idx += 1) {
+    const result = firstMatch(docNode.children[idx], filterFn);
+    if (result) {
+      return result;
+    }
+  }
+  return null;
+}
+
+export function firstWithNodeType(docNode, nodeType) {
+  return firstMatch(docNode, n => n.node_type === nodeType);
+}

--- a/ui/util/render-node.js
+++ b/ui/util/render-node.js
@@ -9,6 +9,7 @@ import heading from '../components/node-renderers/heading';
 import list from '../components/node-renderers/list';
 import listitem from '../components/node-renderers/list-item';
 import math from '../components/node-renderers/math';
+import Noop from '../components/node-renderers/noop';
 import para from '../components/node-renderers/para';
 import policy from '../components/node-renderers/policy';
 import sec from '../components/node-renderers/sec';
@@ -29,6 +30,7 @@ const nodeMapping = {
   math,
   para,
   policy,
+  preamble: Noop,
   sec,
   table,
   tbody,


### PR DESCRIPTION
Serving as a first step of the solution for #597, this adds a set of metadata fields to the top of a policy and hides the document's "preamble" (if present). This isn't well styled, but should be semantically okay. Easiest to review changeset-by-changeset

Along the way, it also:
* Allows a url like `/document/M-16-19`
* Fixes the pdf url from the document API
* Unstyles `sec` nodes

Looks like
<img width="608" alt="screen shot 2017-11-02 at 7 00 04 pm" src="https://user-images.githubusercontent.com/326918/32354430-0e21e01e-c000-11e7-9e95-5892c9f66fb9.png">

