### PR TITLE
Enable webpack dev middleware polling if USE_POLLING is set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,23 @@ There are two types of entry points:
 
 ### Resolving common container issues
 
+#### Bundles aren't being rebuilt when I change them
+
+Try setting `USE_POLLING=true`, either in your host shell environment, or
+via an [`.env` file](https://docs.docker.com/compose/env-file/). This will
+force all the watchers to use filesystem polling instead of OS notifications,
+which works better on some platforms, such as Windows.
+
+#### Conflicting ports
+
 If you see an error about a conflicting port, try spinning down the running
 services (including those associated with integration tests).
 ```sh
 docker-compose down
 docker-compose -p integration_tests down
 ```
+
+#### Restarting from scratch
 
 If all it lost and you want to start from scratch, run
 ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,7 @@ services:
       PORT: 8002
       NODE_ENV: development
       API_URL: 'http://localhost:8001/'
+      USE_POLLING: $USE_POLLING
       VCAP_SERVICES: >
         {"config": [{"name": "config", "credentials": {"UI_BASIC_AUTH": {
         }}}]}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   # This service is a shared network stack (i.e. shared "localhost") for all
   # external-facing services. It allows "localhost" links to work correctly
@@ -99,7 +99,7 @@ services:
       PORT: 8002
       NODE_ENV: development
       API_URL: 'http://localhost:8001/'
-      USE_POLLING: $USE_POLLING
+      USE_POLLING: ${USE_POLLING:-false}
       VCAP_SERVICES: >
         {"config": [{"name": "config", "credentials": {"UI_BASIC_AUTH": {
         }}}]}

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -14,10 +14,12 @@ module.exports = {
     return config;
   },
   webpackDevMiddleware: (config) => {
-    if (process.env.USE_POLLING) {
-      config.watchOptions = {
-        poll: true
-      };
+    if (process.env.USE_POLLING === 'true') {
+      Object.assign(config, {
+        watchOptions: {
+          poll: true,
+        },
+      });
     }
 
     return config;

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -13,4 +13,13 @@ module.exports = {
     }));
     return config;
   },
+  webpackDevMiddleware: (config) => {
+    if (process.env.USE_POLLING) {
+      config.watchOptions = {
+        poll: true
+      };
+    }
+
+    return config;
+  },
 };

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -32,8 +32,8 @@ module.exports = [
   },
 ];
 
-if (process.env.USE_POLLING) {
+if (process.env.USE_POLLING === 'true') {
   module.exports[0].watchOptions = {
-    poll: true
+    poll: true,
   };
 }

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -31,3 +31,9 @@ module.exports = [
     plugins: [new ExtractTextPlugin('styles.css')],
   },
 ];
+
+if (process.env.USE_POLLING) {
+  module.exports[0].watchOptions = {
+    poll: true
+  };
+}


### PR DESCRIPTION
Some docker setups, such as Windows, don't notify processes of changes to the filesystem like Linux does, so we need to use polling.

This detects if `USE_POLLING` is set in the host environment, and if so, configures webpack's dev middleware to use it (both in next.js and the CSS webpack process).

To do:
- [x] Document `USE_POLLING` in the readme.
