### PR TITLE
Refactor redundant node saves.

### DIFF
--- a/api/document/tests/serializers_test.py
+++ b/api/document/tests/serializers_test.py
@@ -4,7 +4,6 @@ import pytest
 from model_mommy import mommy
 
 from document import serializers
-from document.models import DocNode
 from document.tree import DocCursor
 from reqs.models import Policy, Requirement, Topic
 
@@ -117,8 +116,6 @@ def test_requirement():
     root = DocCursor.new_tree('policy', policy=policy)
     req_node = root.add_child('req')
     root.nested_set_renumber()
-    root.model.save()
-    req_node.model.save()
 
     req = mommy.make(
         Requirement,
@@ -164,7 +161,6 @@ def test_footnote_citations():
     footnote1 = para.add_child('footnote').model
     footnote2 = para.add_child('footnote').model
     para.nested_set_renumber()
-    DocNode.objects.bulk_create(n.model for n in para.walk())
     para.model.footnotecitations.create(
         start=len('Some'), end=len('Some1'), footnote_node=footnote1)
     para.model.footnotecitations.create(
@@ -230,7 +226,6 @@ def test_descendant_footnotes():
     root['list_1'].add_child('para')
     ftnt_c = root['list_1']['para_3'].add_child('footnote', 'c')
     root.nested_set_renumber()
-    DocNode.objects.bulk_create(node.model for node in root.walk())
 
     root['para_1'].model.footnotecitations.create(
         start=0, end=1, footnote_node=ftnt_a.model)

--- a/api/document/tests/tree_test.py
+++ b/api/document/tests/tree_test.py
@@ -95,7 +95,7 @@ def test_nested_sets():
     assert root.model.left is None
     assert root.model.right is None
 
-    root.nested_set_renumber()
+    root.nested_set_renumber(bulk_create=False)
 
     assert root.model.left == 1
     assert root['sect_1'].model.left == 2
@@ -142,7 +142,6 @@ def test_create_save_load():
     app1.add_child('apppar', 'i', text='Appendix par i')
 
     root.nested_set_renumber()
-    DocNode.objects.bulk_create(n.model for n in root.walk())
 
     assert DocNode.objects.count() == 7
     model_root = DocNode.objects.get(identifier='root_0')
@@ -158,7 +157,6 @@ def test_create_save_load():
 def test_add_models():
     """We can return to a tree structure from a sequence of models."""
     root = random_doc(15)
-    root.nested_set_renumber()
     models_created = [node.model for node in root.walk()]
     correct_order = [node.identifier for node in root.walk()]
 

--- a/api/document/tests/utils.py
+++ b/api/document/tests/utils.py
@@ -1,7 +1,6 @@
 import random
 from string import ascii_lowercase
 
-from document.models import DocNode
 from document.tree import DocCursor
 
 
@@ -27,7 +26,5 @@ def random_doc(num_nodes: int = 10, save: bool = False, cls=DocCursor,
             # Still need to add more nodes, start from the top again
             to_process = [root]
 
-    root.nested_set_renumber()
-    if save:
-        DocNode.objects.bulk_create(n.model for n in root.walk())
+    root.nested_set_renumber(bulk_create=save)
     return root

--- a/api/document/tests/xml_importer/annotations_test.py
+++ b/api/document/tests/xml_importer/annotations_test.py
@@ -4,7 +4,7 @@ import pytest
 from lxml import etree
 from model_mommy import mommy
 
-from document.models import DocNode, FootnoteCitation, PlainText
+from document.models import FootnoteCitation, PlainText
 from document.tests.utils import random_doc
 from document.tree import DocCursor, XMLAwareCursor
 from document.xml_importer import annotations
@@ -21,7 +21,6 @@ def test_footnote_annotations():
     root['para_2'].add_child('footnote', '3')  # not 1
     root['para_4'].add_child('footnote', '1')  # is 1
     root.nested_set_renumber()
-    DocNode.objects.bulk_create(n.model for n in root.walk())
 
     result = annotations.AnnotationHandler.footnote_citation(
         root, xml_span, 4)

--- a/api/document/xml_importer/importer.py
+++ b/api/document/xml_importer/importer.py
@@ -21,7 +21,6 @@ def import_xml_doc(policy: Policy, xml: etree.ElementBase):
 
     root = convert_to_tree(xml, policy=policy)
     root.nested_set_renumber()
-    DocNode.objects.bulk_create(n.model for n in root.walk())
     logger.info('Created %s nodes for %s', root.subtree_size(),
                 policy.title_with_number)
     annotations_by_cls = derive_annotations(root)


### PR DESCRIPTION
90% of the time when we re-number nodes in our document tree (to agree with
the nested-set model), we want to create them immediately afterwards. The
removes a chunk of redundancy by having the renumber method also save the
DocNodes.