### PR TITLE
Display footnotes at bottom of page

### DIFF
--- a/api/document/tests/serializers_test.py
+++ b/api/document/tests/serializers_test.py
@@ -22,7 +22,8 @@ def test_end_to_end():
     pa.add_child('par', '1', text='Paragraph (a)(1)', marker='(1)')
     sect2.add_child('par', 'b', marker='b.')
 
-    result = serializers.DocCursorSerializer(root).data
+    result = serializers.DocCursorSerializer(root,
+                                             context={'policy': policy}).data
     assert result == {
         'identifier': 'root_0',
         'node_type': 'root',
@@ -30,13 +31,15 @@ def test_end_to_end():
         'text': '',
         'marker': '',
         'depth': 0,
-        'requirement': None,
         'content': [],
-        'policy': {     # Note this field does not appear on children
-            'issuance': '2001-02-03',
-            'omb_policy_id': 'M-18-18',
-            'original_url': 'http://example.com/thing.pdf',
-            'title': 'Some Title',
+        'meta': {
+            'policy': {     # Note this field does not appear on children
+                'issuance': '2001-02-03',
+                'omb_policy_id': 'M-18-18',
+                'original_url': 'http://example.com/thing.pdf',
+                'title': 'Some Title',
+            },
+            'requirement': None,
         },
         'children': [
             {
@@ -46,7 +49,7 @@ def test_end_to_end():
                 'text': 'Section 1',
                 'marker': '',
                 'depth': 1,
-                'requirement': None,
+                'meta': {'requirement': None},
                 'content': [{
                     'content_type': '__text__',
                     'text': 'Section 1',
@@ -60,7 +63,7 @@ def test_end_to_end():
                 'text': '',
                 'marker': '',
                 'depth': 1,
-                'requirement': None,
+                'meta': {'requirement': None},
                 'content': [],
                 'children': [
                     {
@@ -70,7 +73,7 @@ def test_end_to_end():
                         'text': '',
                         'marker': '(a)',
                         'depth': 2,
-                        'requirement': None,
+                        'meta': {'requirement': None},
                         'content': [],
                         'children': [
                             {
@@ -80,7 +83,7 @@ def test_end_to_end():
                                 'text': 'Paragraph (a)(1)',
                                 'marker': '(1)',
                                 'depth': 3,
-                                'requirement': None,
+                                'meta': {'requirement': None},
                                 'content': [{
                                     'content_type': '__text__',
                                     'text': 'Paragraph (a)(1)',
@@ -96,7 +99,7 @@ def test_end_to_end():
                         'text': '',
                         'marker': 'b.',
                         'depth': 2,
-                        'requirement': None,
+                        'meta': {'requirement': None},
                         'content': [],
                         'children': [],
                     },
@@ -132,10 +135,11 @@ def test_requirement():
     )
     req_node.model.refresh_from_db()
 
-    result = serializers.DocCursorSerializer(root).data
-    assert result['requirement'] is None
+    result = serializers.DocCursorSerializer(root,
+                                             context={'policy': policy}).data
+    assert result['meta']['requirement'] is None
     child_node = result['children'][0]
-    assert child_node['requirement'] == {
+    assert child_node['meta']['requirement'] == {
         'citation': 'citcitcit',
         'impacted_entity': 'imp',
         'id': req.id,
@@ -167,7 +171,8 @@ def test_footnotes():
         start=len('Some1 message'), end=len('Some1 message2'),
         footnote_node=footnote2)
 
-    result = serializers.DocCursorSerializer(para).data
+    result = serializers.DocCursorSerializer(para,
+                                             context={'policy': policy}).data
     assert result['content'] == [
         {
             'content_type': '__text__',

--- a/api/document/tests/views_test.py
+++ b/api/document/tests/views_test.py
@@ -43,14 +43,15 @@ def test_correct_data(client):
     def result(url):
         return json.loads(client.get(url).content.decode('utf-8'))
 
-    assert result(f"/{policy.pk}") == DocCursorSerializer(root).data
-    assert result(f"/{policy.pk}/root_0") == DocCursorSerializer(root).data
-    assert result(f"/{policy.pk}/root_0__sect_1") \
-        == DocCursorSerializer(root['sect_1']).data
-    assert result(f"/{policy.pk}/root_0__sect_2") \
-        == DocCursorSerializer(root['sect_2']).data
+    def serialize(node):
+        return DocCursorSerializer(node, context={'policy': policy}).data
+
+    assert result(f"/{policy.pk}") == serialize(root)
+    assert result(f"/{policy.pk}/root_0") == serialize(root)
+    assert result(f"/{policy.pk}/root_0__sect_1") == serialize(root['sect_1'])
+    assert result(f"/{policy.pk}/root_0__sect_2") == serialize(root['sect_2'])
     assert result(f"/{policy.pk}/root_0__sect_1__par_a") \
-        == DocCursorSerializer(root['sect_1']['par_a']).data
+        == serialize(root['sect_1']['par_a'])
 
 
 @pytest.mark.django_db
@@ -63,7 +64,8 @@ def test_by_pretty_url(client):
 
     result = json.loads(client.get("/M-Something-18").content.decode("utf-8"))
 
-    assert result == DocCursorSerializer(root).data
+    assert result == DocCursorSerializer(root,
+                                         context={'policy': policy}).data
 
 
 @pytest.mark.django_db

--- a/ui/__tests__/components/node-renderers/policy.test.js
+++ b/ui/__tests__/components/node-renderers/policy.test.js
@@ -10,20 +10,22 @@ import {
 jest.mock('../../../util/render-node');
 
 describe('<Policy />', () => {
-  const policy = {
-    issuance_pretty: 'March 3, 2003',
-    omb_policy_id: 'M-44-55',
-    original_url: 'http://example.com/thing.pdf',
-    title: 'Magistrate',
+  const meta = {
+    policy: {
+      issuance_pretty: 'March 3, 2003',
+      omb_policy_id: 'M-44-55',
+      original_url: 'http://example.com/thing.pdf',
+      title: 'Magistrate',
+    },
   };
-  itIncludesTheIdentifier(Policy, { policy });
-  itRendersChildNodes(Policy, { policy });
+  itIncludesTheIdentifier(Policy, { meta });
+  itRendersChildNodes(Policy, { meta });
 
   it('uses the policy for default text', () => {
     const docNode = {
       children: [],
       identifier: '',
-      policy,
+      meta,
       text: '',
     };
     const result = shallow(<Policy docNode={docNode} />);
@@ -52,7 +54,7 @@ describe('<Policy />', () => {
         { children: [], marker: 'Stuff:', node_type: 'from', text: 'Someone' },
       ],
       identifier: '',
-      policy,
+      meta,
       text: '',
     };
 

--- a/ui/__tests__/components/node-renderers/policy.test.js
+++ b/ui/__tests__/components/node-renderers/policy.test.js
@@ -6,11 +6,13 @@ import {
   itIncludesTheIdentifier,
   itRendersChildNodes,
 } from '../../test-utils/node-renderers';
+import { renderContent } from '../../../util/render-node';
 
 jest.mock('../../../util/render-node');
 
 describe('<Policy />', () => {
   const meta = {
+    descendant_footnotes: [],
     policy: {
       issuance_pretty: 'March 3, 2003',
       omb_policy_id: 'M-44-55',
@@ -72,5 +74,31 @@ describe('<Policy />', () => {
 
     const date = result.find('LabeledText').first();
     expect(date.children().text()).toEqual('some date here');
+  });
+  it('renders footnotes at the bottom', () => {
+    const docNode = {
+      children: [],
+      identifier: '',
+      text: '',
+      meta: {
+        ...meta,
+        descendant_footnotes: [
+          { identifier: '1', children: [], content: ['a'], marker: '' },
+          { identifier: '2', children: [], content: ['b', 'c'], marker: '' },
+          { identifier: '3', children: [], content: [], marker: '' },
+        ],
+      },
+    };
+
+    const result = shallow(<Policy docNode={docNode} />);
+    const footnotes = result.find('.bottom-footnotes Footnote');
+    expect(footnotes).toHaveLength(3);
+    expect(footnotes.at(0).prop('docNode').identifier).toBe('1');
+    expect(footnotes.at(1).prop('docNode').identifier).toBe('2');
+    expect(footnotes.at(2).prop('docNode').identifier).toBe('3');
+    expect(renderContent).toHaveBeenCalledTimes(3);
+    expect(renderContent.mock.calls[0][0]).toEqual(['a']);
+    expect(renderContent.mock.calls[1][0]).toEqual(['b', 'c']);
+    expect(renderContent.mock.calls[2][0]).toEqual([]);
   });
 });

--- a/ui/__tests__/util/api/queries.test.js
+++ b/ui/__tests__/util/api/queries.test.js
@@ -159,7 +159,7 @@ describe('policyData()', () => {
 describe('documentData()', () => {
   beforeEach(() => {
     endpoints.document.fetchOne.mockImplementationOnce(
-      () => Promise.resolve({ policy: { issuance: '2012-12-12' } }),
+      async () => ({ meta: { policy: { issuance: '2012-12-12' } } }),
     );
   });
   it('hits the correct url', async () => {
@@ -167,9 +167,11 @@ describe('documentData()', () => {
     expect(endpoints.document.fetchOne).toHaveBeenCalledWith('123');
     expect(result).toEqual({
       docNode: {
-        policy: {
-          issuance: '2012-12-12',
-          issuance_pretty: 'December 12, 2012',
+        meta: {
+          policy: {
+            issuance: '2012-12-12',
+            issuance_pretty: 'December 12, 2012',
+          },
         },
       },
     });

--- a/ui/components/node-renderers/footnote.js
+++ b/ui/components/node-renderers/footnote.js
@@ -7,7 +7,7 @@ export default function Footnote({ children, docNode }) {
       <span className="bold col col-1 pr2 right-align">
         { docNode.marker }
       </span>
-      <p className="col col-11 m0 text">{ children }</p>
+      <p className="col col-11 m0 footnote-text">{ children }</p>
     </div>
   );
 }

--- a/ui/components/node-renderers/policy.js
+++ b/ui/components/node-renderers/policy.js
@@ -2,9 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { firstWithNodeType } from '../../util/document-node';
-import renderNode from '../../util/render-node';
+import renderNode, { renderContent } from '../../util/render-node';
 import LabeledText from '../labeled-text';
 import Link from '../link';
+import Footnote from './footnote';
 import From from './from';
 
 function findNodeText(docNode, nodeType, modelValue) {
@@ -13,6 +14,22 @@ function findNodeText(docNode, nodeType, modelValue) {
     return containingNode.text;
   }
   return modelValue;
+}
+
+function footnotes(footnoteList) {
+  if (footnoteList.length === 0) {
+    return null;
+  }
+  const rendered = footnoteList.map(fn => (
+    <Footnote key={fn.identifier} docNode={fn}>
+      { renderContent(fn.content) }
+    </Footnote>
+  ));
+  return (
+    <div className="bottom-footnotes">
+      { rendered }
+    </div>
+  );
 }
 
 
@@ -37,6 +54,7 @@ export default function Policy({ docNode }) {
         </LabeledText>
       </div>
       { docNode.children.map(renderNode) }
+      { footnotes(docNode.meta.descendant_footnotes) }
     </div>
   );
 }

--- a/ui/components/node-renderers/policy.js
+++ b/ui/components/node-renderers/policy.js
@@ -19,20 +19,21 @@ function findNodeText(docNode, nodeType, modelValue) {
 /* Root of a policy document */
 export default function Policy({ docNode }) {
   const fromNode = firstWithNodeType(docNode, 'from');
+  const policyMeta = docNode.meta.policy;
   return (
     <div className="node-policy" id={docNode.identifier}>
       <div className="clearfix">
         <div className="bold">
-          { findNodeText(docNode, 'policyNum', docNode.policy.omb_policy_id) }
+          { findNodeText(docNode, 'policyNum', policyMeta.omb_policy_id) }
         </div>
         <div>{ findNodeText(docNode, 'policyTitle', '') }</div>
         <h2 className="h1">
-          { findNodeText(docNode, 'subject', docNode.policy.title) }
+          { findNodeText(docNode, 'subject', policyMeta.title) }
         </h2>
-        <div><Link href={docNode.policy.original_url}>See original</Link></div>
+        <div><Link href={policyMeta.original_url}>See original</Link></div>
         { fromNode ? <From docNode={fromNode} /> : null }
         <LabeledText id="issuance" label="Issued on:">
-          { findNodeText(docNode, 'published', docNode.policy.issuance_pretty) }
+          { findNodeText(docNode, 'published', policyMeta.issuance_pretty) }
         </LabeledText>
       </div>
       { docNode.children.map(renderNode) }
@@ -43,11 +44,13 @@ Policy.propTypes = {
   docNode: PropTypes.shape({
     children: PropTypes.arrayOf(PropTypes.shape({})).isRequired, // recursive
     identifier: PropTypes.string.isRequired,
-    policy: PropTypes.shape({
-      issuance_pretty: PropTypes.string.isRequired,
-      omb_policy_id: PropTypes.string.isRequired,
-      original_url: PropTypes.string.isRequired,
-      title: PropTypes.string.isRequired,
+    meta: PropTypes.shape({
+      policy: PropTypes.shape({
+        issuance_pretty: PropTypes.string.isRequired,
+        omb_policy_id: PropTypes.string.isRequired,
+        original_url: PropTypes.string.isRequired,
+        title: PropTypes.string.isRequired,
+      }).isRequired,
     }).isRequired,
   }).isRequired,
 };

--- a/ui/css/module/_footnotes.scss
+++ b/ui/css/module/_footnotes.scss
@@ -12,12 +12,16 @@
   color: $color-white;
 }
 
-.node-footnote {
-  border-bottom: 1px solid $color-gray-dark;
+.bottom-footnotes {
   border-top: 1px solid $color-gray-dark;
-  margin: 1em 2em;
+  margin-top: 2.5em;
+  padding-top: .75em;
 
-  .text {
+  .node-footnote {
+    margin-bottom: .875em;
+  }
+
+  .footnote-text {
     color: $color-gray-medium;
   }
 }

--- a/ui/util/api/queries.js
+++ b/ui/util/api/queries.js
@@ -171,7 +171,8 @@ export async function policyData({ query }) {
 export async function documentData({ query }) {
   return propagate404(async () => {
     const docNode = await endpoints.document.fetchOne(query.policyId);
-    docNode.policy = formatIssuance(docNode.policy);
+    const policy = formatIssuance(docNode.meta.policy);
+    docNode.meta = { ...docNode.meta, policy };
     return { docNode };
   });
 }

--- a/ui/util/render-node.js
+++ b/ui/util/render-node.js
@@ -4,7 +4,6 @@ import FootnoteCitation from '../components/content-renderers/footnote-citation'
 import PlainText from '../components/content-renderers/plain-text';
 import Fallback from '../components/node-renderers/fallback';
 import caption from '../components/node-renderers/caption';
-import footnote from '../components/node-renderers/footnote';
 import heading from '../components/node-renderers/heading';
 import list from '../components/node-renderers/list';
 import listitem from '../components/node-renderers/list-item';
@@ -23,7 +22,7 @@ import th from '../components/node-renderers/th';
 
 const nodeMapping = {
   caption,
-  footnote,
+  footnote: Noop,
   heading,
   list,
   listitem,


### PR DESCRIPTION
This modifies the API to include footnotes in the `meta` data for the root of a document and any `table`s. It then uses that new data to display footnotes at the bottom of the `Policy` component. This should resolve a majority of #624, though we'll want a design review before closing.

## Looks like
(note that footnotes aren't displaying inline anymore)
<img width="716" alt="screen shot 2017-11-07 at 6 07 37 pm" src="https://user-images.githubusercontent.com/326918/32522751-91a93fba-c3e6-11e7-8ada-3e91292b5fb5.png"> 

---

<img width="804" alt="screen shot 2017-11-07 at 6 07 48 pm" src="https://user-images.githubusercontent.com/326918/32522750-9199a2ee-c3e6-11e7-82bb-9632f250ea06.png">

---

<img width="1203" alt="screen shot 2017-11-07 at 6 08 04 pm" src="https://user-images.githubusercontent.com/326918/32522749-91883298-c3e6-11e7-97c7-ff0a54417a49.png">

