### PR TITLE
Fix renderContent import.

### DIFF
--- a/ui/components/content-renderers/footnote-citation.js
+++ b/ui/components/content-renderers/footnote-citation.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import renderContent from '../../util/render-node';
+import { renderContent } from '../../util/render-node';
 
 import Footnote from '../node-renderers/footnote';
 import Link from '../link';


### PR DESCRIPTION
The `render-node` module exports `renderNode` by default.