### PR TITLE
[WIP] Attempt to link to policy detail

### DIFF
--- a/api/reqs/serializers.py
+++ b/api/reqs/serializers.py
@@ -24,7 +24,7 @@ class GroupWithAgenciesSerializer(serializers.ModelSerializer):
 
 
 class PolicySerializer(serializers.ModelSerializer):
-    boop = serializers.IntegerField(read_only=True)
+    boop = serializers.BooleanField(read_only=True)
     total_reqs = serializers.IntegerField(read_only=True)
     relevant_reqs = serializers.IntegerField(read_only=True)
     title_with_number = serializers.CharField(read_only=True)

--- a/api/reqs/serializers.py
+++ b/api/reqs/serializers.py
@@ -24,6 +24,7 @@ class GroupWithAgenciesSerializer(serializers.ModelSerializer):
 
 
 class PolicySerializer(serializers.ModelSerializer):
+    boop = serializers.IntegerField(read_only=True)
     total_reqs = serializers.IntegerField(read_only=True)
     relevant_reqs = serializers.IntegerField(read_only=True)
     title_with_number = serializers.CharField(read_only=True)
@@ -46,6 +47,7 @@ class PolicySerializer(serializers.ModelSerializer):
             'title_with_number',
             'total_reqs',
             'uri',
+            'boop',
         )
 
 

--- a/api/reqs/serializers.py
+++ b/api/reqs/serializers.py
@@ -24,7 +24,7 @@ class GroupWithAgenciesSerializer(serializers.ModelSerializer):
 
 
 class PolicySerializer(serializers.ModelSerializer):
-    boop = serializers.BooleanField(read_only=True)
+    has_docnode = serializers.BooleanField(read_only=True)
     total_reqs = serializers.IntegerField(read_only=True)
     relevant_reqs = serializers.IntegerField(read_only=True)
     title_with_number = serializers.CharField(read_only=True)
@@ -47,7 +47,7 @@ class PolicySerializer(serializers.ModelSerializer):
             'title_with_number',
             'total_reqs',
             'uri',
-            'boop',
+            'has_docnode',
         )
 
 

--- a/api/reqs/tests/views_policies_tests.py
+++ b/api/reqs/tests/views_policies_tests.py
@@ -70,14 +70,14 @@ def test_docnode_count_works(policy_setup):
     path = "/policies/?requirements__req_id=" + reqs[1][1].req_id
     response = client.get(path).json()
 
-    assert response['results'][0]['boop'] == 0
+    assert response['results'][0]['boop'] is False
 
     policies[1].docnode = mommy.make(DocNode, policy=policies[1])
     policies[1].save()
 
     response = client.get(path).json()
 
-    assert response['results'][0]['boop'] == 1
+    assert response['results'][0]['boop'] is True
 
 
 @pytest.mark.django_db

--- a/api/reqs/tests/views_policies_tests.py
+++ b/api/reqs/tests/views_policies_tests.py
@@ -62,6 +62,17 @@ def test_topics_counts_filter_req(policy_topic_setup):
 
 
 @pytest.mark.django_db
+def test_docnode_count_works(policy_topic_setup):
+    (_, reqs), topics = policy_topic_setup
+    client = APIClient()
+
+    path = "/policies/?requirements__topics__id__in={0}".format(topics[0].pk)
+    response = client.get(path).json()
+
+    assert response['results'][0]['boop'] == 0
+
+
+@pytest.mark.django_db
 def test_topics_counts_filter_by_one_topic(policy_topic_setup):
     """The API endpoint should include only relevant policies when we filter
     by a single topic"""

--- a/api/reqs/tests/views_policies_tests.py
+++ b/api/reqs/tests/views_policies_tests.py
@@ -63,21 +63,21 @@ def test_topics_counts_filter_req(policy_topic_setup):
 
 
 @pytest.mark.django_db
-def test_docnode_count_works(policy_setup):
+def test_has_docnode_works(policy_setup):
     (policies, reqs) = policy_setup
     client = APIClient()
 
     path = "/policies/?requirements__req_id=" + reqs[1][1].req_id
     response = client.get(path).json()
 
-    assert response['results'][0]['boop'] is False
+    assert response['results'][0]['has_docnode'] is False
 
     policies[1].docnode = mommy.make(DocNode, policy=policies[1])
     policies[1].save()
 
     response = client.get(path).json()
 
-    assert response['results'][0]['boop'] is True
+    assert response['results'][0]['has_docnode'] is True
 
 
 @pytest.mark.django_db

