### PR TITLE
Quick fix for katex.js rendering issues.

### DIFF
--- a/ui/components/node-renderers/math.js
+++ b/ui/components/node-renderers/math.js
@@ -5,9 +5,10 @@ import katex from 'katex';
 
 export default function TeXMath({ docNode }) {
   /* eslint-disable react/no-danger */
+  const math = katex.renderToString(docNode.text, { displayMode: true });
   return (
     <div id={docNode.identifier}>
-      <div dangerouslySetInnerHTML={{ __html: katex.renderToString(docNode.text) }} />
+      <div dangerouslySetInnerHTML={{ __html: math }} />
     </div>
   );
   /* eslint-enable react/no-danger */


### PR DESCRIPTION
It turns out we want `displayMode` to be `true`. Thanks @cmc333333 for helping find this!