### PR TITLE
Alter footnote citations in a table

### DIFF
--- a/ui/__tests__/components/content-renderers/footnote-citation-in-table.test.js
+++ b/ui/__tests__/components/content-renderers/footnote-citation-in-table.test.js
@@ -1,0 +1,21 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import FootnoteCitationInTable from '../../../components/content-renderers/footnote-citation-in-table';
+
+describe('<FootnoteCitationInTable />', () => {
+  const content = {
+    footnote_node: { identifier: 'some__identifier' },
+    text: 'some text, like "1"',
+  };
+  const result = shallow(<FootnoteCitationInTable content={content} />);
+  const link = result.find('Link');
+
+  it('includes the correct link', () => {
+    expect(link).toHaveLength(1);
+    expect(link.prop('href')).toBe('#some__identifier-table');
+  });
+  it('includes the correct text', () => {
+    expect(link.children().text()).toBe('some text, like "1"');
+  });
+});

--- a/ui/__tests__/components/node-renderers/caption.test.js
+++ b/ui/__tests__/components/node-renderers/caption.test.js
@@ -1,0 +1,11 @@
+import Caption from '../../../components/node-renderers/caption';
+import {
+  itRendersFootnoteCitationsDifferently,
+  itUsesTheAppropriateTag,
+} from '../../test-utils/tables';
+
+describe('<Caption />', () => {
+  itRendersFootnoteCitationsDifferently(Caption);
+  itUsesTheAppropriateTag(Caption, 'caption');
+});
+

--- a/ui/__tests__/components/node-renderers/fallback.test.js
+++ b/ui/__tests__/components/node-renderers/fallback.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import Fallback from '../../../components/node-renderers/fallback';
 import renderNode from '../../../util/render-node';
