### PR TITLE
Convert node fns to OO, add table footnotes

### DIFF
--- a/ui/__tests__/components/node-renderers/policy.test.js
+++ b/ui/__tests__/components/node-renderers/policy.test.js
@@ -6,6 +6,7 @@ import {
   itIncludesTheIdentifier,
   itRendersChildNodes,
 } from '../../test-utils/node-renderers';
+import DocumentNode from '../../../util/document-node';
 import { renderContent } from '../../../util/render-node';
 
 jest.mock('../../../util/render-node');
@@ -24,12 +25,12 @@ describe('<Policy />', () => {
   itRendersChildNodes(Policy, { meta });
 
   it('uses the policy for default text', () => {
-    const docNode = {
+    const docNode = new DocumentNode({
       children: [],
       identifier: '',
       meta,
       text: '',
-    };
+    });
     const result = shallow(<Policy docNode={docNode} />);
     const text = result.text();
     expect(text).toMatch(/M-44-55/);
@@ -46,7 +47,7 @@ describe('<Policy />', () => {
     expect(date.children().text()).toEqual('March 3, 2003');
   });
   it('can grab text from subnodes', () => {
-    const docNode = {
+    const docNode = new DocumentNode({
       children: [
         { children: [], node_type: 'other', text: 'other-text' },
         { children: [], node_type: 'subject', text: 'subject-here' },
@@ -58,7 +59,7 @@ describe('<Policy />', () => {
       identifier: '',
       meta,
       text: '',
-    };
+    });
 
     const result = shallow(<Policy docNode={docNode} />);
     const text = result.text();
@@ -76,7 +77,7 @@ describe('<Policy />', () => {
     expect(date.children().text()).toEqual('some date here');
   });
   it('renders footnotes at the bottom', () => {
-    const docNode = {
+    const docNode = new DocumentNode({
       children: [],
       identifier: '',
       text: '',
@@ -88,7 +89,7 @@ describe('<Policy />', () => {
           { identifier: '3', children: [], content: [], marker: '' },
         ],
       },
-    };
+    });
 
     const result = shallow(<Policy docNode={docNode} />);
     const footnotes = result.find('.bottom-footnotes Footnote');

--- a/ui/__tests__/components/node-renderers/table/tfoot.test.js
+++ b/ui/__tests__/components/node-renderers/table/tfoot.test.js
@@ -1,0 +1,78 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Tfoot from '../../../../components/node-renderers/table/tfoot';
+import DocumentNode from '../../../../util/document-node';
+
+describe('<Tfoot />', () => {
+  it('is null if there are no footnotes', () => {
+    const docNode = new DocumentNode({
+      children: [],
+      meta: { descendant_footnotes: [] },
+    });
+    const result = shallow(<Tfoot docNode={docNode} />);
+    expect(result.type()).toBeNull();
+  });
+  it('calculates the correct colspan', () => {
+    const docNode = new DocumentNode({
+      children: [
+        { node_type: 'caption', children: [] },
+        { node_type: 'thead',
+          children: [
+            { node_type: 'tr',
+              children: [
+                { node_type: 'td', children: [] },
+                { node_type: 'td', children: [] },
+                { node_type: 'td', children: [] },
+                { node_type: 'td', children: [] },
+              ],
+            },
+          ],
+        },
+      ],
+      meta: {
+        descendant_footnotes: [{ identifier: '', marker: '', content: [] }],
+      },
+    });
+    const result = shallow(<Tfoot docNode={docNode} />);
+    expect(result.find('td').prop('colSpan')).toBe(4);
+  });
+  it('defaults to colspan="1"', () => {
+    const docNode = new DocumentNode({
+      children: [],
+      meta: {
+        descendant_footnotes: [{ identifier: '', marker: '', content: [] }],
+      },
+    });
+    const result = shallow(<Tfoot docNode={docNode} />);
+    expect(result.find('td').prop('colSpan')).toBe(1);
+  });
+  it('includes text in order', () => {
+    const docNode = new DocumentNode({
+      children: [],
+      meta: {
+        descendant_footnotes: [
+          { content: [{ content_type: '__text__', text: 'aaa' }],
+            identifier: 'footnote_1',
+            marker: '1.',
+          },
+          { content: [{ content_type: '__text__', text: 'bbb' }],
+            identifier: 'footnote_2',
+            marker: '2!',
+          },
+          { content: [{ content_type: '__text__', text: 'ccc' }],
+            identifier: 'footnote_3',
+            marker: '3)',
+          },
+        ],
+      },
+    });
+    const result = shallow(<Tfoot docNode={docNode} />);
+    expect(result.text()).toMatch(/1\..*2!.*3\)/);
+    const texts = result.find('PlainText');
+    expect(texts).toHaveLength(3);
+    expect(texts.at(0).prop('content').text).toBe('aaa');
+    expect(texts.at(1).prop('content').text).toBe('bbb');
+    expect(texts.at(2).prop('content').text).toBe('ccc');
+  });
+});

--- a/ui/__tests__/pages/document.test.js
+++ b/ui/__tests__/pages/document.test.js
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { Document } from '../../pages/document';
+import DocumentNode from '../../util/document-node';
+import renderNode from '../../util/render-node';
+
+jest.mock('../../util/render-node');
+
+describe('<Document />', () => {
+  it('calls renderNode with a DocumentNode', () => {
+    renderNode.mockImplementationOnce(() => <span>Stuff</span>);
+    const docNode = { children: [], some: 'thing' };
+    const result = shallow(<Document docNode={docNode} />);
+    expect(result.text()).toBe('Stuff');
+    expect(renderNode).toHaveBeenCalledTimes(1);
+    expect(renderNode).toHaveBeenCalledWith(new DocumentNode(docNode));
+  });
+});

--- a/ui/__tests__/test-utils/node-renderers.js
+++ b/ui/__tests__/test-utils/node-renderers.js
@@ -1,16 +1,17 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
+import DocumentNode from '../../util/document-node';
 import renderNode from '../../util/render-node';
 
 export function itIncludesTheIdentifier(Component, extraAttrs) {
   it('includes the identifier', () => {
-    const docNode = {
+    const docNode = new DocumentNode({
       children: [],
       identifier: 'aaa_1__bbb_2__ccc_3',
       marker: '',
       ...(extraAttrs || {}),
-    };
+    });
     const result = shallow(<Component docNode={docNode} />);
     expect(result.prop('id')).toBe('aaa_1__bbb_2__ccc_3');
   });
@@ -18,12 +19,12 @@ export function itIncludesTheIdentifier(Component, extraAttrs) {
 
 export function itIncludesNodeText(Component, extraAttrs) {
   it('includes node text', () => {
-    const docNode = {
+    const docNode = new DocumentNode({
       children: [],
       identifier: '',
       marker: '',
       ...(extraAttrs || {}),
-    };
+    });
     const result = shallow(
       <Component docNode={docNode}>
         <span id="some-contents">Textextext</span>
@@ -46,7 +47,7 @@ export function itRendersChildNodes(Component, extraAttrs) {
     renderNode.mockImplementationOnce(
       () => <child key="2">second child</child>);
 
-    const docNode = {
+    const docNode = new DocumentNode({
       children: [
         { children: [], node_type: 'first-child' },
         { children: [], node_type: 'second-child' },
@@ -54,7 +55,7 @@ export function itRendersChildNodes(Component, extraAttrs) {
       identifier: '',
       marker: '',
       ...(extraAttrs || {}),
-    };
+    });
     const result = shallow(<Component docNode={docNode} />);
     expect(result.text()).toMatch(/first child.*second child/);
     expect(result.find('child')).toHaveLength(2);

--- a/ui/__tests__/util/document-node.test.js
+++ b/ui/__tests__/util/document-node.test.js
@@ -1,6 +1,6 @@
-import { firstMatch, firstWithNodeType, linearize } from '../../util/document-node';
+import DocumentNode from '../../util/document-node';
 
-const exampleNode = {
+const exampleNode = new DocumentNode({
   identifier: '1',
   node_type: 'aaa',
   children: [
@@ -12,38 +12,38 @@ const exampleNode = {
     },
     { identifier: '5', node_type: 'ccc', children: [] },
   ],
-};
+});
 
 describe('linearize()', () => {
   it('is recursive', () => {
-    const idents = linearize(exampleNode).map(d => d.identifier);
+    const idents = exampleNode.linearize().map(d => d.identifier);
     expect(idents).toEqual(['1', '2', '3', '4', '5']);
   });
 });
 
 describe('firstMatch()', () => {
   it('can match the root', () => {
-    const result = firstMatch(exampleNode, n => n.identifier === '1');
+    const result = exampleNode.firstMatch(n => n.identifier === '1');
     expect(result.identifier).toEqual('1');
   });
   it('is recursive', () => {
-    const result = firstMatch(exampleNode, n => n.identifier === '4');
+    const result = exampleNode.firstMatch(n => n.identifier === '4');
     expect(result.identifier).toEqual('4');
   });
   it('grabs only the first', () => {
-    const result = firstMatch(
-      exampleNode, n => parseInt(n.identifier, 10) % 2 === 0);
+    const result = exampleNode.firstMatch(
+      n => parseInt(n.identifier, 10) % 2 === 0);
     expect(result.identifier).toEqual('2');
   });
 });
 
 describe('firstWithNodeType()', () => {
   it('grabs only the first', () => {
-    const result = firstWithNodeType(exampleNode, 'bbb');
+    const result = exampleNode.firstWithNodeType('bbb');
     expect(result.identifier).toEqual('2');
   });
   it('returns null when there are no matches', () => {
-    const result = firstWithNodeType(exampleNode, 'doesnt-exist');
+    const result = exampleNode.firstWithNodeType('doesnt-exist');
     expect(result).toBeNull();
   });
 });

--- a/ui/components/node-renderers/policy.js
+++ b/ui/components/node-renderers/policy.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { firstWithNodeType } from '../../util/document-node';
 import renderNode, { renderContent } from '../../util/render-node';
 import LabeledText from '../labeled-text';
 import Link from '../link';
@@ -9,7 +8,7 @@ import Footnote from './footnote';
 import From from './from';
 
 function findNodeText(docNode, nodeType, modelValue) {
-  const containingNode = firstWithNodeType(docNode, nodeType);
+  const containingNode = docNode.firstWithNodeType(nodeType);
   if (containingNode && containingNode.text.length > 0) {
     return containingNode.text;
   }
@@ -35,7 +34,7 @@ function footnotes(footnoteList) {
 
 /* Root of a policy document */
 export default function Policy({ docNode }) {
-  const fromNode = firstWithNodeType(docNode, 'from');
+  const fromNode = docNode.firstWithNodeType('from');
   const policyMeta = docNode.meta.policy;
   return (
     <div className="node-policy" id={docNode.identifier}>

--- a/ui/components/node-renderers/table/index.js
+++ b/ui/components/node-renderers/table/index.js
@@ -1,12 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import renderNode from '../../util/render-node';
+import renderNode from '../../../util/render-node';
+import Tfoot from './tfoot';
 
 export default function Table({ docNode }) {
   return (
     <table className="basic-table" id={docNode.identifier}>
       { docNode.children.map(renderNode) }
+      <Tfoot docNode={docNode} />
     </table>
   );
 }

--- a/ui/components/node-renderers/table/tfoot.js
+++ b/ui/components/node-renderers/table/tfoot.js
@@ -1,0 +1,45 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { renderContent } from '../../../util/render-node';
+
+/* We're assuming, for the time being, that all rows within a single table
+ * have the same number of columns. */
+function deriveColspan(docNode) {
+  const thead = docNode.firstWithNodeType('thead');
+  const tr = thead ? thead.firstWithNodeType('tr') : null;
+  return tr ? tr.children.length : 1;
+}
+
+export default function Tfoot({ docNode }) {
+  const footnotes = docNode.meta.descendant_footnotes.map(ft => (
+    <div className="clearfix" key={ft.identifier}>
+      <div className="col col-1">{ft.marker}</div>
+      <div className="col col-11">{ renderContent(ft.content) }</div>
+    </div>
+  ));
+  if (footnotes.length === 0) {
+    return null;
+  }
+  return (
+    <tfoot>
+      <tr>
+        <td colSpan={deriveColspan(docNode)} className="border">
+          <h1 className="h4">Footnotes for table</h1>
+          { footnotes }
+        </td>
+      </tr>
+    </tfoot>
+  );
+}
+Tfoot.propTypes = {
+  docNode: PropTypes.shape({
+    meta: PropTypes.shape({
+      descendant_footnotes: PropTypes.arrayOf(PropTypes.shape({
+        content: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+        identifier: PropTypes.string.isRequired,
+        marker: PropTypes.string.isRequired,
+      })).isRequired,
+    }).isRequired,
+  }).isRequired,
+};

--- a/ui/pages/document.js
+++ b/ui/pages/document.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 
 import wrapPage from '../components/app-wrapper';
 import { documentData } from '../util/api/queries';
+import DocumentNode from '../util/document-node';
 import renderNode from '../util/render-node';
 
 
@@ -11,18 +12,10 @@ const headerFooterParams = {
 };
 
 export function Document({ docNode }) {
-  return renderNode(docNode);
+  return renderNode(new DocumentNode(docNode));
 }
 Document.propTypes = {
-  docNode: PropTypes.shape({
-    children: PropTypes.arrayOf(PropTypes.shape({})), // recursive
-    content: PropTypes.arrayOf(PropTypes.shape({
-      content_type: PropTypes.string.isRequired,
-      text: PropTypes.string.isRequired,
-    })),
-    identifier: PropTypes.string.isRequired,
-    node_type: PropTypes.string.isRequired,
-  }).isRequired,
+  docNode: PropTypes.shape({}).isRequired,
 };
 
 export default wrapPage(Document, documentData, headerFooterParams);

--- a/ui/util/document-node.js
+++ b/ui/util/document-node.js
@@ -1,22 +1,29 @@
-export function linearize(docNode) {
-  return docNode.children.reduce(
-    (soFar, nextNode) => soFar.concat(linearize(nextNode)), [docNode]);
-}
-
-export function firstMatch(docNode, filterFn) {
-  if (filterFn(docNode)) {
-    return docNode;
+export default class DocumentNode {
+  constructor(docNode) {
+    Object.assign(this, docNode);
+    this.children = docNode.children.map(c => new DocumentNode(c));
   }
-  // Use for loop so we can short-circuit
-  for (let idx = 0; idx < docNode.children.length; idx += 1) {
-    const result = firstMatch(docNode.children[idx], filterFn);
-    if (result) {
-      return result;
+
+  linearize() {
+    return this.children.reduce(
+      (soFar, nextNode) => soFar.concat(nextNode.linearize()), [this]);
+  }
+
+  firstMatch(filterFn) {
+    if (filterFn(this)) {
+      return this;
     }
+    // Use for loop so we can short-circuit
+    for (let idx = 0; idx < this.children.length; idx += 1) {
+      const result = this.children[idx].firstMatch(filterFn);
+      if (result) {
+        return result;
+      }
+    }
+    return null;
   }
-  return null;
-}
 
-export function firstWithNodeType(docNode, nodeType) {
-  return firstMatch(docNode, n => n.node_type === nodeType);
+  firstWithNodeType(nodeType) {
+    return this.firstMatch(n => n.node_type === nodeType);
+  }
 }


### PR DESCRIPTION
As part of #623, this adds footnotes to the bottom of tables. It's not styled well, but should get us started. It also converts some library functions into methods for ease of use.

Looks like
<img width="744" alt="screen shot 2017-11-09 at 6 52 35 pm" src="https://user-images.githubusercontent.com/326918/32635619-1725c476-c57f-11e7-9f2a-bc0cf57b3dc8.png">
