### PR TITLE
Ensure only one footnote is opened at a time

### DIFF
--- a/ui/.eslintrc
+++ b/ui/.eslintrc
@@ -30,7 +30,6 @@
     "scanjs-rules/call_addEventListener" : 2,
     "scanjs-rules/call_addEventListener_deviceproximity" : 2,
     "scanjs-rules/call_addEventListener_message" : 2,
-    "scanjs-rules/call_connect" : 2,
     "scanjs-rules/call_eval" : 2,
     "scanjs-rules/call_execScript" : 2,
     "scanjs-rules/call_hide" : 2,

--- a/ui/__tests__/components/app-wrapper.test.js
+++ b/ui/__tests__/components/app-wrapper.test.js
@@ -1,7 +1,11 @@
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import React from 'react';
 
 import wrapPage from '../../components/app-wrapper';
+import HeaderFooter from '../../components/header-footer';
+import initialState from '../../store/initial-state';
+
+jest.mock('../../components/header-footer', () => jest.fn());
 
 
 describe('wrapPage()', () => {
@@ -13,8 +17,10 @@ describe('wrapPage()', () => {
       const Wrapped = wrapPage(ExamplePage, dataFn);
       const results = await Wrapped.getInitialProps({ a: 'context' });
 
-      expect(results).toEqual({ some: 'data' });
-      expect(dataFn).toHaveBeenCalledWith({ a: 'context' });
+      expect(results.initialProps).toEqual({ some: 'data' });
+      expect(dataFn).toHaveBeenCalledTimes(1);
+      const firstArg = dataFn.mock.calls[0][0];
+      expect(firstArg.a).toBe('context');
     });
     it('handles errors', async () => {
       const err = new Error('oy');
@@ -22,45 +28,51 @@ describe('wrapPage()', () => {
       const Wrapped = wrapPage(ExamplePage, dataFn);
       const results = await Wrapped.getInitialProps();
 
-      expect(results).toEqual({ err });
+      expect(results.initialProps).toEqual({ err });
     });
     it('allows fetched data to trigger a 404', async () => {
       const dataFn = jest.fn(async () => ({ statusCode: 404 }));
       const Wrapped = wrapPage(ExamplePage, dataFn);
       const results = await Wrapped.getInitialProps();
 
-      expect(results).toEqual({ statusCode: 404 });
+      expect(results.initialProps).toEqual({ statusCode: 404 });
+    });
+    it('includes redux', async () => {
+      const dataFn = jest.fn(async () => ({}));
+      const Wrapped = wrapPage(ExamplePage, dataFn);
+      const results = await Wrapped.getInitialProps();
+
+      expect(results.initialState).toEqual(initialState);
     });
   });
   describe('render()', () => {
     const Wrapped = wrapPage(ExamplePage, jest.fn());
     it('renders content if no error', () => {
-      const result = shallow(<Wrapped arg1="some value" />);
+      HeaderFooter.mockImplementationOnce(({ children }) => (
+        <div className="hf">{ children }</div>
+      ));
+      const result = mount(<Wrapped arg1="some value" />);
+      expect(result.find('ErrorView')).toHaveLength(0);
 
-      expect(result.name()).toBe('HeaderFooter');
-      expect(result.find('ExamplePage')).toHaveLength(1);
-      expect(result.find('ExamplePage').first().prop('arg1')).toBe('some value');
+      const hf = result.find('.hf');
+      expect(hf).toHaveLength(1);
+      expect(hf.find('ExamplePage')).toHaveLength(1);
+      expect(hf.find('ExamplePage').first().prop('arg1')).toBe('some value');
     });
     it('renders an error, with no explicit status code', () => {
       const err = new Error('oh noes');
-      const result = shallow(<Wrapped err={err} />);
+      const result = mount(<Wrapped err={err} />).find('ErrorView');
 
-      expect(result.name()).toBe('ErrorView');
-      expect(result.find('ErrorView')).toHaveLength(1);
-      expect(result.find('ErrorView').first().props()).toEqual({
-        err,
-        statusCode: null,
-      });
+      expect(result).toHaveLength(1);
+      expect(result.props()).toEqual({ err, statusCode: null });
     });
     it('renders an error, with an explicit status code', () => {
-      const result = shallow(<Wrapped statusCode={404} />);
+      // HeaderFooter is present in the 404 page
+      HeaderFooter.mockImplementationOnce(() => null);
+      const result = mount(<Wrapped statusCode={404} />).find('ErrorView');
 
-      expect(result.name()).toBe('ErrorView');
-      expect(result.find('ErrorView')).toHaveLength(1);
-      expect(result.find('ErrorView').first().props()).toEqual({
-        err: null,
-        statusCode: 404,
-      });
+      expect(result).toHaveLength(1);
+      expect(result.props()).toEqual({ err: null, statusCode: 404 });
     });
   });
 });