+import nodeFactory from '../../test-utils/node-factory';
 
 jest.mock(
   '../../../util/render-node',
@@ -19,39 +20,30 @@ afterEach(() => {
 });
 
 describe('<Fallback />', () => {
-  const docNode = {
-    children: [{ first: 'child' }],
+  const docNode = nodeFactory({
+    content: [{ content_type: '__text__', text: 'Example content' }],
+    children: [nodeFactory({ first: 'child' })],
     identifier: 'aaa_1__bbb_2',
-  };
+  });
   it('includes text, children, id when not in dev mode', () => {
-    const result = shallow(
-      <Fallback docNode={docNode}>
-        <span>Example content</span>
-      </Fallback>);
+    const result = shallow(<Fallback docNode={docNode} />);
 
-    expect(result.text()).toMatch(/Example content.*some child/);
+    expect(result.text()).toMatch(/PlainText.*some child/);
     expect(result.prop('id')).toBe('aaa_1__bbb_2');
     expect(result.prop('style')).toBeUndefined();
     expect(result.prop('title')).toBeUndefined();
-    expect(result.find('span')).toHaveLength(1);
-    expect(result.find('child')).toHaveLength(1);
     expect(renderNode).toHaveBeenCalledTimes(1);
-    expect(renderNode.mock.calls[0][0]).toEqual({ first: 'child' });
+    expect(renderNode.mock.calls[0][0]).toEqual(docNode.children[0]);
   });
   it('includes that plus title text and a background when in dev mode', () => {
     process.env.NODE_ENV = 'development';
-    const result = shallow(
-      <Fallback docNode={docNode}>
-        <span>Example content</span>
-      </Fallback>);
+    const result = shallow(<Fallback docNode={docNode} />);
 
-    expect(result.text()).toMatch(/Example content.*some child/);
+    expect(result.text()).toMatch(/PlainText.*some child/);
     expect(result.prop('id')).toBe('aaa_1__bbb_2');
     expect(result.prop('style')).toEqual({ backgroundColor: 'pink' });
     expect(result.prop('title')).toBe('aaa_1__bbb_2');
-    expect(result.find('span')).toHaveLength(1);
-    expect(result.find('child')).toHaveLength(1);
     expect(renderNode).toHaveBeenCalledTimes(1);
-    expect(renderNode.mock.calls[0][0]).toEqual({ first: 'child' });
+    expect(renderNode.mock.calls[0][0]).toEqual(docNode.children[0]);
   });
 });

--- a/ui/__tests__/components/node-renderers/footnote.test.js
+++ b/ui/__tests__/components/node-renderers/footnote.test.js
@@ -2,6 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import Footnote from '../../../components/node-renderers/footnote';
+import nodeFactory from '../../test-utils/node-factory';
 import {
   itIncludesNodeText,
   itIncludesTheIdentifier,
@@ -13,32 +14,12 @@ describe('<Footnote />', () => {
   it('includes the marker', () => {
     const params = {
       children: [],
-      docNode: {
-        children: [],
-        content: [],
-        identifier: '',
-        marker: '8',
-        text: 'test the content around',
-      },
+      docNode: nodeFactory({ marker: '8' }),
     };
     const result = shallow(<Footnote {...params} />);
 
     const marker = result.children().first();
     expect(marker.text()).toBe('8');
-  });
-
-  it('Properlly displays footnote_node content', () => {
-    const params = {
-      docNode: {
-        children: [],
-        content: [],
-        identifier: '',
-        marker: '10',
-      },
-    };
-    const result = shallow(<Footnote {...params}>test the content around</Footnote>);
-
-    expect(result.text()).toMatch(/test the content around/);
   });
 });
 

--- a/ui/__tests__/components/node-renderers/heading.test.js
+++ b/ui/__tests__/components/node-renderers/heading.test.js
@@ -2,6 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import Heading from '../../../components/node-renderers/heading';
+import nodeFactory from '../../test-utils/node-factory';
 import {
   itIncludesNodeText,
   itIncludesTheIdentifier,
@@ -11,14 +12,14 @@ describe('<Heading />', () => {
   itIncludesNodeText(Heading);
   itIncludesTheIdentifier(Heading);
   it('generates an h1 when there are no sections', () => {
-    const docNode = { identifier: 'aaa_1__bbb_2__ccc_3' };
+    const docNode = nodeFactory({ identifier: 'aaa_1__bbb_2__ccc_3' });
     const result = shallow(<Heading docNode={docNode} />);
     expect(result.name()).toBe('h1');
   });
   it('generates an h4 if there are three sections', () => {
-    const docNode = {
+    const docNode = nodeFactory({
       identifier: 'root_1__sec_4__sec_a__appendix_A__sec_3__heading_1',
-    };
+    });
     const result = shallow(<Heading docNode={docNode} />);
     expect(result.name()).toBe('h4');
   });

--- a/ui/__tests__/components/node-renderers/policy.test.js
+++ b/ui/__tests__/components/node-renderers/policy.test.js
@@ -2,12 +2,11 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import Policy from '../../../components/node-renderers/policy';
+import nodeFactory from '../../test-utils/node-factory';
 import {
   itIncludesTheIdentifier,
   itRendersChildNodes,
 } from '../../test-utils/node-renderers';
-import DocumentNode from '../../../util/document-node';
-import { renderContent } from '../../../util/render-node';
 
 jest.mock('../../../util/render-node');
 
@@ -25,13 +24,7 @@ describe('<Policy />', () => {
   itRendersChildNodes(Policy, { meta });
 
   it('uses the policy for default text', () => {
-    const docNode = new DocumentNode({
-      children: [],
-      identifier: '',
-      meta,
-      text: '',
-    });
-    const result = shallow(<Policy docNode={docNode} />);
+    const result = shallow(<Policy docNode={nodeFactory({ meta })} />);
     const text = result.text();
     expect(text).toMatch(/M-44-55/);
     expect(text).toMatch(/Magistrate/);
@@ -47,7 +40,7 @@ describe('<Policy />', () => {
     expect(date.children().text()).toEqual('March 3, 2003');
   });
   it('can grab text from subnodes', () => {
-    const docNode = new DocumentNode({
+    const docNode = nodeFactory({
       children: [
         { children: [], node_type: 'other', text: 'other-text' },
         { children: [], node_type: 'subject', text: 'subject-here' },
@@ -56,9 +49,7 @@ describe('<Policy />', () => {
         { children: [], node_type: 'policyTitle', text: 'a title!' },
         { children: [], marker: 'Stuff:', node_type: 'from', text: 'Someone' },
       ],
-      identifier: '',
       meta,
-      text: '',
     });
 
     const result = shallow(<Policy docNode={docNode} />);
@@ -77,15 +68,12 @@ describe('<Policy />', () => {
     expect(date.children().text()).toEqual('some date here');
   });
   it('renders footnotes at the bottom', () => {
-    const docNode = new DocumentNode({
-      children: [],
-      identifier: '',
-      text: '',
+    const docNode = nodeFactory({
       meta: {
         ...meta,
         descendant_footnotes: [
-          { identifier: '1', children: [], content: ['a'], marker: '', type_emblem: '' },
-          { identifier: '2', children: [], content: ['b', 'c'], marker: '', type_emblem: '' },
+          { identifier: '1', children: [], content: [], marker: '', type_emblem: '' },
+          { identifier: '2', children: [], content: [], marker: '', type_emblem: '' },
           { identifier: '3', children: [], content: [], marker: '', type_emblem: '' },
         ],
       },
@@ -97,9 +85,5 @@ describe('<Policy />', () => {
     expect(footnotes.at(0).prop('docNode').identifier).toBe('1');
     expect(footnotes.at(1).prop('docNode').identifier).toBe('2');
     expect(footnotes.at(2).prop('docNode').identifier).toBe('3');
-    expect(renderContent).toHaveBeenCalledTimes(3);
-    expect(renderContent.mock.calls[0][0]).toEqual(['a']);
-    expect(renderContent.mock.calls[1][0]).toEqual(['b', 'c']);
-    expect(renderContent.mock.calls[2][0]).toEqual([]);
   });
 });

--- a/ui/__tests__/components/node-renderers/table/tfoot.test.js
+++ b/ui/__tests__/components/node-renderers/table/tfoot.test.js
@@ -75,4 +75,16 @@ describe('<Tfoot />', () => {
     expect(texts.at(1).prop('content').text).toBe('bbb');
     expect(texts.at(2).prop('content').text).toBe('ccc');
   });
+  it('includes a mangled version of the footnote identifier', () => {
+    const docNode = new DocumentNode({
+      children: [],
+      meta: {
+        descendant_footnotes: [
+          { content: [], identifier: 'footnote_1', marker: '' },
+        ],
+      },
+    });
+    const result = shallow(<Tfoot docNode={docNode} />);
+    expect(result.find('#footnote_1-table')).toHaveLength(1);
+  });
 });

--- a/ui/__tests__/components/node-renderers/td.test.js
+++ b/ui/__tests__/components/node-renderers/td.test.js
@@ -1,0 +1,10 @@
+import Td from '../../../components/node-renderers/td';
+import {
+  itRendersFootnoteCitationsDifferently,
+  itUsesTheAppropriateTag,
+} from '../../test-utils/tables';
+
+describe('<Td />', () => {
+  itRendersFootnoteCitationsDifferently(Td);
+  itUsesTheAppropriateTag(Td, 'td');
+});

--- a/ui/__tests__/components/node-renderers/th.test.js
+++ b/ui/__tests__/components/node-renderers/th.test.js
@@ -1,0 +1,11 @@
+import Th from '../../../components/node-renderers/th';
+import {
+  itRendersFootnoteCitationsDifferently,
+  itUsesTheAppropriateTag,
+} from '../../test-utils/tables';
+
+describe('<Th />', () => {
+  itRendersFootnoteCitationsDifferently(Th);
+  itUsesTheAppropriateTag(Th, 'th');
+});
+

--- a/ui/__tests__/test-utils/node-factory.js
+++ b/ui/__tests__/test-utils/node-factory.js
@@ -1,0 +1,16 @@
+import DocumentNode from '../../util/document-node';
+
+const defaults = {
+  children: [],
+  content: [],
+  identifier: '',
+  marker: '',
+  text: '',
+};
+
+export default function nodeFactory(attrs = null) {
+  return new DocumentNode({
+    ...defaults,
+    ...(attrs || {}),
+  });
+}

--- a/ui/__tests__/test-utils/node-renderers.js
+++ b/ui/__tests__/test-utils/node-renderers.js
@@ -1,15 +1,13 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import DocumentNode from '../../util/document-node';
 import renderNode from '../../util/render-node';
+import nodeFactory from './node-factory';
 
 export function itIncludesTheIdentifier(Component, extraAttrs) {
   it('includes the identifier', () => {
-    const docNode = new DocumentNode({
-      children: [],
+    const docNode = nodeFactory({
       identifier: 'aaa_1__bbb_2__ccc_3',
-      marker: '',
       ...(extraAttrs || {}),
     });
     const result = shallow(<Component docNode={docNode} />);
@@ -19,21 +17,18 @@ export function itIncludesTheIdentifier(Component, extraAttrs) {
 
 export function itIncludesNodeText(Component, extraAttrs) {
   it('includes node text', () => {
-    const docNode = new DocumentNode({
-      children: [],
-      identifier: '',
-      marker: '',
+    const docNode = nodeFactory({
+      content: [
+        { content_type: '__text__', text: 'Textextext' },
+        { content_type: '__text__', text: 'Moreoreore' },
+      ],
       ...(extraAttrs || {}),
     });
-    const result = shallow(
-      <Component docNode={docNode}>
-        <span id="some-contents">Textextext</span>
-      </Component>);
-    expect(result.text()).toMatch(/Textextext/);
-    const content = result.find('#some-contents');
-    expect(content).toHaveLength(1);
-    expect(content.name()).toBe('span');
-    expect(content.text()).toBe('Textextext');
+    const result = shallow(<Component docNode={docNode} />);
+    const plainTexts = result.find('PlainText');
+    expect(plainTexts).toHaveLength(2);
+    expect(plainTexts.first().prop('content')).toEqual(docNode.content[0]);
+    expect(plainTexts.last().prop('content')).toEqual(docNode.content[1]);
   });
 }
 
@@ -47,13 +42,11 @@ export function itRendersChildNodes(Component, extraAttrs) {
     renderNode.mockImplementationOnce(
       () => <child key="2">second child</child>);
 
-    const docNode = new DocumentNode({
+    const docNode = nodeFactory({
       children: [
         { children: [], node_type: 'first-child' },
         { children: [], node_type: 'second-child' },
       ],
-      identifier: '',
-      marker: '',
       ...(extraAttrs || {}),
     });
     const result = shallow(<Component docNode={docNode} />);

--- a/ui/__tests__/test-utils/tables.js
+++ b/ui/__tests__/test-utils/tables.js
@@ -1,0 +1,27 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import nodeFactory from './node-factory';
+
+export function itRendersFootnoteCitationsDifferently(Component) {
+  it('renders footnote citation differently', () => {
+    const content = [{
+      content_type: 'footnote_citation',
+      footnote_node: { identifier: 'some_footnote' },
+      text: '3',
+    }];
+    const docNode = nodeFactory({ content });
+    const result = shallow(<Component docNode={docNode} />);
+
+    const ft = result.find('FootnoteCitationInTable');
+    expect(ft).toHaveLength(1);
+    expect(ft.prop('content')).toEqual(content[0]);
+  });
+}
+
+export function itUsesTheAppropriateTag(Component, tagName) {
+  it('uses the appropriate tag', () => {
+    const result = shallow(<Component docNode={nodeFactory()} />);
+    expect(result.name()).toBe(tagName);
+  });
+}

--- a/ui/__tests__/util/render-contents.test.js
+++ b/ui/__tests__/util/render-contents.test.js
@@ -31,5 +31,12 @@ describe('renderContents()', () => {
     expect(c3.type).toBe(FootnoteCitation);
     expect(c3.props.content).toEqual(content[3]);
   });
+
+  it('allows renderers to be overridden', () => {
+    const content = [{ content_type: 'footnote_citation', text: 'aaaa' }];
+    const override = jest.fn();
+    const result = renderContents(content, { footnote_citation: override });
+    expect(result[0].type).toBe(override);
+  });
 });
 

--- a/ui/__tests__/util/render-contents.test.js
+++ b/ui/__tests__/util/render-contents.test.js
@@ -1,0 +1,35 @@
+import FootnoteCitation from '../../components/content-renderers/footnote-citation';
+import PlainText from '../../components/content-renderers/plain-text';
+import renderContents from '../../util/render-contents';
+
+
+describe('renderContents()', () => {
+  it('uses the appropriate renderers', () => {
+    const content = [
+      { content_type: '__text__', text: 'Some highlighted' },
+      {
+        content_type: 'footnote_citation',
+        footnote_node: { identifier: 'aaa_1__footnote_1' },
+        text: '1',
+      },
+      { content_type: '__text__', text: ' text here' },
+      {
+        content_type: 'footnote_citation',
+        footnote_node: { identifier: 'aaa_1__bbb_2__footnote_2' },
+        text: '2',
+      },
+    ];
+    const result = renderContents(content);
+    expect(result).toHaveLength(4);
+    const [c0, c1, c2, c3] = result;
+    expect(c0.type).toBe(PlainText);
+    expect(c0.props.content).toEqual(content[0]);
+    expect(c1.type).toBe(FootnoteCitation);
+    expect(c1.props.content).toEqual(content[1]);
+    expect(c2.type).toBe(PlainText);
+    expect(c2.props.content).toEqual(content[2]);
+    expect(c3.type).toBe(FootnoteCitation);
+    expect(c3.props.content).toEqual(content[3]);
+  });
+});
+

--- a/ui/__tests__/util/render-node.test.js
+++ b/ui/__tests__/util/render-node.test.js
@@ -1,5 +1,3 @@
-import FootnoteCitation from '../../components/content-renderers/footnote-citation';
-import PlainText from '../../components/content-renderers/plain-text';
 import Fallback from '../../components/node-renderers/fallback';
 import Noop from '../../components/node-renderers/noop';
 import Paragraph from '../../components/node-renderers/para';
@@ -30,40 +28,6 @@ describe('renderNode()', () => {
     const result = renderNode(docNode);
     expect(result.type).toBe(Fallback);
     expect(result.props.docNode).toEqual(docNode);
-  });
-  it('renders the "content" field', () => {
-    const docNode = {
-      identifier: 'aaa_1',
-      node_type: 'aaa',
-      text: 'Some highlighted1 text here2',
-      content: [
-        { content_type: '__text__', text: 'Some highlighted' },
-        {
-          content_type: 'footnote_citation',
-          footnote_node: { identifier: 'aaa_1__footnote_1' },
-          text: '1',
-        },
-        { content_type: '__text__', text: ' text here' },
-        {
-          content_type: 'footnote_citation',
-          footnote_node: { identifier: 'aaa_1__bbb_2__footnote_2' },
-          text: '2',
-        },
-      ],
-      children: [],
-    };
-    const result = renderNode(docNode);
-    const renderedContent = result.props.children;
-    expect(renderedContent).toHaveLength(4);
-    const [c0, c1, c2, c3] = renderedContent;
-    expect(c0.type).toBe(PlainText);
-    expect(c0.props.content).toEqual(docNode.content[0]);
-    expect(c1.type).toBe(FootnoteCitation);
-    expect(c1.props.content).toEqual(docNode.content[1]);
-    expect(c2.type).toBe(PlainText);
-    expect(c2.props.content).toEqual(docNode.content[2]);
-    expect(c3.type).toBe(FootnoteCitation);
-    expect(c3.props.content).toEqual(docNode.content[3]);
   });
   it('does not render preambles', () => {
     const docNode = {

--- a/ui/components/content-renderers/footnote-citation-in-table.js
+++ b/ui/components/content-renderers/footnote-citation-in-table.js
@@ -1,0 +1,17 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Link from '../link';
+
+export default function FootnoteCitationInTable({ content }) {
+  const href = `#${content.footnote_node.identifier}-table`;
+  return <sup><Link href={href}>{ content.text }</Link></sup>;
+}
+FootnoteCitationInTable.propTypes = {
+  content: PropTypes.shape({
+    footnote_node: PropTypes.shape({
+      identifier: PropTypes.string.isRequired,
+    }).isRequired,
+    text: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/ui/components/content-renderers/footnote-citation.js
+++ b/ui/components/content-renderers/footnote-citation.js
@@ -4,9 +4,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import Link from '../link';
-import { renderContent } from '../../util/render-node';
 import { closeFootnote, openFootnote } from '../../store/actions';
-
 import Footnote from '../node-renderers/footnote';
 
 export class FootnoteCitation extends React.Component {
@@ -66,10 +64,8 @@ export class FootnoteCitation extends React.Component {
     );
     if (expanded) {
       footnoteContent = (
-        <span className="citation-wrapper" role="alertdialog" aria-label={`Footnote ${footnote.marker}`} tabIndex="-1" ref={(el) => { this.citationWrapper = el; }}>
-          <Footnote docNode={footnote}>
-            { renderContent(footnote.content) }
-          </Footnote>
+        <span className="footnote-wrapper" role="alertdialog" aria-label={`Footnote ${footnote.marker}`} tabIndex="-1" ref={(el) => { this.citationWrapper = el; }}>
+          <Footnote docNode={footnote} />
           <span className="clearfix" />
           <button className="close-button" onClick={this.shrinkFootnote}>Close</button>
         </span>

--- a/ui/components/node-renderers/caption.js
+++ b/ui/components/node-renderers/caption.js
@@ -3,11 +3,16 @@ import React from 'react';
 
 import renderContents from '../../util/render-contents';
 import renderNode from '../../util/render-node';
+import FootnoteCitationInTable from '../content-renderers/footnote-citation-in-table';
 
 export default function Caption({ docNode }) {
+  const content = renderContents(
+    docNode.content,
+    { footnote_citation: FootnoteCitationInTable },
+  );
   return (
     <caption className="node-caption" id={docNode.identifier}>
-      { renderContents(docNode.content) }
+      { content }
       { docNode.children.map(renderNode) }
     </caption>
   );

--- a/ui/components/node-renderers/caption.js
+++ b/ui/components/node-renderers/caption.js
@@ -1,23 +1,24 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import renderContents from '../../util/render-contents';
 import renderNode from '../../util/render-node';
 
-export default function Caption({ children, docNode }) {
+export default function Caption({ docNode }) {
   return (
     <caption className="node-caption" id={docNode.identifier}>
-      { children }
+      { renderContents(docNode.content) }
       { docNode.children.map(renderNode) }
     </caption>
   );
 }
 Caption.propTypes = {
-  children: PropTypes.node,
   docNode: PropTypes.shape({
     children: PropTypes.arrayOf(PropTypes.shape({})).isRequired, // recursive
+    content: PropTypes.arrayOf(PropTypes.shape({
+      content_type: PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
+    })).isRequired,
     identifier: PropTypes.string.isRequired,
   }).isRequired,
-};
-Caption.defaultProps = {
-  children: null,
 };

--- a/ui/components/node-renderers/fallback.js
+++ b/ui/components/node-renderers/fallback.js
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import renderContents from '../../util/render-contents';
 import renderNode from '../../util/render-node';
 
 /* We've been asked to render a node we don't have a renderer for. We'll do
  * our best but flag it when in development mode */
-export default function Fallback({ children, docNode }) {
+export default function Fallback({ docNode }) {
   const props = {
     className: 'node-fallback',
     id: docNode.identifier,
@@ -16,18 +17,18 @@ export default function Fallback({ children, docNode }) {
   }
   return (
     <div {...props}>
-      <p className="m0">{ children }</p>
+      <p className="m0">{ renderContents(docNode.content) }</p>
       { docNode.children.map(renderNode) }
     </div>
   );
 }
 Fallback.propTypes = {
-  children: PropTypes.node,
   docNode: PropTypes.shape({
     children: PropTypes.arrayOf(PropTypes.shape({})).isRequired, // recursive
+    content: PropTypes.arrayOf(PropTypes.shape({
+      content_type: PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
+    })).isRequired,
     identifier: PropTypes.string.isRequired,
   }).isRequired,
-};
-Fallback.defaultProps = {
-  children: null,
 };

--- a/ui/components/node-renderers/footnote.js
+++ b/ui/components/node-renderers/footnote.js
@@ -1,31 +1,28 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default function Footnote({ children, docNode }) {
+import renderContents from '../../util/render-contents';
+
+export default function Footnote({ docNode }) {
   return (
     <span className="clearfix node-footnote" id={docNode.identifier}>
       <span className="node-footnote-content">
         <span className="citation-marker">
           { docNode.marker }
         </span>
-        <p className="footnote-text">{ children }</p>
+        <p className="footnote-text">{ renderContents(docNode.content) }</p>
       </span>
     </span>
   );
 }
 Footnote.propTypes = {
-  children: PropTypes.node,
   docNode: PropTypes.shape({
     children: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+    content: PropTypes.arrayOf(PropTypes.shape({
+      content_type: PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
+    })).isRequired,
     identifier: PropTypes.string.isRequired,
     marker: PropTypes.string,
   }).isRequired,
-};
-Footnote.defaultProps = {
-  children: null,
-  docNode: {
-    children: [],
-    identifier: '',
-    marker: '',
-  },
 };

--- a/ui/components/node-renderers/heading.js
+++ b/ui/components/node-renderers/heading.js
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import renderContents from '../../util/render-contents';
+
 /* An h1/2/3/etc. depending on section depth */
-export default function Heading({ children, docNode }) {
+export default function Heading({ docNode }) {
   const hLevel = docNode.identifier
     .split('_')
     .filter(e => e === 'sec')
@@ -10,16 +12,16 @@ export default function Heading({ children, docNode }) {
   const Component = `h${hLevel}`;
   return (
     <Component className="node-heading" id={docNode.identifier}>
-      { children }
+      { renderContents(docNode.content) }
     </Component>
   );
 }
 Heading.propTypes = {
-  children: PropTypes.node,
   docNode: PropTypes.shape({
+    content: PropTypes.arrayOf(PropTypes.shape({
+      content_type: PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
+    })).isRequired,
     identifier: PropTypes.string.isRequired,
   }).isRequired,
-};
-Heading.defaultProps = {
-  children: null,
 };

--- a/ui/components/node-renderers/para.js
+++ b/ui/components/node-renderers/para.js
@@ -1,24 +1,25 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import renderContents from '../../util/render-contents';
 import renderNode from '../../util/render-node';
 
 /* Paragraph of text */
-export default function Paragraph({ children, docNode }) {
+export default function Paragraph({ docNode }) {
   return (
     <div className="node-paragraph" id={docNode.identifier}>
-      <p className="m0">{ children }</p>
+      <p className="m0">{ renderContents(docNode.content) }</p>
       { docNode.children.map(renderNode) }
     </div>
   );
 }
 Paragraph.propTypes = {
-  children: PropTypes.node,
   docNode: PropTypes.shape({
+    content: PropTypes.arrayOf(PropTypes.shape({
+      content_type: PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
+    })).isRequired,
     children: PropTypes.arrayOf(PropTypes.shape({})).isRequired, // recursive
     identifier: PropTypes.string.isRequired,
   }).isRequired,
-};
-Paragraph.defaultProps = {
-  children: null,
 };

--- a/ui/components/node-renderers/policy.js
+++ b/ui/components/node-renderers/policy.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import renderNode, { renderContent } from '../../util/render-node';
+import renderNode from '../../util/render-node';
 import LabeledText from '../labeled-text';
 import Link from '../link';
 import Footnote from './footnote';
@@ -20,9 +20,7 @@ function footnotes(footnoteList) {
     return null;
   }
   const rendered = footnoteList.map(fn => (
-    <Footnote key={fn.identifier} docNode={fn}>
-      { renderContent(fn.content) }
-    </Footnote>
+    <Footnote key={fn.identifier} docNode={fn} />
   ));
   return (
     <div className="bottom-footnotes">

--- a/ui/components/node-renderers/table/tfoot.js
+++ b/ui/components/node-renderers/table/tfoot.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { renderContent } from '../../../util/render-node';
+import renderContents from '../../../util/render-contents';
 
 /* We're assuming, for the time being, that all rows within a single table
  * have the same number of columns. */
@@ -15,7 +15,7 @@ export default function Tfoot({ docNode }) {
   const footnotes = docNode.meta.descendant_footnotes.map(ft => (
     <div className="clearfix" key={ft.identifier}>
       <div className="col col-1">{ft.marker}</div>
-      <div className="col col-11">{ renderContent(ft.content) }</div>
+      <div className="col col-11">{ renderContents(ft.content) }</div>
     </div>
   ));
   if (footnotes.length === 0) {

--- a/ui/components/node-renderers/table/tfoot.js
+++ b/ui/components/node-renderers/table/tfoot.js
@@ -13,7 +13,7 @@ function deriveColspan(docNode) {
 
 export default function Tfoot({ docNode }) {
   const footnotes = docNode.meta.descendant_footnotes.map(ft => (
-    <div className="clearfix" key={ft.identifier}>
+    <div className="clearfix" key={ft.identifier} id={`${ft.identifier}-table`}>
       <div className="col col-1">{ft.marker}</div>
       <div className="col col-11">{ renderContents(ft.content) }</div>
     </div>

--- a/ui/components/node-renderers/td.js
+++ b/ui/components/node-renderers/td.js
@@ -1,23 +1,24 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import renderContents from '../../util/render-contents';
 import renderNode from '../../util/render-node';
 
-export default function Td({ children, docNode }) {
+export default function Td({ docNode }) {
   return (
     <td className="basic-td" id={docNode.identifier}>
-      { children }
+      { renderContents(docNode.content) }
       { docNode.children.map(renderNode) }
     </td>
   );
 }
 Td.propTypes = {
-  children: PropTypes.node,
   docNode: PropTypes.shape({
     children: PropTypes.arrayOf(PropTypes.shape({})).isRequired, // recursive
+    content: PropTypes.arrayOf(PropTypes.shape({
+      content_type: PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
+    })).isRequired,
     identifier: PropTypes.string.isRequired,
   }).isRequired,
-};
-Td.defaultProps = {
-  children: null,
 };

--- a/ui/components/node-renderers/td.js
+++ b/ui/components/node-renderers/td.js
@@ -3,11 +3,16 @@ import React from 'react';
 
 import renderContents from '../../util/render-contents';
 import renderNode from '../../util/render-node';
+import FootnoteCitationInTable from '../content-renderers/footnote-citation-in-table';
 
 export default function Td({ docNode }) {
+  const content = renderContents(
+    docNode.content,
+    { footnote_citation: FootnoteCitationInTable },
+  );
   return (
     <td className="basic-td" id={docNode.identifier}>
-      { renderContents(docNode.content) }
+      { content }
       { docNode.children.map(renderNode) }
     </td>
   );

--- a/ui/components/node-renderers/th.js
+++ b/ui/components/node-renderers/th.js
@@ -3,11 +3,16 @@ import React from 'react';
 
 import renderContents from '../../util/render-contents';
 import renderNode from '../../util/render-node';
+import FootnoteCitationInTable from '../content-renderers/footnote-citation-in-table';
 
 export default function Th({ docNode }) {
+  const content = renderContents(
+    docNode.content,
+    { footnote_citation: FootnoteCitationInTable },
+  );
   return (
     <th className="basic-th" id={docNode.identifier}>
-      { renderContents(docNode.content) }
+      { content }
       { docNode.children.map(renderNode) }
     </th>
   );

--- a/ui/components/node-renderers/th.js
+++ b/ui/components/node-renderers/th.js
@@ -1,23 +1,24 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import renderContents from '../../util/render-contents';
 import renderNode from '../../util/render-node';
 
-export default function Th({ children, docNode }) {
+export default function Th({ docNode }) {
   return (
     <th className="basic-th" id={docNode.identifier}>
-      { children }
+      { renderContents(docNode.content) }
       { docNode.children.map(renderNode) }
     </th>
   );
 }
 Th.propTypes = {
-  children: PropTypes.node,
   docNode: PropTypes.shape({
     children: PropTypes.arrayOf(PropTypes.shape({})).isRequired, // recursive
+    content: PropTypes.arrayOf(PropTypes.shape({
+      content_type: PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
+    })).isRequired,
     identifier: PropTypes.string.isRequired,
   }).isRequired,
-};
-Th.defaultProps = {
-  children: null,
 };

--- a/ui/util/render-contents.js
+++ b/ui/util/render-contents.js
@@ -5,9 +5,10 @@ import PlainText from '../components/content-renderers/plain-text';
 
 /* Looks up the React Component for each element in the contents field and
  * renders it */
-export default function renderContents(contents) {
+export default function renderContents(contents, overrideMapping = null) {
   const contentMapping = {
     footnote_citation: FootnoteCitation,
+    ...(overrideMapping || {}),
   };
 
   return contents.map((content, idx) => {

--- a/ui/util/render-contents.js
+++ b/ui/util/render-contents.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import FootnoteCitation from '../components/content-renderers/footnote-citation';
+import PlainText from '../components/content-renderers/plain-text';
+
+/* Looks up the React Component for each element in the contents field and
+ * renders it */
+export default function renderContents(contents) {
+  const contentMapping = {
+    footnote_citation: FootnoteCitation,
+  };
+
+  return contents.map((content, idx) => {
+    const ContentComponent = contentMapping[content.content_type] || PlainText;
+    // We're guaranteed these have a consistent order
+    /* eslint-disable react/no-array-index-key */
+    return <ContentComponent content={content} key={idx} />;
+    /* eslint-enable react/no-array-index-key */
+  });
+}

--- a/ui/util/render-node.js
+++ b/ui/util/render-node.js
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import FootnoteCitation from '../components/content-renderers/footnote-citation';
-import PlainText from '../components/content-renderers/plain-text';
 import Fallback from '../components/node-renderers/fallback';
 import caption from '../components/node-renderers/caption';
 import heading from '../components/node-renderers/heading';
@@ -18,22 +16,6 @@ import thead from '../components/node-renderers/thead';
 import td from '../components/node-renderers/td';
 import tr from '../components/node-renderers/tr';
 import th from '../components/node-renderers/th';
-
-/* Looks up the React Component for each element in the contents field and
- * renders it */
-export function renderContent(contents) {
-  const contentMapping = {
-    footnote_citation: FootnoteCitation,
-  };
-
-  return contents.map((content, idx) => {
-    const ContentComponent = contentMapping[content.content_type] || PlainText;
-    // We're guaranteed these have a consistent order
-    /* eslint-disable react/no-array-index-key */
-    return <ContentComponent content={content} key={idx} />;
-    /* eslint-enable react/no-array-index-key */
-  });
-}
 
 /* Looks up the React Component for this type of docNode and renders it */
 export default function renderNode(docNode) {
@@ -57,9 +39,5 @@ export default function renderNode(docNode) {
   };
   const NodeComponent = nodeMapping[docNode.node_type] || Fallback;
   const props = { docNode, key: docNode.identifier };
-  return (
-    <NodeComponent {...props}>
-      { renderContent(docNode.content) }
-    </NodeComponent>
-  );
+  return <NodeComponent {...props} />;
 }


### PR DESCRIPTION
As part of #623, this renders footnote citations within tables differently than the rest of the document by:
1. allowing individual node renderers to override how their content is rendered
2. adding a custom renderer for footnote citations for use within tables.

The big change about the former is a change in the way we render content (specifically, inline text, citations, etc.) Rather than having `renderNode` pass the rendered content along, this pushes the render logic into the components:

```jsx
<Footnote docNode={docNode}>
  { renderContents(docNode.content) }
</Footnote>

function Footnote({ children, docNode }) {
  return <div id={docNode.identifier}>{ children }</div>;
}
```

becomes:

```jsx
<Footnote docNode={docNode} />

function Footnote({ docNode }) {
  return <div id={docNode.identifier}>{ renderContents(docNode.content) }</div>
}
```