### PR TITLE
Activate eslint import ordering plugin.

### DIFF
--- a/ui/.eslintrc
+++ b/ui/.eslintrc
@@ -18,6 +18,7 @@
     "no-unsafe-innerhtml/no-unsafe-innerhtml" : 2,
     "react/jsx-filename-extension": [1, {"extensions": [".js", ".jsx"]}],
     "import/no-named-as-default": 0,
+    "import/order": 2,
     "scanjs-rules/assign_to_hostname" : 2,
     "scanjs-rules/assign_to_href" : 2,
     "scanjs-rules/assign_to_location" : 2,

--- a/ui/__tests__/components/app-wrapper.test.js
+++ b/ui/__tests__/components/app-wrapper.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import wrapPage from '../../components/app-wrapper';
 
 

--- a/ui/__tests__/components/conditional-render.test.js
+++ b/ui/__tests__/components/conditional-render.test.js
@@ -1,6 +1,5 @@
 import { mount, shallow } from 'enzyme';
 import React from 'react';
-
 import ConditionalRender from '../../components/conditional-render';
 
 

--- a/ui/__tests__/components/contact-email.test.js
+++ b/ui/__tests__/components/contact-email.test.js
@@ -1,6 +1,5 @@
 import { mount } from 'enzyme';
 import React from 'react';
-
 import { email, ContactEmail } from '../../components/contact-email';
 
 const expr = `a[href="mailto:${email}"]`;

--- a/ui/__tests__/components/content-renderers/footnote-citation.test.js
+++ b/ui/__tests__/components/content-renderers/footnote-citation.test.js
@@ -1,6 +1,5 @@
 import { mount } from 'enzyme';
 import React from 'react';
-
 import FootnoteCitation from '../../../components/content-renderers/footnote-citation';
 
 

--- a/ui/__tests__/components/content-renderers/plain-text.test.js
+++ b/ui/__tests__/components/content-renderers/plain-text.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import PlainText from '../../../components/content-renderers/plain-text';
 
 

--- a/ui/__tests__/components/disclaimer.test.js
+++ b/ui/__tests__/components/disclaimer.test.js
@@ -1,8 +1,7 @@
 import { mount } from 'enzyme';
 import React from 'react';
-
-import Disclaimer from '../../components/disclaimer';
 import { email } from '../../components/contact-email';