--- a/api/reqs/tests/views_policies_tests.py
+++ b/api/reqs/tests/views_policies_tests.py
@@ -5,6 +5,7 @@ from django.http import Http404
 from model_mommy import mommy
 from rest_framework.test import APIClient
 
+from document.models import DocNode
 from reqs.models import Agency, AgencyGroup, Policy, Requirement, Topic
 from reqs.views import policies as policies_views
 
@@ -62,14 +63,21 @@ def test_topics_counts_filter_req(policy_topic_setup):
 
 
 @pytest.mark.django_db
-def test_docnode_count_works(policy_topic_setup):
-    (_, reqs), topics = policy_topic_setup
+def test_docnode_count_works(policy_setup):
+    (policies, reqs) = policy_setup
     client = APIClient()
 
-    path = "/policies/?requirements__topics__id__in={0}".format(topics[0].pk)
+    path = "/policies/?requirements__req_id=" + reqs[1][1].req_id
     response = client.get(path).json()
 
     assert response['results'][0]['boop'] == 0
+
+    policies[1].docnode = mommy.make(DocNode, policy=policies[1])
+    policies[1].save()
+
+    response = client.get(path).json()
+
+    assert response['results'][0]['boop'] == 1
 
 
 @pytest.mark.django_db

--- a/api/reqs/views/policies.py
+++ b/api/reqs/views/policies.py
@@ -85,7 +85,7 @@ class PolicyViewSet(viewsets.ModelViewSet):
         queryset = super().get_queryset()
         queryset = queryset.filter(public=True)
         queryset = queryset.annotate(
-            boop=Exists(DocNode.objects.filter(
+            has_docnode=Exists(DocNode.objects.filter(
                 policy=OuterRef('pk'),
             )),
             total_reqs=relevant_reqs_count({}),

--- a/api/reqs/views/policies.py
+++ b/api/reqs/views/policies.py
@@ -84,6 +84,7 @@ class PolicyViewSet(viewsets.ModelViewSet):
         queryset = super().get_queryset()
         queryset = queryset.filter(public=True)
         queryset = queryset.annotate(
+            boop=Count('docnode'),
             total_reqs=relevant_reqs_count({}),
             relevant_reqs=relevant_reqs_count(self.request.GET),
         ).filter(relevant_reqs__gt=0)

--- a/api/reqs/views/policies.py
+++ b/api/reqs/views/policies.py
@@ -1,7 +1,8 @@
-from django.db.models import Count, IntegerField, OuterRef, Subquery
+from django.db.models import Count, IntegerField, OuterRef, Subquery, Exists
 from django.http import Http404
 from rest_framework import viewsets
 
+from document.models import DocNode
 from reqs.filtersets import (AgencyFilter, AgencyGroupFilter, PolicyFilter,
                              RequirementFilter, TopicFilter)
 from reqs.models import Agency, AgencyGroup, Policy, Requirement, Topic
@@ -84,7 +85,9 @@ class PolicyViewSet(viewsets.ModelViewSet):
         queryset = super().get_queryset()
         queryset = queryset.filter(public=True)
         queryset = queryset.annotate(
-            boop=Count('docnode'),
+            boop=Exists(DocNode.objects.filter(
+                policy=OuterRef('pk'),
+            )),
             total_reqs=relevant_reqs_count({}),
             relevant_reqs=relevant_reqs_count(self.request.GET),
         ).filter(relevant_reqs__gt=0)

--- a/api/reqs/views/policies.py
+++ b/api/reqs/views/policies.py
@@ -1,4 +1,4 @@
-from django.db.models import Count, IntegerField, OuterRef, Subquery, Exists
+from django.db.models import Count, Exists, IntegerField, OuterRef, Subquery
 from django.http import Http404
 from rest_framework import viewsets
 

--- a/ui/__tests__/components/policies/policy-view.test.js
+++ b/ui/__tests__/components/policies/policy-view.test.js
@@ -1,0 +1,39 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import PolicyView from '../../../components/policies/policy-view';
+
+describe('<PolicyView />', () => {
+  const basePolicy = {
+    id: 1,
+    title_with_number: 'Funky Policy',
+    omb_policy_id: 'M-16-19',
+    has_docnode: false,
+    relevant_reqs: 1,
+    total_reqs: 2,
+  };
+
+  it('does not link to policy if no docnode for it exists', () => {
+    const policy = {
+      ...basePolicy,
+      has_docnode: false,
+    };
+    const result = shallow(<PolicyView policy={policy} topicsIds="" />);
+    expect(result.find('h2 Link').exists()).toBeFalsy();
+    expect(result.find('h2').text()).toEqual('Funky Policy');
+  });
+
+  it('links to policy if a docnode for it exists', () => {
+    const policy = {
+      ...basePolicy,
+      has_docnode: true,
+    };
+    const result = shallow(<PolicyView policy={policy} topicsIds="" />);
+    const link = result.find('h2 Link');
+    expect(link.exists()).toBeTruthy();
+    expect(link.prop('params')).toEqual({
+      policyId: 'M-16-19',
+    });
+    expect(link.children().text()).toEqual('Funky Policy');
+  });
+});

--- a/ui/components/policies/policy-view.js
+++ b/ui/components/policies/policy-view.js
@@ -56,6 +56,8 @@ Policy.propTypes = {
     title_with_number: PropTypes.string,
     relevant_reqs: PropTypes.number,
     total_reqs: PropTypes.number,
+    has_docnode: PropTypes.bool,
+    omb_policy_id: PropTypes.string,
   }),
   topicsIds: PropTypes.string,
 };

--- a/ui/components/policies/policy-view.js
+++ b/ui/components/policies/policy-view.js
@@ -10,10 +10,20 @@ export default function Policy({ policy, topicsIds }) {
   };
   const relevantReqCount = policy.relevant_reqs >= 100 ? '99+' : policy.relevant_reqs;
   const countClass = relevantReqCount === '99+' ? 'ninety-nine-plus' : '';
+  let policyTitle = policy.title_with_number;
+
+  if (policy.omb_policy_id && policy.boop) {
+    policyTitle = (
+      <Link route="document" params={{policyId: policy.omb_policy_id}}>
+        {policyTitle}
+      </Link>
+    );
+  }
+
   return (
     <li key={policy.id} className="my2">
       <section className="policy border rounded gray-border p2">
-        <h2 className="mt0 mb3">{policy.title_with_number}</h2>
+        <h2 className="mt0 mb3">{policyTitle}</h2>
         <div className="clearfix">
           <div className="requirements-links mb1 sm-col sm-col-12 md-col-8">
             <div className="circle-bg border gray-border center p1">

--- a/ui/components/policies/policy-view.js
+++ b/ui/components/policies/policy-view.js
@@ -14,7 +14,7 @@ export default function Policy({ policy, topicsIds }) {
 
   if (policy.omb_policy_id && policy.boop) {
     policyTitle = (
-      <Link route="document" params={{policyId: policy.omb_policy_id}}>
+      <Link route="document" params={{ policyId: policy.omb_policy_id }}>
         {policyTitle}
       </Link>
     );

--- a/ui/components/policies/policy-view.js
+++ b/ui/components/policies/policy-view.js
@@ -12,7 +12,7 @@ export default function Policy({ policy, topicsIds }) {
   const countClass = relevantReqCount === '99+' ? 'ninety-nine-plus' : '';
   let policyTitle = policy.title_with_number;
 
-  if (policy.omb_policy_id && policy.boop) {
+  if (policy.omb_policy_id && policy.has_docnode) {
     policyTitle = (
       <Link route="document" params={{ policyId: policy.omb_policy_id }}>
         {policyTitle}


### PR DESCRIPTION
One day, this might fix #556, but for now

<img src="https://i.redd.it/2a1tdpd5lg1y.jpg">

Interesting things that have happened so far:

* ~~I originally tried adding a property to the policy API response called `docnode_count`, but this caused next.js to fail while rendering the homepage, claiming that it was being asked to JSONify a self-referential object. I have no idea why it felt that way, but renaming the field to `boop` somehow fixed things.~~ **Update:** CM explained the error and I've filed #665 separately.

* ~~Even once I called the field `boop` and it showed up in unit tests, it still wasn't showing up in API responses.  Eventually I did `docker-compose up dev-api` and intentionally broke the API by adding a nonsensical field, and when I fixed it and the server restarted itself, `boop` was in the API responses. So I guess something weird was being cached somewhere.~~ Apparently the app has a LRU cache for API results both in the browser and on the server, so I need to restart the server for stuff to take effect properly.

## To do

- [x] Figure out how to rename `boop` to `has_docnode` and change the data type to a boolean instead of an int.
- [x] Add tests for the front-end.
- [x] Add a test to the back-end that verifies that `has_docnode` is `true` when it should be.
- [ ] If the OMB policy ID doesn't exist for the document, we need to fall back to its slug.
