### PR TITLE
Include footnote content in citation annotation

### DIFF
--- a/api/document/models.py
+++ b/api/document/models.py
@@ -1,5 +1,3 @@
-from abc import abstractmethod
-
 from collections_extended import RangeMap
 from django.db import models
 
@@ -81,32 +79,12 @@ class Annotation(models.Model):
     class Meta:
         abstract = True
 
-    @property
-    @abstractmethod
-    def content_type(self):
-        raise NotImplementedError()
-
-    def serialize_content(self, doc_node=None):
-        doc_node = doc_node or self.doc_node
-        return {
-            'content_type': self.content_type,
-            'text': doc_node.text[self.start:self.end],
-        }
-
 
 class PlainText(Annotation):
-    content_type = '__text__'
-
     class Meta:
         abstract = True
 
 
 class FootnoteCitation(Annotation):
-    content_type = 'footnote_citation'
     footnote_node = models.ForeignKey(
         DocNode, on_delete=models.CASCADE, related_name='+')
-
-    def serialize_content(self, doc_node=None):
-        result = super().serialize_content(doc_node)
-        result['footnote_node'] = self.footnote_node.identifier
-        return result

--- a/api/document/serializers.py
+++ b/api/document/serializers.py
@@ -1,8 +1,9 @@
+from functools import singledispatch
 from typing import NamedTuple
 
 from rest_framework import serializers
 
-from document.models import DocNode
+from document.models import Annotation, DocNode, FootnoteCitation, PlainText
 from document.tree import DocCursor
 from reqs.models import Policy, Requirement
 from reqs.serializers import TopicSerializer
@@ -90,6 +91,28 @@ class MetaSerializer(serializers.Serializer):
             return RequirementSerializer(instance.model.requirement).data
 
 
+@singledispatch
+def serialize_content(content: Annotation, cursor: DocCursor):
+    raise NotImplementedError()
+
+
+@serialize_content.register(PlainText)
+def serialize_plaintext(content: PlainText, cursor: DocCursor):
+    return {
+        'content_type': '__text__',
+        'text': cursor.model.text[content.start:content.end],
+    }
+
+
+@serialize_content.register(FootnoteCitation)
+def serialize_footnote_citation(content: FootnoteCitation, cursor: DocCursor):
+    return {
+        'content_type': 'footnote_citation',
+        'footnote_node': content.footnote_node.identifier,
+        'text': cursor.model.text[content.start:content.end],
+    }
+
+
 class DocCursorSerializer(serializers.ModelSerializer):
     children = serializers.SerializerMethodField()
     content = serializers.SerializerMethodField()
@@ -123,7 +146,8 @@ class DocCursorSerializer(serializers.ModelSerializer):
 
     def get_content(self, instance):
         """Include all annotations of the text."""
-        return [c.serialize_content(instance) for c in instance.content()]
+        cursor = self.context['cursor']
+        return [serialize_content(c, cursor) for c in instance.content()]
 
     def get_meta(self, instance):
         """Include meta data which applies to the whole node."""

--- a/api/document/serializers.py
+++ b/api/document/serializers.py
@@ -106,9 +106,12 @@ def serialize_plaintext(content: PlainText, cursor: DocCursor):
 
 @serialize_content.register(FootnoteCitation)
 def serialize_footnote_citation(content: FootnoteCitation, cursor: DocCursor):
+    footnote_tree = DocCursor(cursor.tree, content.footnote_node.identifier)
+    footnote_node = DocCursorSerializer(footnote_tree,
+                                        context={'is_root': False}).data
     return {
         'content_type': 'footnote_citation',
-        'footnote_node': content.footnote_node.identifier,
+        'footnote_node': footnote_node,
         'text': cursor.model.text[content.start:content.end],
     }
 

