### PR TITLE
Add temporary, simple footnote style.

### DIFF
--- a/ui/__tests__/components/node-renderers/footnote.test.js
+++ b/ui/__tests__/components/node-renderers/footnote.test.js
@@ -1,0 +1,25 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Footnote from '../../../components/node-renderers/footnote';
+
+describe('<Footnote />', () => {
+  const props = {
+    docNode: { identifier: 'aaa_1__bbb_2__ccc_3', marker: '8' },
+    renderedContent: [<span key="1">Textextext</span>],
+  };
+  it('includes the identifier', () => {
+    const result = shallow(<Footnote {...props} />);
+    expect(result.prop('id')).toBe('aaa_1__bbb_2__ccc_3');
+  });
+  it('includes node text', () => {
+    const paragraphs = shallow(<Footnote {...props} />).find('p');
+    expect(paragraphs).toHaveLength(1);
+    expect(paragraphs.first().text()).toBe('Textextext');
+  });
+  it('includes the marker', () => {
+    const marker = shallow(<Footnote {...props} />).children().first();
+    expect(marker.text()).toBe('8');
+  });
+});
+

--- a/ui/components/node-renderers/footnote.js
+++ b/ui/components/node-renderers/footnote.js
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default function Footnote({ docNode, renderedContent }) {
+  return (
+    <div className="clearfix node-footnote" id={docNode.identifier}>
+      <span className="bold col col-1 pr2 right-align">
+        { docNode.marker }
+      </span>
+      <p className="col col-11 m0 text">{ renderedContent }</p>
+    </div>
+  );
+}
+Footnote.propTypes = {
+  docNode: PropTypes.shape({
+    identifier: PropTypes.string.isRequired,
+    marker: PropTypes.string.isRequired,
+  }).isRequired,
+  renderedContent: PropTypes.node.isRequired,
+};

--- a/ui/css/main.scss
+++ b/ui/css/main.scss
@@ -30,3 +30,4 @@
 @import 'policies';
 @import 'homepage';
 @import 'loading-indicator';
+@import 'module/footnotes';

--- a/ui/css/module/_footnotes.scss
+++ b/ui/css/module/_footnotes.scss
@@ -1,0 +1,9 @@
+.node-footnote {
+  border-bottom: 1px solid $color-gray-dark;
+  border-top: 1px solid $color-gray-dark;
+  margin: 1em 2em;
+
+  .text {
+    color: $color-gray-medium;
+  }
+}

--- a/ui/pages/document.js
+++ b/ui/pages/document.js
@@ -5,6 +5,7 @@ import wrapPage from '../components/app-wrapper';
 import FootnoteCitation from '../components/content-renderers/footnote-citation';
 import PlainText from '../components/content-renderers/plain-text';
 import Fallback from '../components/node-renderers/fallback';
+import footnote from '../components/node-renderers/footnote';
 import heading from '../components/node-renderers/heading';
 import list from '../components/node-renderers/list';
 import listitem from '../components/node-renderers/list-item';
@@ -16,6 +17,7 @@ import { documentData } from '../util/api/queries';
 
 
 const nodeMapping = {
+  footnote,
   heading,
   list,
   listitem,


### PR DESCRIPTION
We won't be able to get the footnotes at the bottom of the page prior to demo.
In its stead, render a display that's at least evocative of the original
design.

Looks like
<img width="1177" alt="screen shot 2017-11-03 at 10 58 27 am" src="https://user-images.githubusercontent.com/326918/32380220-eb4e52bc-c085-11e7-8cb6-1e5092cadbea.png">
