### PR TITLE
Fix footnote accessibility issues

### DIFF
--- a/ui/__tests__/components/link.test.js
+++ b/ui/__tests__/components/link.test.js
@@ -41,7 +41,7 @@ describe('<Link />', () => {
     // of the link on ATs. We might bring back this functionality in
     // a better way, though, so for now we'll skip it rather than deleting
     // it entirely. For more details, see:
-    // 
+    //
     //   https://github.com/18F/omb-eregs/issues/655
     it.skip('renders as an external link if the URL includes a protocol', () => {
       const externalUrl = 'https://www.other-site.gov';

--- a/ui/__tests__/components/link.test.js
+++ b/ui/__tests__/components/link.test.js
@@ -35,7 +35,15 @@ describe('<Link />', () => {
       expect(aProps.href).toEqual(url);
       expect(aProps['aria-label']).toEqual(undefined);
     });
-    it('renders as an external link if the URL includes a protocol', () => {
+
+    // TODO: We're skipping this for now, because setting the aria-label
+    // to "Link opens in a new window" obscured the actual destination
+    // of the link on ATs. We might bring back this functionality in
+    // a better way, though, so for now we'll skip it rather than deleting
+    // it entirely. For more details, see:
+    // 
+    //   https://github.com/18F/omb-eregs/issues/655
+    it.skip('renders as an external link if the URL includes a protocol', () => {
       const externalUrl = 'https://www.other-site.gov';
       const result = shallow(<Link href={externalUrl}>hi</Link>);
       const aProps = result.find('a').props();

--- a/ui/components/content-renderers/footnote-citation.js
+++ b/ui/components/content-renderers/footnote-citation.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import Link from '../link';
 import { renderContent } from '../../util/render-node';
 
 import Footnote from '../node-renderers/footnote';
@@ -55,14 +56,14 @@ export default class FootnoteCitation extends React.Component {
     const href = `#${this.props.content.footnote_node.identifier}`;
     const link = (
       <sup>
-        <a
+        <Link
           className={klass}
           onClick={this.handleCitationClick}
           href={href}
-          ref={(el) => { this.citationLink = el; }}
+          ref={(component) => { this.citationLink = component; }}
         >
           Footnote { this.props.content.text }
-        </a>
+        </Link>
       </sup>
     );
     if (expanded) {

--- a/ui/components/content-renderers/footnote-citation.js
+++ b/ui/components/content-renderers/footnote-citation.js
@@ -4,7 +4,6 @@ import React from 'react';
 import { renderContent } from '../../util/render-node';
 
 import Footnote from '../node-renderers/footnote';
-import Link from '../link';
 
 const propTypes = {
   content: PropTypes.shape({
@@ -26,6 +25,14 @@ export default class FootnoteCitation extends React.Component {
     this.handleCitationClick = this.handleCitationClick.bind(this);
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if (!prevState.expanded && this.state.expanded && this.citationWrapper) {
+      // Focus the footnote so screen-readers announce it, and to ensure
+      // that keyboard focus moves to it.
+      this.citationWrapper.focus();
+    }
+  }
+
   handleCitationClick(e) {
     e.preventDefault();
     this.setState({ expanded: !this.state.expanded });
@@ -40,14 +47,6 @@ export default class FootnoteCitation extends React.Component {
     this.setState({ expanded: false });
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    if (!prevState.expanded && this.state.expanded && this.citationWrapper) {
-      // Focus the footnote so screen-readers announce it, and to ensure
-      // that keyboard focus moves to it.
-      this.citationWrapper.focus();
-    }
-  }
-
   render() {
     let footnoteContent;
     const footnote = this.props.content.footnote_node;
@@ -56,17 +55,19 @@ export default class FootnoteCitation extends React.Component {
     const href = `#${this.props.content.footnote_node.identifier}`;
     const link = (
       <sup>
-        <a className={klass} onClick={this.handleCitationClick} href={href}
-          ref={(el) => { this.citationLink = el; }}>
+        <a
+          className={klass}
+          onClick={this.handleCitationClick}
+          href={href}
+          ref={(el) => { this.citationLink = el; }}
+        >
           Footnote { this.props.content.text }
         </a>
       </sup>
     );
     if (expanded) {
       footnoteContent = (
-        <span className="citation-wrapper" role="alertdialog"
-          aria-label={"Footnote " + footnote.marker} tabIndex="-1"
-          ref={(el) => { this.citationWrapper = el; }}>
+        <span className="citation-wrapper" role="alertdialog" aria-label={`Footnote ${footnote.marker}`} tabIndex="-1" ref={(el) => { this.citationWrapper = el; }}>
           <Footnote docNode={footnote}>
             { renderContent(footnote.content) }
           </Footnote>

--- a/ui/components/content-renderers/footnote-citation.js
+++ b/ui/components/content-renderers/footnote-citation.js
@@ -18,7 +18,7 @@ export class FootnoteCitation extends React.Component {
     this.footnoteIdentifier = props.content.footnote_node.identifier;
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     if (!prevProps.expanded && this.props.expanded && this.citationWrapper) {
       // Focus the footnote so screen-readers announce it, and to ensure
       // that keyboard focus moves to it.

--- a/ui/components/content-renderers/footnote-citation.js
+++ b/ui/components/content-renderers/footnote-citation.js
@@ -33,7 +33,19 @@ export default class FootnoteCitation extends React.Component {
 
   shrinkFootnote(e) {
     e.preventDefault();
+    if (this.citationLink) {
+      // Focus on the citation button so keyboard focus isn't undefined.
+      this.citationLink.focus();
+    }
     this.setState({ expanded: false });
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (!prevState.expanded && this.state.expanded && this.citationWrapper) {
+      // Focus the footnote so screen-readers announce it, and to ensure
+      // that keyboard focus moves to it.
+      this.citationWrapper.focus();
+    }
   }
 
   render() {
@@ -44,14 +56,17 @@ export default class FootnoteCitation extends React.Component {
     const href = `#${this.props.content.footnote_node.identifier}`;
     const link = (
       <sup>
-        <Link className={klass} onClick={this.handleCitationClick} href={href}>
+        <a className={klass} onClick={this.handleCitationClick} href={href}
+          ref={(el) => { this.citationLink = el; }}>
           Footnote { this.props.content.text }
-        </Link>
+        </a>
       </sup>
     );
     if (expanded) {
       footnoteContent = (
-        <span className="citation-wrapper">
+        <span className="citation-wrapper" role="alertdialog"
+          aria-label={"Footnote " + footnote.marker} tabIndex="-1"
+          ref={(el) => { this.citationWrapper = el; }}>
           <Footnote docNode={footnote}>
             { renderContent(footnote.content) }
           </Footnote>

--- a/ui/components/link.js
+++ b/ui/components/link.js
@@ -27,7 +27,6 @@ export default class Link extends React.Component {
       if (href.search(/^https|http|^\/\//) === 0) {
         props.target = '_blank';
         props.rel = 'noopener noreferrer';
-        props['aria-label'] = 'Link opens in a new window';
       }
       return <a {...props} ref={(el) => { this.el = el; }}>{children}</a>;
     }

--- a/ui/components/link.js
+++ b/ui/components/link.js
@@ -3,24 +3,35 @@ import React from 'react';
 
 import { Link as RouterLink, routes } from '../routes';
 
-export default function Link({ children, href, params, route, ...otherProps }) {
-  if (route) {
-    return (
-      <RouterLink params={params} route={route}>
-        <a {...otherProps}>{children}</a>
-      </RouterLink>
-    );
-  } else if (href) {
-    const props = {
-      ...otherProps,
-      href,
-    };
-    if (href.search(/^https|http|^\/\//) === 0) {
-      props.target = '_blank';
-      props.rel = 'noopener noreferrer';
-      props['aria-label'] = 'Link opens in a new window';
+export default class Link extends React.Component {
+  focus() {
+    if (this.el) {
+      this.el.focus();
     }
-    return <a {...props}>{children}</a>;
+  }
+
+  render() {
+    const { children, href, params, route, ...otherProps } = this.props;
+
+    if (route) {
+      return (
+        <RouterLink params={params} route={route}>
+          <a {...otherProps}>{children}</a>
+        </RouterLink>
+      );
+    } else if (href) {
+      const props = {
+        ...otherProps,
+        href,
+      };
+      if (href.search(/^https|http|^\/\//) === 0) {
+        props.target = '_blank';
+        props.rel = 'noopener noreferrer';
+        props['aria-label'] = 'Link opens in a new window';
+      }
+      return <a {...props} ref={(el) => { this.el = el; }}>{children}</a>;
+    }
+    throw new Error('Link created without an href or route');
   }
 }
 

--- a/ui/css/module/_footnotes.scss
+++ b/ui/css/module/_footnotes.scss
@@ -31,6 +31,12 @@
     padding-bottom: 0.2em;
   }
 
+  /* It's ok to add outline: none here for accessibility purposes.
+   * For more details, see: https://youtu.be/ifW_oy9hajU */
+  .citation-wrapper[tabindex="-1"] {
+    outline: none;
+  }
+
   .node-footnote {
     font-size: 0.9em;
     display: block;

--- a/ui/css/module/_footnotes.scss
+++ b/ui/css/module/_footnotes.scss
@@ -31,8 +31,8 @@
     padding-bottom: 0.2em;
   }
 
-  /* It's ok to add outline: none here for accessibility purposes.
-   * For more details, see: https://youtu.be/ifW_oy9hajU */
+  // It's ok to add outline: none here for accessibility purposes.
+  // For more details, see: https://youtu.be/ifW_oy9hajU
   .citation-wrapper[tabindex="-1"] {
     outline: none;
   }


### PR DESCRIPTION
Fixes #633.

Notes:

* `role="alertdialog"` for the pop-up footnote might not be ideal, but it's the closest thing I could find that seemed to work on screen readers.
* I replaced the footnote `<Link>` with an `<a>` because I couldn't figure out how to get a reference to the DOM node for the link otherwise (when I put a `ref` on the `<Link>` it was called back with `null` as its first argument). I thought it would be okay since we're not actually using this link for any next.js-specific functionality, e.g. next.js isn't intercepting clicks and diverting them to `pushState` here or anything.
* I considered adding an `aria-haspopup="true"` to the footnote link, so screen-reader users would know what would happen when they activate the link, but apparently [`aria-haspopup` should only be used for menus and sub-menus](https://stackoverflow.com/a/20402871). Huh.

To do:

- [ ] Add tests.
- [x] Convert `<Link>` to a React class so it can support `ref`.
- [x] Use `<Link>` instead of `<a>`.