--- a/ui/__tests__/components/content-renderers/footnote-citation.test.js
+++ b/ui/__tests__/components/content-renderers/footnote-citation.test.js
@@ -1,48 +1,88 @@
 import { mount } from 'enzyme';
 import React from 'react';
 
-import FootnoteCitation from '../../../components/content-renderers/footnote-citation';
+import { FootnoteCitation, mapStateToProps } from '../../../components/content-renderers/footnote-citation';
 
+function footnoteNode(attrs = null) {
+  const defaultAttrs = { children: [], content: [], identifier: '' };
+  return Object.assign({}, defaultAttrs, attrs || {});
+}
 
 describe('<FootnoteCitation />', () => {
+  const exampleProps = {
+    content: { footnote_node: footnoteNode(), text: '' },
+    expanded: false,
+    openFootnote: jest.fn(),
+  };
   it('includes all of the text of the content', () => {
-    const content = {
-      footnote_node: { identifier: '' },
-      text: 'Some text here ',
+    const props = {
+      ...exampleProps,
+      content: {
+        footnote_node: footnoteNode(),
+        text: 'Some text here ',
+      },
     };
-    const text = mount(<FootnoteCitation content={content} />).text();
+    const text = mount(<FootnoteCitation {...props} />).text();
     expect(text).toMatch(/Some text here /);
     expect(text).toMatch(/Footnote /);
   });
 
   it('references the footnote node', () => {
-    const content = {
-      footnote_node: { identifier: 'aaa_1__bbb_2' },
-      text: '',
+    const props = {
+      ...exampleProps,
+      content: {
+        footnote_node: footnoteNode({ identifier: 'aaa_1__bbb_2' }),
+        text: '',
+      },
     };
-    const html = mount(<FootnoteCitation content={content} />).html();
+    const html = mount(<FootnoteCitation {...props} />).html();
     expect(html).toMatch(/aaa_1__bbb_2/);
   });
 
-  it('expands on click', () => {
-    const content = {
-      footnote_node: {
-        children: [],
-        content: [],
-        identifier: '',
-        type_emblem: '10',
-      },
-      text: 'text content here',
-    };
-    const footnote = mount(<FootnoteCitation content={content} />);
+  it('has a closed state', () => {
+    const props = { ...exampleProps, expanded: false };
+    const footnote = mount(<FootnoteCitation {...props} />);
     expect(footnote.html()).toMatch(/footnote-link/);
     expect(footnote.html()).not.toMatch(/node-footnote/);
     expect(footnote.html()).not.toMatch(/active/);
+  });
 
-    footnote.find('a').simulate('click');
+  it('has an expanded state', () => {
+    const props = { ...exampleProps, expanded: true };
+    const footnote = mount(<FootnoteCitation {...props} />);
     expect(footnote.html()).toMatch(/footnote-link/);
     expect(footnote.html()).toMatch(/node-footnote/);
     expect(footnote.html()).toMatch(/active/);
   });
+
+  it('triggers a state transition if clicked', () => {
+    const content = {
+      footnote_node: footnoteNode({ identifier: 'aaa_1__bbb_2' }),
+      text: '',
+    };
+    const props = {
+      ...exampleProps,
+      content,
+      openFootnote: jest.fn(),
+    };
+    mount(<FootnoteCitation {...props} />).find('Link').simulate('click');
+    expect(props.openFootnote).toHaveBeenCalledTimes(1);
+    expect(props.openFootnote).toHaveBeenCalledWith('aaa_1__bbb_2');
+  });
 });
 
+describe('mapStateToProps()', () => {
+  const props = { content: { footnote_node: { identifier: 'aaa_1' } } };
+  it('converts to an expanded state', () => {
+    const result = mapStateToProps({ openedFootnote: 'aaa_1' }, props);
+    expect(result).toEqual({ expanded: true });
+  });
+  it('handles null', () => {
+    const result = mapStateToProps({ openedFootnote: null }, props);
+    expect(result).toEqual({ expanded: false });
+  });
+  it('will not be expanded if a different footnote is selected', () => {
+    const result = mapStateToProps({ openedFootnote: 'bbb_2' }, props);
+    expect(result).toEqual({ expanded: false });
+  });
+});

--- a/ui/__tests__/components/content-renderers/footnote-citation.test.js
+++ b/ui/__tests__/components/content-renderers/footnote-citation.test.js
@@ -10,6 +10,7 @@ function footnoteNode(attrs = null) {
 
 describe('<FootnoteCitation />', () => {
   const exampleProps = {
+    closeFootnote: jest.fn(),
     content: { footnote_node: footnoteNode(), text: '' },
     expanded: false,
     openFootnote: jest.fn(),
@@ -55,19 +56,34 @@ describe('<FootnoteCitation />', () => {
     expect(footnote.html()).toMatch(/active/);
   });
 
-  it('triggers a state transition if clicked', () => {
+  it('triggers a state transition if clicked when closed', () => {
     const content = {
       footnote_node: footnoteNode({ identifier: 'aaa_1__bbb_2' }),
       text: '',
     };
     const props = {
       ...exampleProps,
+      expanded: false,
       content,
       openFootnote: jest.fn(),
     };
-    mount(<FootnoteCitation {...props} />).find('Link').simulate('click');
+    const link = mount(<FootnoteCitation {...props} />).find('Link');
+    link.simulate('click');
     expect(props.openFootnote).toHaveBeenCalledTimes(1);
     expect(props.openFootnote).toHaveBeenCalledWith('aaa_1__bbb_2');
+    expect(props.closeFootnote).not.toHaveBeenCalled();
+  });
+
+  it('triggers a state transition if clicked when open', () => {
+    const props = {
+      ...exampleProps,
+      closeFootnote: jest.fn(),
+      expanded: true,
+    };
+    const link = mount(<FootnoteCitation {...props} />).find('Link');
+    link.simulate('click');
+    expect(props.openFootnote).not.toHaveBeenCalled();
+    expect(props.closeFootnote).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/ui/__tests__/store.test.js
+++ b/ui/__tests__/store.test.js
@@ -1,0 +1,13 @@
+import { openFootnote } from '../store/actions';
+import initialState from '../store/initial-state';
+import reducer from '../store/reducer';
+
+describe('footnote functionality', () => {
+  it('has the correct initial state', () => {
+    expect(initialState.openedFootnote).toBeNull();
+  });
+  it('reduces appropriately', () => {
+    const result = reducer(initialState, openFootnote('some-id'));
+    expect(result).toEqual({ openedFootnote: 'some-id' });
+  });
+});

--- a/ui/__tests__/store.test.js
+++ b/ui/__tests__/store.test.js
@@ -1,13 +1,18 @@
-import { openFootnote } from '../store/actions';
+import { closeFootnote, openFootnote } from '../store/actions';
 import initialState from '../store/initial-state';
 import reducer from '../store/reducer';
 
 describe('footnote functionality', () => {
   it('has the correct initial state', () => {
-    expect(initialState.openedFootnote).toBeNull();
+    expect(initialState.openedFootnote).toBe('');
   });
-  it('reduces appropriately', () => {
+  it('reduces openFootnote appropriately', () => {
     const result = reducer(initialState, openFootnote('some-id'));
-    expect(result).toEqual({ openedFootnote: 'some-id' });
+    expect(result.openedFootnote).toBe('some-id');
+  });
+  it('reduces closeFootnote appropriately', () => {
+    const state = { ...initialState, openedFootnote: 'aaa_1__bbb_2' };
+    const result = reducer(state, closeFootnote());
+    expect(result.openedFootnote).toBe('');
   });
 });

--- a/ui/components/app-wrapper.js
+++ b/ui/components/app-wrapper.js
@@ -1,8 +1,10 @@
 import Router from 'next/router';
+import withRedux from 'next-redux-wrapper';
 import NProgress from 'nprogress';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import createStore from '../store';
 import ErrorView from './error';
 import HeaderFooter from './header-footer';
 
@@ -45,5 +47,8 @@ export default function wrapPage(Page, dataFn, headerFooterParams) {
       return { err };
     }
   };
-  return WrappedPage;
+  return withRedux({
+    createStore,
+    debug: process.env.NODE_ENV === 'development',
+  })(WrappedPage);
 }

--- a/ui/components/content-renderers/footnote-citation.js
+++ b/ui/components/content-renderers/footnote-citation.js
@@ -4,7 +4,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import { renderContent } from '../../util/render-node';
-import { openFootnote } from '../../store/actions';
+import { closeFootnote, openFootnote } from '../../store/actions';
 
 import Footnote from '../node-renderers/footnote';
 import Link from '../link';
@@ -20,12 +20,16 @@ export class FootnoteCitation extends React.Component {
 
   handleCitationClick(e) {
     e.preventDefault();
-    this.props.openFootnote(this.footnoteIdentifier);
+    if (this.props.expanded) {
+      this.props.closeFootnote();
+    } else {
+      this.props.openFootnote(this.footnoteIdentifier);
+    }
   }
 
   shrinkFootnote(e) {
     e.preventDefault();
-    this.props.openFootnote(null);
+    this.props.closeFootnote();
   }
 
   render() {
@@ -62,6 +66,7 @@ export class FootnoteCitation extends React.Component {
 }
 
 FootnoteCitation.propTypes = {
+  closeFootnote: PropTypes.func.isRequired,
   content: PropTypes.shape({
     footnote_node: PropTypes.shape({
       identifier: PropTypes.string.isRequired,
@@ -77,7 +82,10 @@ export function mapStateToProps({ openedFootnote }, { content }) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return { openFootnote: bindActionCreators(openFootnote, dispatch) };
+  return {
+    closeFootnote: bindActionCreators(closeFootnote, dispatch),
+    openFootnote: bindActionCreators(openFootnote, dispatch),
+  };
 }
 
 

--- a/ui/components/content-renderers/footnote-citation.js
+++ b/ui/components/content-renderers/footnote-citation.js
@@ -1,45 +1,37 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
 
 import { renderContent } from '../../util/render-node';
+import { openFootnote } from '../../store/actions';
 
 import Footnote from '../node-renderers/footnote';
 import Link from '../link';
 
-const propTypes = {
-  content: PropTypes.shape({
-    footnote_node: PropTypes.shape({
-      identifier: PropTypes.string.isRequired,
-    }).isRequired,
-    text: PropTypes.string.isRequired,
-  }).isRequired,
-};
-
-export default class FootnoteCitation extends React.Component {
+export class FootnoteCitation extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      expanded: false,
-    };
     this.shrinkFootnote = this.shrinkFootnote.bind(this);
     this.handleCitationClick = this.handleCitationClick.bind(this);
+    this.footnoteIdentifier = props.content.footnote_node.identifier;
   }
 
   handleCitationClick(e) {
     e.preventDefault();
-    this.setState({ expanded: !this.state.expanded });
+    this.props.openFootnote(this.footnoteIdentifier);
   }
 
   shrinkFootnote(e) {
     e.preventDefault();
-    this.setState({ expanded: false });
+    this.props.openFootnote(null);
   }
 
   render() {
     let footnoteContent;
     const footnote = this.props.content.footnote_node;
-    const expanded = this.state.expanded;
+    const expanded = this.props.expanded;
     const klass = `footnote-link nowrap${expanded ? ' active' : ''}`;
     const href = `#${this.props.content.footnote_node.identifier}`;
     const link = (
@@ -69,12 +61,24 @@ export default class FootnoteCitation extends React.Component {
   }
 }
 
-FootnoteCitation.propTypes = propTypes;
-FootnoteCitation.defaultProps = {
-  content: {
-    footnote_node: {
-      identifier: '',
-    },
-    text: '',
-  },
+FootnoteCitation.propTypes = {
+  content: PropTypes.shape({
+    footnote_node: PropTypes.shape({
+      identifier: PropTypes.string.isRequired,
+    }).isRequired,
+    text: PropTypes.string.isRequired,
+  }).isRequired,
+  expanded: PropTypes.bool.isRequired,
+  openFootnote: PropTypes.func.isRequired,
 };
+
+export function mapStateToProps({ openedFootnote }, { content }) {
+  return { expanded: openedFootnote === content.footnote_node.identifier };
+}
+
+function mapDispatchToProps(dispatch) {
+  return { openFootnote: bindActionCreators(openFootnote, dispatch) };
+}
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(FootnoteCitation);

--- a/ui/npm-shrinkwrap.json
+++ b/ui/npm-shrinkwrap.json
@@ -1649,6 +1649,11 @@
       "from": "lodash@4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
     },
+    "lodash-es": {
+      "version": "4.17.4",
+      "from": "lodash-es@>=4.2.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz"
+    },
     "lodash.reduce": {
       "version": "4.6.0",
       "from": "lodash.reduce@4.6.0",
@@ -1676,7 +1681,7 @@
     },
     "match-at": {
       "version": "0.1.1",
-      "from": "match-at@>=0.1.0 <0.2.0",
+      "from": "match-at@latest",
       "resolved": "https://registry.npmjs.org/match-at/-/match-at-0.1.1.tgz"
     },
     "maximatch": {
@@ -1871,6 +1876,11 @@
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz"
         }
       }
+    },
+    "next-redux-wrapper": {
+      "version": "1.3.4",
+      "from": "next-redux-wrapper@latest",
+      "resolved": "https://registry.npmjs.org/next-redux-wrapper/-/next-redux-wrapper-1.3.4.tgz"
     },
     "next-routes": {
       "version": "1.0.40",
@@ -2331,6 +2341,11 @@
       "from": "react-proxy@>=3.0.0-alpha.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz"
     },
+    "react-redux": {
+      "version": "5.0.6",
+      "from": "react-redux@latest",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz"
+    },
     "react-select": {
       "version": "1.0.0-rc.10",
       "from": "react-select@>=1.0.0-rc.5 <2.0.0",
@@ -2401,6 +2416,11 @@
           "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz"
         }
       }
+    },
+    "redux": {
+      "version": "3.7.2",
+      "from": "redux@latest",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz"
     },
     "referrer-policy": {
       "version": "1.1.0",
@@ -2707,6 +2727,11 @@
       "version": "2.0.0",
       "from": "supports-color@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+    },
+    "symbol-observable": {
+      "version": "1.0.4",
+      "from": "symbol-observable@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz"
     },
     "tapable": {
       "version": "0.2.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,8 +1,7 @@
 {
   "name": "omb-eregs",
   "version": "1.0.0",
-  "description":
-    "This repository contains code necessary to run the White House Office of Management and Budget (OMB) instance of [eRegulations](https://eregs.github.io) (a regulation parser, API, and viewer).",
+  "description": "This repository contains code necessary to run the White House Office of Management and Budget (OMB) instance of [eRegulations](https://eregs.github.io) (a regulation parser, API, and viewer).",
   "main": "index.js",
   "scripts": {
     "build": "next build",
@@ -58,6 +57,7 @@
     "morgan": "^1.8.2",
     "newrelic": "^2.2.0",
     "next": "^3.2.2",
+    "next-redux-wrapper": "^1.3.4",
     "next-routes": "^1.0.40",
     "nprogress": "^0.2.0",
     "passport": "^0.4.0",
@@ -67,7 +67,9 @@
     "range_check": "^1.4.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
+    "react-redux": "^5.0.6",
     "react-select": "^1.0.0-rc.5",
+    "redux": "^3.7.2",
     "serialize-javascript": "^1.4.0",
     "uswds": "^0.14.0",
     "validator": "^8.1.0"
@@ -76,7 +78,9 @@
     "node": "6.x"
   },
   "jest": {
-    "coverageReporters": ["lcov"],
+    "coverageReporters": [
+      "lcov"
+    ],
     "testRegex": "/__tests__/.*\\.test\\.jsx?$",
     "verbose": true
   }

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -1,6 +1,9 @@
+export const CLOSE_FOOTNOTE = 'CLOSE_FOOTNOTE';
 export const OPEN_FOOTNOTE = 'OPEN_FOOTNOTE';
 
 export const openFootnote = footnoteIdentifier => ({
   footnoteIdentifier,
   type: OPEN_FOOTNOTE,
 });
+
+export const closeFootnote = () => ({ type: CLOSE_FOOTNOTE });

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -1,0 +1,6 @@
+export const OPEN_FOOTNOTE = 'OPEN_FOOTNOTE';
+
+export const openFootnote = footnoteIdentifier => ({
+  footnoteIdentifier,
+  type: OPEN_FOOTNOTE,
+});

--- a/ui/store/index.js
+++ b/ui/store/index.js
@@ -1,0 +1,8 @@
+import { createStore } from 'redux';
+
+import initialState from './initial-state';
+import reducer from './reducer';
+
+export default function initStore(startState = initialState) {
+  return createStore(reducer, startState);
+}

--- a/ui/store/initial-state.js
+++ b/ui/store/initial-state.js
@@ -1,0 +1,1 @@
+export default {};

--- a/ui/store/initial-state.js
+++ b/ui/store/initial-state.js
@@ -1,1 +1,1 @@
-export default { openedFootnote: null };
+export default { openedFootnote: '' };

--- a/ui/store/initial-state.js
+++ b/ui/store/initial-state.js
@@ -1,1 +1,1 @@
-export default {};
+export default { openedFootnote: null };

--- a/ui/store/initial-state.js
+++ b/ui/store/initial-state.js
@@ -1,1 +1,3 @@
+/* Note that we're only tracking which foonote is opened right now. We may
+ * expand this to include the url and other state vars in the future. */
 export default { openedFootnote: '' };

--- a/ui/store/reducer.js
+++ b/ui/store/reducer.js
@@ -1,0 +1,9 @@
+import initialState from './initial-state';
+
+
+export default function reducer(state = initialState, action) {
+  switch (action.type) {
+    default:
+      return state;
+  }
+}

--- a/ui/store/reducer.js
+++ b/ui/store/reducer.js
@@ -1,4 +1,4 @@
-import { OPEN_FOOTNOTE } from './actions';
+import { CLOSE_FOOTNOTE, OPEN_FOOTNOTE } from './actions';
 import initialState from './initial-state';
 
 
@@ -8,6 +8,11 @@ export default function reducer(state = initialState, action) {
       return {
         ...state,
         openedFootnote: action.footnoteIdentifier,
+      };
+    case CLOSE_FOOTNOTE:
+      return {
+        ...state,
+        openedFootnote: '',
       };
     default:
       return state;

--- a/ui/store/reducer.js
+++ b/ui/store/reducer.js
@@ -1,8 +1,14 @@
+import { OPEN_FOOTNOTE } from './actions';
 import initialState from './initial-state';
 
 
 export default function reducer(state = initialState, action) {
   switch (action.type) {
+    case OPEN_FOOTNOTE:
+      return {
+        ...state,
+        openedFootnote: action.footnoteIdentifier,
+      };
     default:
       return state;
   }


### PR DESCRIPTION
This resolves #621 by pushing the which-footnote-is-expanded logic into redux. It's overkill for our single bit of state, but should bootstrap this style of state management.

CC @tadhg-ohiggins for visibility