### PR TITLE
Add simple test for KaTeX math component

### DIFF
--- a/ui/__tests__/components/node-renderers/math.test.js
+++ b/ui/__tests__/components/node-renderers/math.test.js
@@ -12,12 +12,12 @@ describe('<TeXMath />', () => {
   it('generates something math-like', () => {
     const docNode = {
       identifier: 'aaa_1__bbb_2__ccc_3_math',
-      text: '\\frac{10}{11}',
+      text: '\\frac{12345654321}{10987678901}',
     };
     const result = mount(<TeXMath docNode={docNode} />);
     expect(result.render().find('span.katex')).toHaveLength(1);
-    expect(result.html()).toContain('10');
-    expect(result.html()).toContain('11');
+    expect(result.text()).toContain('12345654321');
+    expect(result.text()).toContain('10987678901');
   });
 });
 

--- a/ui/__tests__/components/node-renderers/math.test.js
+++ b/ui/__tests__/components/node-renderers/math.test.js
@@ -1,0 +1,23 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import TeXMath from '../../../components/node-renderers/math';
+import {
+  itIncludesTheIdentifier,
+} from '../../test-utils/node-renderers';
+
+jest.mock('../../../util/render-node');
+
+describe('<TeXMath />', () => {
+  itIncludesTheIdentifier(TeXMath, { text: 'abcd' });
+  it('generates something math-like', () => {
+    const docNode = {
+      identifier: 'aaa_1__bbb_2__ccc_3_math',
+      text: '\\frac{10}{11}',
+    };
+    const result = mount(<TeXMath docNode={docNode} />);
+    expect(result.render().find('span.katex')).toHaveLength(1);
+    expect(result.html()).toContain('10');
+    expect(result.html()).toContain('11');
+  });
+});
+


### PR DESCRIPTION
If a render fails
When nobody can hear it
Now we might find out.

Add a basic test for the KaTeX math component.