### PR TITLE
Style bottom policy footnotes

### DIFF
--- a/ui/components/content-renderers/footnote-citation.js
+++ b/ui/components/content-renderers/footnote-citation.js
@@ -39,15 +39,17 @@ export class FootnoteCitation extends React.Component {
     const klass = `footnote-link nowrap${expanded ? ' active' : ''}`;
     const href = `#${this.props.content.footnote_node.identifier}`;
     const link = (
-      <sup>
-        <Link className={klass} onClick={this.handleCitationClick} href={href}>
-          Footnote { this.props.content.text }
-        </Link>
-      </sup>
+      <cite>
+        <sup>
+          <Link className={klass} onClick={this.handleCitationClick} href={href}>
+            Footnote { this.props.content.text }
+          </Link>
+        </sup>
+      </cite>
     );
     if (expanded) {
       footnoteContent = (
-        <span className="citation-wrapper">
+        <span className="footnote-wrapper">
           <Footnote docNode={footnote}>
             { renderContent(footnote.content) }
           </Footnote>
@@ -57,10 +59,10 @@ export class FootnoteCitation extends React.Component {
       );
     }
     return (
-      <cite className="inline-citation" data-citation-target={href}>
+      <span className="inline-footnote" data-citation-target={href}>
         { link }
         { footnoteContent }
-      </cite>
+      </span>
     );
   }
 }

--- a/ui/css/base/_colors.scss
+++ b/ui/css/base/_colors.scss
@@ -53,3 +53,6 @@ $color-focus:                #3e94cf !default;
 $color-visited:              #4c2c92 !default;
 
 $color-shadow:               rgba(#000, 0.3) !default;
+
+// New pallet
+$pallet-blue:                #1067a6 !default;

--- a/ui/css/layout/_markers.scss
+++ b/ui/css/layout/_markers.scss
@@ -1,0 +1,28 @@
+$marker-width-xs: 24px;
+$marker-whitespace-xs: 4px;
+$marker-width-md: $marker-width-xs + 8;
+$marker-whitespace-md: $marker-whitespace-xs + 4;
+
+@mixin paragraph-marker() {
+  @extend .col;
+  @extend .right-align;
+  width: $marker-width-xs;
+  margin-right: $marker-whitespace-xs;
+  display: inline-block;
+
+  @media #{$breakpoint-md} {
+    width: $marker-width-md;
+    margin-right: $marker-whitespace-md;
+  }
+}
+
+@mixin paragraph-with-marker() {
+  @extend .col;
+  @extend .col-11;
+  width: calc(100% - #{$marker-width-xs + $marker-whitespace-xs});
+  word-wrap: break-word;
+
+  @media #{$breakpoint-md} {
+    width: calc(100% - #{$marker-width-md + $marker-whitespace-md});
+  }
+}

--- a/ui/css/main.scss
+++ b/ui/css/main.scss
@@ -15,6 +15,7 @@
 
 @import 'layout/typography';
 @import 'layout/layout';
+@import 'layout/markers';
 
 @import 'module/header';
 @import 'module/footnotes';

--- a/ui/css/module/_footnotes.scss
+++ b/ui/css/module/_footnotes.scss
@@ -13,7 +13,7 @@
   }
 }
 
-.inline-citation {
+.inline-footnote {
   .node-footnote-content {
     display: block;
     width: 100%;
@@ -21,7 +21,7 @@
     margin-right: auto;
   }
 
-  .citation-wrapper {
+  .footnote-wrapper {
     display: block;
     border-top: 1px solid $color-primary-darker;
     border-bottom: 1px solid $color-primary-darker;

--- a/ui/css/module/_footnotes.scss
+++ b/ui/css/module/_footnotes.scss
@@ -75,32 +75,35 @@
 }
 
 .bottom-footnotes {
-  border-top: 1px solid $color-gray-dark;
+  border-top: 1px solid $pallet-blue;
   margin-top: 2.5em;
   padding-top: .75em;
 
   .node-footnote {
-    margin-bottom: .875em;
+    @extend .clearfix;
     display: block;
+    margin-bottom: .875em;
   }
 
   .citation-marker {
-    @extend .col;
-    @extend .col-1;
-    @extend .pr2;
-    @extend .right-align;
+    @include font-san-serif-bold();
+    @include paragraph-marker();
+    font-size: .875em;
+    line-height: 1em; // like font-text, except adjusting for bold
   }
 
-  .footnote-text {
-    @extend .col;
-    @extend .col-11;
+  .footnote-text,
+  p {
+    @include paragraph-with-marker();
     @extend .m0;
     color: $color-gray-medium;
+    font-size: .875em;
+    line-height: 1.125em;
   }
 }
 
 .footnote-text {
-  @include font-source-sans-pro();
+  @include font-san-serif();
   font-style: normal;
   color: $color-gray-medium;
 }

--- a/ui/css/module/_listitem.scss
+++ b/ui/css/module/_listitem.scss
@@ -1,30 +1,13 @@
 .node-list-item {
   @extend .clearfix;
   margin-bottom: 8px;
-  $marker-width-xs: 24px;
-  $marker-padding-xs: 4px;
-  $marker-width-md: $marker-width-xs + 8;
-  $marker-padding-md: $marker-padding-xs + 4;
 
   .list-item-marker {
-    @extend .right-align;
     @include font-san-serif-bold();
-    width: $marker-width-xs;
-    padding-right: $marker-padding-xs;
-    display: inline-block;
-    float: left;
-
-    @media #{$breakpoint-md} {
-      width: $marker-width-md;
-      padding-right: $marker-padding-md;
-    }
+    @include paragraph-marker();
   }
 
   .list-item-text {
-    margin-left: $marker-width-xs + $marker-padding-xs;
-
-    @media #{$breakpoint-md} {
-      margin-left: $marker-width-md + $marker-padding-md;
-    }
+    @include paragraph-with-marker();
   }
 }


### PR DESCRIPTION
As part of #624, this

* Changes color of border
* Changes indent for marker
* Shrinks font size a bit
* Ensures long URLs are wrapped
* Makes marker text bold
* Attempts to line up marker text with footnote text

It also moves the `cite` tag to be more semantic and prevent italic text from appearing in our inline footnotes.

It also adds a new color variable since the requested color wasn't present. I've opened #648 to try to resolve that more permanently.