### PR TITLE
Remove the need to repeat policy in tree children.

### DIFF
--- a/api/document/tests/serializers_test.py
+++ b/api/document/tests/serializers_test.py
@@ -112,7 +112,7 @@ def test_requirement():
     policy = mommy.make(Policy)
     topics = [mommy.make(Topic, name='AaA'), mommy.make(Topic, name='BbB')]
     root = DocCursor.new_tree('policy', '1', policy=policy)
-    req_node = root.add_child('req', policy=policy)
+    req_node = root.add_child('req')
     root.nested_set_renumber()
     root.model.save()
     req_node.model.save()
@@ -157,8 +157,8 @@ def test_footnotes():
     policy = mommy.make(Policy)
     para = DocCursor.new_tree('para', '1', text='Some1 message2 here',
                               policy=policy)
-    footnote1 = para.add_child('footnote', policy=policy).model
-    footnote2 = para.add_child('footnote', policy=policy).model
+    footnote1 = para.add_child('footnote').model
+    footnote2 = para.add_child('footnote').model
     para.nested_set_renumber()
     DocNode.objects.bulk_create(n.model for n in para.walk())
     para.model.footnotecitations.create(

--- a/api/document/tests/views_test.py
+++ b/api/document/tests/views_test.py
@@ -17,7 +17,7 @@ from reqs.models import Policy, Requirement, Topic
 def test_404s(client):
     policy = mommy.make(Policy)
     root = DocCursor.new_tree('root', '0', policy=policy)
-    root.add_child('sect', policy=policy)
+    root.add_child('sect')
     root.nested_set_renumber()
     DocNode.objects.bulk_create(n.model for n in root.walk())
 
@@ -34,9 +34,9 @@ def test_404s(client):
 def test_correct_data(client):
     policy = mommy.make(Policy)
     root = DocCursor.new_tree('root', '0', policy=policy)
-    sect1 = root.add_child('sect', policy=policy)
-    root.add_child('sect', policy=policy)
-    sect1.add_child('par', 'a', policy=policy)
+    sect1 = root.add_child('sect')
+    root.add_child('sect')
+    sect1.add_child('par', 'a')
     root.nested_set_renumber()
     DocNode.objects.bulk_create(n.model for n in root.walk())
 

--- a/api/document/tests/xml_importer/annotations_test.py
+++ b/api/document/tests/xml_importer/annotations_test.py
@@ -17,9 +17,9 @@ def test_footnote_annotations():
     xml_span = etree.fromstring("<footnote_citation> 1  </footnote_citation>")
     root = DocCursor.new_tree('sect', '2', policy=policy)
     for _ in range(8):
-        root.add_child('para', policy=policy)
-    root['para_2'].add_child('footnote', '3', policy=policy)  # not 1
-    root['para_4'].add_child('footnote', '1', policy=policy)  # is 1
+        root.add_child('para')
+    root['para_2'].add_child('footnote', '3')  # not 1
+    root['para_4'].add_child('footnote', '1')  # is 1
     root.nested_set_renumber()
     DocNode.objects.bulk_create(n.model for n in root.walk())
 

--- a/api/document/tree.py
+++ b/api/document/tree.py
@@ -18,8 +18,10 @@ class DocCursor():
         self.identifier = identifier
 
     @classmethod
-    def new_tree(cls, node_type: str, type_emblem: str='1', **attrs):
-        tree = DiGraph()
+    def new_tree(cls, node_type: str, type_emblem: str='1', policy=None,
+                 **attrs):
+        attrs = {**attrs, 'policy': policy}
+        tree = DiGraph(policy=policy)
         identifier = f"{node_type}_{type_emblem}"
         tree.add_node(identifier, model=DocNode(
             identifier=identifier, node_type=node_type,
@@ -65,6 +67,8 @@ class DocCursor():
                   **attrs):
         if type_emblem is None:
             type_emblem = self.next_emblem(node_type)
+        if 'policy' not in attrs:
+            attrs = {**attrs, 'policy': self.tree.graph.get('policy')}
 
         identifier = f"{self.identifier}__{node_type}_{type_emblem}"
         self.tree.add_node(identifier, model=DocNode(


### PR DESCRIPTION
This resolves a minor annoyance around creating document trees. All nodes
within a single document should be associated with the same policy, yet we
needed to specify the policy for every node that we added.

This removes the redundancy by adding the policy as an attribute of the
underlying graph and using that whenever adding a new child node. It's still
possible to manually set the policy differently in a child (though I don't see
a use case).