### PR TITLE
Use white-space: nowrap in the footnote citation.

### DIFF
--- a/ui/__tests__/components/content-renderers/footnote-citation.test.js
+++ b/ui/__tests__/components/content-renderers/footnote-citation.test.js
@@ -35,9 +35,14 @@ describe('<FootnoteCitation />', () => {
       text: 'text content here',
     };
     const footnote = mount(<FootnoteCitation content={content} />);
+    expect(footnote.html()).toMatch(/footnote-link/);
+    expect(footnote.html()).not.toMatch(/node-footnote/);
+    expect(footnote.html()).not.toMatch(/active/);
+
     footnote.find('a').simulate('click');
-    expect(footnote.html()).toMatch(/active footnote-link/);
+    expect(footnote.html()).toMatch(/footnote-link/);
     expect(footnote.html()).toMatch(/node-footnote/);
+    expect(footnote.html()).toMatch(/active/);
   });
 });
 

--- a/ui/components/content-renderers/footnote-citation.js
+++ b/ui/components/content-renderers/footnote-citation.js
@@ -40,7 +40,7 @@ export default class FootnoteCitation extends React.Component {
     let footnoteContent;
     const footnote = this.props.content.footnote_node;
     const expanded = this.state.expanded;
-    const klass = expanded ? 'active footnote-link' : 'footnote-link';
+    const klass = `footnote-link nowrap${expanded ? ' active' : ''}`;
     const href = `#${this.props.content.footnote_node.identifier}`;
     const link = (
       <sup>

--- a/ui/css/base/_util.scss
+++ b/ui/css/base/_util.scss
@@ -1,0 +1,3 @@
+.nowrap {
+  white-space: nowrap;
+}

--- a/ui/css/main.scss
+++ b/ui/css/main.scss
@@ -11,6 +11,7 @@
 @import 'base/colors';
 @import 'base/base';
 @import 'base/fonts';
+@import 'base/util';
 
 @import 'layout/typography';
 @import 'layout/layout';


### PR DESCRIPTION
This prevents the citation from breaking across lines.

## Before
![footnote-split](https://user-images.githubusercontent.com/326918/32636203-c7d16314-c581-11e7-9abd-040bb0f39e6a.gif)


## After
![footnote-fixed](https://user-images.githubusercontent.com/326918/32636212-cb445448-c581-11e7-8a59-9c8fd091d490.gif)
