### PR TITLE
Allow use of non-ints when looking up documents.

### DIFF
--- a/ui/routes.js
+++ b/ui/routes.js
@@ -6,7 +6,7 @@ const routes = Routes()
   .add('search-redirect', '/search-redirect/:lookup(agencies|policies|topics)', 'search-redirect')
   .add('policies')
   .add('policy', '/policy/:policyId/:reqId(\\d+)?', 'policy')
-  .add('document', '/document/:policyId(\\d+)', 'document')
+  .add('document', '/document/:policyId', 'document')
   .add('privacy')
   .add('requirements');
 


### PR DESCRIPTION
The API now allows documents to be looked up by their policy's M-number (and
soon, slug); allow that on the frontend as well.

This pulls out the only part of #606 that feels essential for demo