--- a/api/document/tests/serializers_test.py
+++ b/api/document/tests/serializers_test.py
@@ -180,14 +180,20 @@ def test_footnote_citations():
         }, {
             'content_type': 'footnote_citation',
             'text': '1',
-            'footnote_node': footnote1.identifier,
+            'footnote_node': serializers.DocCursorSerializer(
+                para['footnote_1'],
+                context={'policy': policy, 'is_root': False},
+            ).data,
         }, {
             'content_type': '__text__',
             'text': ' message',
         }, {
             'content_type': 'footnote_citation',
             'text': '2',
-            'footnote_node': footnote2.identifier,
+            'footnote_node': serializers.DocCursorSerializer(
+                para['footnote_2'],
+                context={'policy': policy, 'is_root': False},
+            ).data,
         }, {
             'content_type': '__text__',
             'text': ' here',

--- a/api/document/tests/views_test.py
+++ b/api/document/tests/views_test.py
@@ -87,10 +87,16 @@ def test_query_count(client):
             req.topics.add(mommy.make(Topic))
         req.docnode = req_node
         req.save()
-    # select 3 nodes as footnotes
-    for citing, footnote in zip(random.sample(subtree_nodes, 3),
-                                random.sample(subtree_nodes, 3)):
-        citing.footnotecitations.create(start=0, end=1, footnote_node=footnote)
+
+    # select 3 nodes to add footnote citations
+    citing_nodes = random.sample(list(root.walk()), 3)
+    footnotes = [citing.add_child('footnote') for citing in citing_nodes]
+    root.nested_set_renumber()
+    for node in root.walk():
+        node.model.save()
+    for citing, footnote in zip(citing_nodes, footnotes):
+        citing.model.footnotecitations.create(start=0, end=1,
+                                              footnote_node=footnote.model)
 
     # pytest will alter the connection, so we only want to load it within this
     # test

--- a/ui/__tests__/components/content-renderers/footnote-citation.test.js
+++ b/ui/__tests__/components/content-renderers/footnote-citation.test.js
@@ -6,13 +6,19 @@ import FootnoteCitation from '../../../components/content-renderers/footnote-cit
 
 describe('<FootnoteCitation />', () => {
   it('includes all of the text of the content', () => {
-    const content = { footnote_node: '', text: 'Some text here ' };
+    const content = {
+      footnote_node: { identifier: '' },
+      text: 'Some text here ',
+    };
     const text = mount(<FootnoteCitation content={content} />).text();
     expect(text).toMatch(/Some text here /);
     expect(text).toMatch(/Footnote /);
   });
   it('references the footnote node', () => {
-    const content = { footnote_node: 'aaa_1__bbb_2', text: '' };
+    const content = {
+      footnote_node: { identifier: 'aaa_1__bbb_2' },
+      text: '',
+    };
     const html = mount(<FootnoteCitation content={content} />).html();
     expect(html).toMatch(/aaa_1__bbb_2/);
   });

--- a/ui/__tests__/util/render-node.test.js
+++ b/ui/__tests__/util/render-node.test.js
@@ -40,13 +40,13 @@ describe('renderNode()', () => {
         { content_type: '__text__', text: 'Some highlighted' },
         {
           content_type: 'footnote_citation',
-          footnote_node: 'aaa_1__footnote_1',
+          footnote_node: { identifier: 'aaa_1__footnote_1' },
           text: '1',
         },
         { content_type: '__text__', text: ' text here' },
         {
           content_type: 'footnote_citation',
-          footnote_node: 'aaa_1__bbb_2__footnote_2',
+          footnote_node: { identifier: 'aaa_1__bbb_2__footnote_2' },
           text: '2',
         },
       ],

--- a/ui/components/content-renderers/footnote-citation.js
+++ b/ui/components/content-renderers/footnote-citation.js
@@ -5,12 +5,14 @@ import Link from '../link';
 
 
 export default function FootnoteCitation({ content }) {
-  const href = `#${content.footnote_node}`;
+  const href = `#${content.footnote_node.identifier}`;
   return <Link className="footnote-link" href={href}><sup>Footnote { content.text }</sup></Link>;
 }
 FootnoteCitation.propTypes = {
   content: PropTypes.shape({
-    footnote_node: PropTypes.string.isRequired,
+    footnote_node: PropTypes.shape({
+      identifier: PropTypes.string.isRequired,
+    }).isRequired,
     text: PropTypes.string.isRequired,
   }).isRequired,
 };


### PR DESCRIPTION
This extends the FootnoteCitation serialization to include the referenced node, which should make it easier to display (and lines up well with #629).

I hope @tadhg-ohiggins will enjoy the use of `singledispatch` over `abc`.