+import Disclaimer from '../../components/disclaimer';
 
 describe('<Disclaimer />', () => {
   describe('returns the right contents', () => {

--- a/ui/__tests__/components/error.test.js
+++ b/ui/__tests__/components/error.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import ErrorView from '../../components/error';
 
 describe('<ErrorView />', () => {

--- a/ui/__tests__/components/errors/four-oh-four-error.test.js
+++ b/ui/__tests__/components/errors/four-oh-four-error.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import FourOhFour from '../../../components/errors/four-oh-four-error';
 
 describe('<FourOhFour />', () => {

--- a/ui/__tests__/components/errors/unexpected-error.test.js
+++ b/ui/__tests__/components/errors/unexpected-error.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import UnexpectedError from '../../../components/errors/unexpected-error';
 
 describe('<UnexpectedError />', () => {

--- a/ui/__tests__/components/errors/user-error.test.js
+++ b/ui/__tests__/components/errors/user-error.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import UserError from '../../../components/errors/user-error';
 
 describe('<UserError />', () => {

--- a/ui/__tests__/components/filters/existing-container.test.js
+++ b/ui/__tests__/components/filters/existing-container.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import ExistingFiltersContainer from '../../../components/filters/existing-container';
 
 describe('<ExistingFiltersContainer />', () => {

--- a/ui/__tests__/components/filters/fallback-view.test.js
+++ b/ui/__tests__/components/filters/fallback-view.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import FallbackView from '../../../components/filters/fallback-view';
 
 

--- a/ui/__tests__/components/filters/remove-link-container.test.js
+++ b/ui/__tests__/components/filters/remove-link-container.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import { RemoveLinkContainer } from '../../../components/filters/remove-link-container';
 
 describe('<RemoveLinkContainer />', () => {

--- a/ui/__tests__/components/filters/remove-search-container.test.js
+++ b/ui/__tests__/components/filters/remove-search-container.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import { RemoveSearchContainer } from '../../../components/filters/remove-search-container';
 
 describe('<RemoveSearchContainer />', () => {

--- a/ui/__tests__/components/filters/selector.test.js
+++ b/ui/__tests__/components/filters/selector.test.js
@@ -1,10 +1,8 @@
-
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import { Selector } from '../../../components/filters/selector';
-import * as queries from '../../../util/api/queries';
 import { Router } from '../../../routes';
+import * as queries from '../../../util/api/queries';
 
 jest.mock('../../../routes', () => ({ Router: { pushRoute: jest.fn() } }));
 jest.mock('../../../util/api/queries', () => ({

--- a/ui/__tests__/components/homepage/new-policy-view.test.js
+++ b/ui/__tests__/components/homepage/new-policy-view.test.js
@@ -1,6 +1,5 @@
 import { mount } from 'enzyme';
 import React from 'react';
-
 import NewPolicyView from '../../../components/homepage/new-policy-view';
 
 describe('<NewPolicyView />', () => {

--- a/ui/__tests__/components/homepage/topic-autocomplete.test.js
+++ b/ui/__tests__/components/homepage/topic-autocomplete.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import TopicAutocomplete from '../../../components/homepage/topic-autocomplete';
 
 describe('<TopicAutocomplete />', () => {

--- a/ui/__tests__/components/labeled-text.test.js
+++ b/ui/__tests__/components/labeled-text.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import LabeledText from '../../components/labeled-text';
 
 describe('<LabeledText />', () => {

--- a/ui/__tests__/components/link.test.js
+++ b/ui/__tests__/components/link.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import Link from '../../components/link';
 
 jest.mock('../../routes', () => ({

--- a/ui/__tests__/components/navbar.test.js
+++ b/ui/__tests__/components/navbar.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import Navbar from '../../components/navbar';
 import SearchContainer from '../../components/search/search';
 

--- a/ui/__tests__/components/node-renderers/fallback.test.js
+++ b/ui/__tests__/components/node-renderers/fallback.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import Fallback from '../../../components/node-renderers/fallback';
 import renderNode from '../../../util/render-node';
 

--- a/ui/__tests__/components/node-renderers/footnote.test.js
+++ b/ui/__tests__/components/node-renderers/footnote.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import Footnote from '../../../components/node-renderers/footnote';
 import {
   itIncludesNodeText,

--- a/ui/__tests__/components/node-renderers/from.test.js
+++ b/ui/__tests__/components/node-renderers/from.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import From from '../../../components/node-renderers/from';
 
 describe('<From />', () => {

--- a/ui/__tests__/components/node-renderers/heading.test.js
+++ b/ui/__tests__/components/node-renderers/heading.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import Heading from '../../../components/node-renderers/heading';
 import {
   itIncludesNodeText,

--- a/ui/__tests__/components/node-renderers/list-item.test.js
+++ b/ui/__tests__/components/node-renderers/list-item.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import ListItem from '../../../components/node-renderers/list-item';
 import {
   itIncludesTheIdentifier,

--- a/ui/__tests__/components/node-renderers/policy.test.js
+++ b/ui/__tests__/components/node-renderers/policy.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import Policy from '../../../components/node-renderers/policy';
 import {
   itIncludesTheIdentifier,

--- a/ui/__tests__/components/page-counter.test.js
+++ b/ui/__tests__/components/page-counter.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import PageCounter from '../../components/page-counter';
 
 

--- a/ui/__tests__/components/pagers.test.js
+++ b/ui/__tests__/components/pagers.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import { Pagers } from '../../components/pagers';
 
 function pagerArgs(count, query = null) {

--- a/ui/__tests__/components/policy/req.test.js
+++ b/ui/__tests__/components/policy/req.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import Req from '../../../components/policy/req';
 
 describe('<Req />', () => {

--- a/ui/__tests__/components/requirements/metadata.test.js
+++ b/ui/__tests__/components/requirements/metadata.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import Metadata from '../../../components/requirements/metadata';
 
 describe('<Metadata />', () => {

--- a/ui/__tests__/components/requirements/policy-link.test.js
+++ b/ui/__tests__/components/requirements/policy-link.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import PolicyLink from '../../../components/requirements/policy-link';
 
 describe('<PolicyLink />', () => {

--- a/ui/__tests__/components/requirements/requirements.test.js
+++ b/ui/__tests__/components/requirements/requirements.test.js
@@ -1,6 +1,5 @@
 import { mount } from 'enzyme';
 import React from 'react';
-
 import Requirement from '../../../components/requirements/requirement';
 
 describe('<Requirement />', () => {

--- a/ui/__tests__/components/requirements/topic-link.test.js
+++ b/ui/__tests__/components/requirements/topic-link.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import TopicLink from '../../../components/requirements/topic-link';
 
 describe('<TopicLink />', () => {

--- a/ui/__tests__/components/search/search.test.js
+++ b/ui/__tests__/components/search/search.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import { Search } from '../../../components/search/search';
 
 const blankRouter = { pathname: '', query: {} };

--- a/ui/__tests__/components/thing-counters.test.js
+++ b/ui/__tests__/components/thing-counters.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import { ThingCounter } from '../../components/thing-counters';
 
 function makeReqThing(count, query = null) {

--- a/ui/__tests__/pages/policies.test.js
+++ b/ui/__tests__/pages/policies.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import { PoliciesContainer } from '../../pages/policies';
 
 describe('<PoliciesContainer />', () => {

--- a/ui/__tests__/pages/policy.test.js
+++ b/ui/__tests__/pages/policy.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import { Policy } from '../../pages/policy';
 import { Router } from '../../routes';
 

--- a/ui/__tests__/pages/privacy.test.js
+++ b/ui/__tests__/pages/privacy.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import { PrivacyView } from '../../pages/privacy';
 
 

--- a/ui/__tests__/pages/requirements.test.js
+++ b/ui/__tests__/pages/requirements.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import { PoliciesTab, RequirementsContainer } from '../../pages/requirements';
 
 describe('<RequirementsContainer />', () => {

--- a/ui/__tests__/pages/search-redirect.test.js
+++ b/ui/__tests__/pages/search-redirect.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import { SearchRedirect } from '../../pages/search-redirect';
 
 describe('<SearchRedirect />', () => {

--- a/ui/__tests__/test-utils/node-renderers.js
+++ b/ui/__tests__/test-utils/node-renderers.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-
 import renderNode from '../../util/render-node';
 
 export function itIncludesTheIdentifier(Component, extraAttrs) {

--- a/ui/__tests__/util/api/endpoints.test.js
+++ b/ui/__tests__/util/api/endpoints.test.js
@@ -1,5 +1,4 @@
 import axios from 'axios';
-
 import { Endpoint } from '../../../util/api/endpoints';
 
 jest.mock('axios');

--- a/ui/components/app-wrapper.js
+++ b/ui/components/app-wrapper.js
@@ -2,7 +2,6 @@ import Router from 'next/router';
 import NProgress from 'nprogress';
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import ErrorView from './error';
 import HeaderFooter from './header-footer';
 

--- a/ui/components/contact-email.js
+++ b/ui/components/contact-email.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import Link from './link';
 
 export const email = 'PolicyLibrary@omb.eop.gov';

--- a/ui/components/content-renderers/footnote-citation.js
+++ b/ui/components/content-renderers/footnote-citation.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import Link from '../link';
 
 

--- a/ui/components/disclaimer.js
+++ b/ui/components/disclaimer.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import { ContactEmail } from './contact-email';
 
 export default function Disclaimer() {

--- a/ui/components/error.js
+++ b/ui/components/error.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import FourOhFour from './errors/four-oh-four-error';
 import UnexpectedError from './errors/unexpected-error';
 import UserError from './errors/user-error';

--- a/ui/components/errors/four-oh-four-error.js
+++ b/ui/components/errors/four-oh-four-error.js
@@ -1,8 +1,7 @@
 import React from 'react';
-
 import { ContactEmail } from '../contact-email';
-import Link from '../link';
 import HeaderFooter from '../header-footer';
+import Link from '../link';
 
 
 export default function FourOhFour() {

--- a/ui/components/errors/unexpected-error.js
+++ b/ui/components/errors/unexpected-error.js
@@ -1,7 +1,6 @@
 import HTTPStatus from 'http-status';
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import { ContactEmail } from '../contact-email';
 
 /* Note that we intentionally avoid "Link" to minimize sources of error */

--- a/ui/components/errors/user-error.js
+++ b/ui/components/errors/user-error.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import HeaderFooter from '../header-footer';
 import Link from '../link';
 

--- a/ui/components/filters/existing-container.js
+++ b/ui/components/filters/existing-container.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 /* eslint-disable import/no-named-as-default */
 import RemoveLinkContainer from './remove-link-container';
 import RemoveSearchContainer from './remove-search-container';

--- a/ui/components/filters/remove-link-container.js
+++ b/ui/components/filters/remove-link-container.js
@@ -1,7 +1,6 @@
 import { withRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import FilterRemoveView from './remove-view';
 
 export function RemoveLinkContainer({ existing, field, heading, idToRemove, name, route, router }) {

--- a/ui/components/filters/remove-search-container.js
+++ b/ui/components/filters/remove-search-container.js
@@ -1,7 +1,6 @@
 import { withRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import FilterRemoveView from './remove-view';
 
 export function RemoveSearchContainer({ field, route, router }) {

--- a/ui/components/filters/remove-view.js
+++ b/ui/components/filters/remove-view.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import Link from '../link';
 
 export default function FilterRemoveView({ heading, name, params, route }) {

--- a/ui/components/filters/selector.js
+++ b/ui/components/filters/selector.js
@@ -2,12 +2,11 @@ import { withRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Async } from 'react-select';
-
-import FallbackView from './fallback-view';
 import ConditionalRender from '../conditional-render';
 import { apiNameField, makeOptionLoader } from '../../lookup-search';
-import { redirectQuery } from '../../util/api/queries';
 import { Router } from '../../routes';
+import { redirectQuery } from '../../util/api/queries';
+import FallbackView from './fallback-view';
 
 
 export function Selector(props) {

--- a/ui/components/footer.js
+++ b/ui/components/footer.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import { ContactEmail } from './contact-email';
 import Link from './link';
 

--- a/ui/components/header-footer.js
+++ b/ui/components/header-footer.js
@@ -1,7 +1,6 @@
 import Head from 'next/head';
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import Disclaimer from './disclaimer';
 import Navbar from './navbar';
 import Footer from './footer';

--- a/ui/components/homepage/topic-autocomplete.js
+++ b/ui/components/homepage/topic-autocomplete.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Async } from 'react-select';
-
 import { makeOptionLoader } from '../../lookup-search';
 
 

--- a/ui/components/link.js
+++ b/ui/components/link.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import { Link as RouterLink, routes } from '../routes';
 
 export default function Link({ children, href, params, route, ...otherProps }) {

--- a/ui/components/navbar.js
+++ b/ui/components/navbar.js
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
-
 import React from 'react';
-import Search from './search/search';
 import Link from './link';
+import Search from './search/search';
 
 export default function Navbar({ showSearch }) {
   let searchContainer;

--- a/ui/components/node-renderers/caption.js
+++ b/ui/components/node-renderers/caption.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import renderNode from '../../util/render-node';
 
 export default function Caption({ children, docNode }) {

--- a/ui/components/node-renderers/fallback.js
+++ b/ui/components/node-renderers/fallback.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import renderNode from '../../util/render-node';
 
 /* We've been asked to render a node we don't have a renderer for. We'll do

--- a/ui/components/node-renderers/from.js
+++ b/ui/components/node-renderers/from.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import LabeledText from '../labeled-text';
 
 export default function From({ docNode }) {

--- a/ui/components/node-renderers/list-item.js
+++ b/ui/components/node-renderers/list-item.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import renderNode from '../../util/render-node';
 
 export default function ListItem({ docNode }) {

--- a/ui/components/node-renderers/list.js
+++ b/ui/components/node-renderers/list.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import renderNode from '../../util/render-node';
 
 export default function List({ docNode }) {

--- a/ui/components/node-renderers/math.js
+++ b/ui/components/node-renderers/math.js
@@ -1,6 +1,6 @@
+import katex from 'katex';
 import PropTypes from 'prop-types';
 import React from 'react';
-import katex from 'katex';
 
 
 export default function TeXMath({ docNode }) {

--- a/ui/components/node-renderers/para.js
+++ b/ui/components/node-renderers/para.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import renderNode from '../../util/render-node';
 
 /* Paragraph of text */

--- a/ui/components/node-renderers/policy.js
+++ b/ui/components/node-renderers/policy.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import { firstWithNodeType } from '../../util/document-node';
 import renderNode, { renderContent } from '../../util/render-node';
 import LabeledText from '../labeled-text';

--- a/ui/components/node-renderers/sec.js
+++ b/ui/components/node-renderers/sec.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import renderNode from '../../util/render-node';
 
 /* Uses indentation and border to indicate separate sections */

--- a/ui/components/node-renderers/table.js
+++ b/ui/components/node-renderers/table.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import renderNode from '../../util/render-node';
 
 export default function Table({ docNode }) {

--- a/ui/components/node-renderers/tbody.js
+++ b/ui/components/node-renderers/tbody.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import renderNode from '../../util/render-node';
 
 export default function Tbody({ docNode }) {

--- a/ui/components/node-renderers/td.js
+++ b/ui/components/node-renderers/td.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import renderNode from '../../util/render-node';
 
 export default function Td({ children, docNode }) {

--- a/ui/components/node-renderers/th.js
+++ b/ui/components/node-renderers/th.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import renderNode from '../../util/render-node';
 
 export default function Th({ children, docNode }) {

--- a/ui/components/node-renderers/thead.js
+++ b/ui/components/node-renderers/thead.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import renderNode from '../../util/render-node';
 
 export default function Thead({ docNode }) {

--- a/ui/components/node-renderers/tr.js
+++ b/ui/components/node-renderers/tr.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import renderNode from '../../util/render-node';
 
 export default function Tr({ docNode }) {

--- a/ui/components/pagers.js
+++ b/ui/components/pagers.js
@@ -1,7 +1,6 @@
 import { withRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import Link from './link';
 
 export function Pagers({ count, route, router }) {

--- a/ui/components/policies/policies-view.js
+++ b/ui/components/policies/policies-view.js
@@ -1,9 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import PagersContainer from '../pagers';
-import Policy from './policy-view';
 import ThingCounterContainer from '../thing-counters';
+import Policy from './policy-view';
 
 export default function PoliciesView({ policies, count, topicsIds }) {
   const singular = 'policy';

--- a/ui/components/policies/policy-view.js
+++ b/ui/components/policies/policy-view.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import Link from '../link';
 
 export default function Policy({ policy, topicsIds }) {

--- a/ui/components/policy/req.js
+++ b/ui/components/policy/req.js
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
-import { filterAppliesTo } from '../requirements/requirement';
 import Metadata from '../requirements/metadata';
+import { filterAppliesTo } from '../requirements/requirement';
 import TopicLink from '../requirements/topic-link';
 
 export default function Req({ highlighted, href, onClick, req }) {

--- a/ui/components/requirements/policy-link.js
+++ b/ui/components/requirements/policy-link.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import Link from '../link';
 
 export function policyLinkTag(policy) {

--- a/ui/components/requirements/requirement.js
+++ b/ui/components/requirements/requirement.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import Metadata from './metadata';
 import PolicyLink from './policy-link';
 import TopicLink from './topic-link';

--- a/ui/components/requirements/requirements-view.js
+++ b/ui/components/requirements/requirements-view.js
@@ -1,9 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
-import Requirement from './requirement';
 import PagersContainer from '../pagers';
 import ThingCounterContainer from '../thing-counters';
+import Requirement from './requirement';
 
 export default function RequirementsView({ requirements, count }) {
   const singular = 'requirement';

--- a/ui/components/requirements/topic-link.js
+++ b/ui/components/requirements/topic-link.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import Link from '../link';
 
 export default function TopicLink({ topic }) {

--- a/ui/components/search/search.js
+++ b/ui/components/search/search.js
@@ -1,7 +1,6 @@
 import { withRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import routes from '../../routes';
 
 const defaultRoute = 'policies';

--- a/ui/components/tab-view.js
+++ b/ui/components/tab-view.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import Link from './link';
 
 export default function TabView({ active, params, route, tabName }) {

--- a/ui/pages/_error.js
+++ b/ui/pages/_error.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import ErrorView from '../components/error';
 
 export default function ErrorPage({ err, statusCode }) {

--- a/ui/pages/document.js
+++ b/ui/pages/document.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-
 import wrapPage from '../components/app-wrapper';
 import { documentData } from '../util/api/queries';
 import renderNode from '../util/render-node';

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -1,9 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import wrapPage from '../components/app-wrapper';
-import NewPolicyView from '../components/homepage/new-policy-view';
 import { ContactEmail } from '../components/contact-email';
+import NewPolicyView from '../components/homepage/new-policy-view';
 import Link from '../components/link';
 import Search from '../components/search/search';
 import { homepageData } from '../util/api/queries';

--- a/ui/pages/policies.js
+++ b/ui/pages/policies.js
@@ -1,12 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import wrapPage from '../components/app-wrapper';
-import PoliciesView from '../components/policies/policies-view';
-import SearchFilterView from '../components/search-filter-view';
 import ExistingFilters from '../components/filters/existing-container';
 import FilterListView from '../components/filters/list-view';
 import SelectorContainer from '../components/filters/selector';
+import PoliciesView from '../components/policies/policies-view';
+import SearchFilterView from '../components/search-filter-view';
 import { policiesData } from '../util/api/queries';
 
 const fieldNames = {

--- a/ui/pages/policy.js
+++ b/ui/pages/policy.js
@@ -1,12 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import wrapPage from '../components/app-wrapper';
-import Pagers from '../components/pagers';
-import { policyData } from '../util/api/queries';
-import { Router } from '../routes';
 import PageCounter from '../components/page-counter';
+import Pagers from '../components/pagers';
 import Req from '../components/policy/req';
+import { Router } from '../routes';
+import { policyData } from '../util/api/queries';
 
 
 export class Policy extends React.Component {

--- a/ui/pages/privacy.js
+++ b/ui/pages/privacy.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import { email, ContactEmail } from '../components/contact-email';
 import HeaderFooter from '../components/header-footer';
 import Link from '../components/link';

--- a/ui/pages/requirements.js
+++ b/ui/pages/requirements.js
@@ -1,14 +1,13 @@
 import { withRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import wrapPage from '../components/app-wrapper';
-import RequirementsView from '../components/requirements/requirements-view';
-import SearchFilterView from '../components/search-filter-view';
-import TabView from '../components/tab-view';
 import ExistingFilters from '../components/filters/existing-container';
 import FilterListView from '../components/filters/list-view';
 import SelectorContainer from '../components/filters/selector';
+import RequirementsView from '../components/requirements/requirements-view';
+import SearchFilterView from '../components/search-filter-view';
+import TabView from '../components/tab-view';
 import { requirementsData } from '../util/api/queries';
 
 export function PoliciesTab({ router }) {

--- a/ui/pages/search-redirect.js
+++ b/ui/pages/search-redirect.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import wrapPage from '../components/app-wrapper';
 import Link from '../components/link';
 import PagersContainer from '../components/pagers';

--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -7,10 +7,9 @@ const helmet = require('helmet');
 const morgan = require('morgan');
 const next = require('next');
 const passport = require('passport');
-
+const routes = require('../routes');
 const setupAuth = require('./auth').default;
 const doNotCache = require('./do-not-cache');
-const routes = require('../routes');
 
 const expressApp = express();
 const nextApp = next({ dev: process.env.NODE_ENV !== 'production' });

--- a/ui/util/api/queries.js
+++ b/ui/util/api/queries.js
@@ -1,10 +1,9 @@
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import validator from 'validator';
-
-import endpoints from './endpoints';
 import { apiNameField, search } from '../../lookup-search';
 import { routes } from '../../routes';
+import endpoints from './endpoints';
 
 const NUM_POLICIES = 4;
 // See https://momentjs.com/docs/#/displaying/ for options

--- a/ui/util/render-node.js
+++ b/ui/util/render-node.js
@@ -1,9 +1,8 @@
 import React from 'react';
-
 import FootnoteCitation from '../components/content-renderers/footnote-citation';
 import PlainText from '../components/content-renderers/plain-text';
-import Fallback from '../components/node-renderers/fallback';
 import caption from '../components/node-renderers/caption';
+import Fallback from '../components/node-renderers/fallback';
 import heading from '../components/node-renderers/heading';
 import list from '../components/node-renderers/list';
 import listitem from '../components/node-renderers/list-item';
@@ -14,10 +13,10 @@ import policy from '../components/node-renderers/policy';
 import sec from '../components/node-renderers/sec';
 import table from '../components/node-renderers/table';
 import tbody from '../components/node-renderers/tbody';
-import thead from '../components/node-renderers/thead';
 import td from '../components/node-renderers/td';
-import tr from '../components/node-renderers/tr';
 import th from '../components/node-renderers/th';
+import thead from '../components/node-renderers/thead';
+import tr from '../components/node-renderers/tr';
 
 
 const nodeMapping = {

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 


### PR DESCRIPTION
The plugin *doesn't* make demands about import order within a "group" (e.g.
builtins, external libs, parent, etc.), but does demand those groups be in a
particular order. It also discourages newlines between groups.