### PR TITLE
Footnote citation links in maths!

### DIFF
--- a/api/example_docs/m_16_19_1.xml
+++ b/api/example_docs/m_16_19_1.xml
@@ -708,6 +708,7 @@
                           \textit{Total Active}
                           \\
                           \textit{Rack Count}
+                          <footnote_citation>28</footnote_citation>
                         \end{matrix}
                         *
                         \textit{30 sq. ft.}
@@ -716,9 +717,6 @@
                       }
                     </content>
                   </math>
-                  <content>
-                    <footnote_citation>28</footnote_citation>
-                  </content>
                   <footnote emblem="28" marker="28">
                     “Active” racks are those that have IT equipment
                     consuming electricity.

--- a/ui/__tests__/components/node-renderers/math.test.js
+++ b/ui/__tests__/components/node-renderers/math.test.js
@@ -1,6 +1,7 @@
 import { mount } from 'enzyme';
 import React from 'react';
-import TeXMath from '../../../components/node-renderers/math';
+import TeXMath, { texFromContents } from '../../../components/node-renderers/math';
+import nodeFactory from '../../test-utils/node-factory';
 import {
   itIncludesTheIdentifier,
 } from '../../test-utils/node-renderers';
@@ -8,16 +9,60 @@ import {
 jest.mock('../../../util/render-node');
 
 describe('<TeXMath />', () => {
-  itIncludesTheIdentifier(TeXMath, { text: 'abcd' });
+  itIncludesTheIdentifier(TeXMath);
   it('generates something math-like', () => {
-    const docNode = {
-      identifier: 'aaa_1__bbb_2__ccc_3_math',
-      text: '\\frac{12345654321}{10987678901}',
-    };
+    const docNode = nodeFactory({
+      content: [
+        { content_type: '__text__', text: '\\frac{12345654321}{10987678901}' },
+      ],
+    });
     const result = mount(<TeXMath docNode={docNode} />);
     expect(result.render().find('span.katex')).toHaveLength(1);
     expect(result.text()).toContain('12345654321');
     expect(result.text()).toContain('10987678901');
   });
+  it('generates inline links', () => {
+    const docNode = nodeFactory({
+      content: [
+        { content_type: '__text__', text: '\\frac{top' },
+        { content_type: 'footnote_citation',
+          footnote_node: { identifier: 'some_1__footnote_2' },
+          text: '14',
+        },
+        { content_type: '__text__', text: '}{bottom}' },
+      ],
+    });
+    const html = mount(<TeXMath docNode={docNode} />).html();
+    expect(html).toMatch(/<a/);
+    expect(html).toMatch(/#some_1__footnote_2/);
+  });
 });
 
+describe('texFromContents()', () => {
+  it('renders both text and footnotes', () => {
+    const contents = [
+      { content_type: '__text__', text: 'Some prefix ' },
+      { content_type: 'footnote_citation',
+        footnote_node: { identifier: 'aaa_1__bbb_2' },
+        text: '62',
+      },
+      { content_type: '__text__', text: ' suffix' },
+    ];
+    expect(texFromContents(contents)).toBe(
+      // All underscores and the pound character need to be escaped in TeX
+      'Some prefix ^{\\textit{[62](\\#aaa\\_1\\_\\_bbb\\_2)}} suffix');
+  });
+  it('renders footnote citations in tables differently', () => {
+    const contents = [
+      { content_type: 'footnote_citation',
+        footnote_node: { identifier: 'aaa_1__bbb_2' },
+        text: '62',
+      },
+    ];
+    // All underscores and the pound character need to be escaped in TeX
+    expect(texFromContents(contents)).toBe(
+      '^{\\textit{[62](\\#aaa\\_1\\_\\_bbb\\_2)}}');
+    expect(texFromContents(contents, true)).toBe(
+      '^{\\textit{[62](\\#aaa\\_1\\_\\_bbb\\_2-table)}}');
+  });
+});

--- a/ui/__tests__/util/document-node.test.js
+++ b/ui/__tests__/util/document-node.test.js
@@ -47,3 +47,22 @@ describe('firstWithNodeType()', () => {
     expect(result).toBeNull();
   });
 });
+
+describe('hasAncestor()', () => {
+  it('must be present', () => {
+    const node = new DocumentNode({
+      children: [],
+      identifier: 'aaa_1__bbb_2__ccc_3',
+    });
+    expect(node.hasAncestor('ddd')).toBe(false);
+    expect(node.hasAncestor('bbb')).toBe(true);
+  });
+  it('must be an exact match', () => {
+    const node = new DocumentNode({
+      children: [],
+      identifier: 'aaa_1__bbbb_2__ccc_3',
+    });
+    expect(node.hasAncestor('bbb')).toBe(false);
+    expect(node.hasAncestor('bbbb')).toBe(true);
+  });
+});

--- a/ui/components/node-renderers/math.js
+++ b/ui/components/node-renderers/math.js
@@ -1,11 +1,50 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import katex from 'katex';
+
+export function texFromContents(contents, inTable = false) {
+  const texts = contents.map((content) => {
+    switch (content.content_type) {
+      case 'footnote_citation': {
+        // TeX requires all underscores be escaped
+        let url = content.footnote_node.identifier.replace(/_/g, '\\_');
+        if (inTable) {
+          url = `${url}-table`;
+        }
+        // We use a markdown syntax to represent this link
+        const markdown = `[${content.text}](\\#${url})`;
+        // superscript, italic
+        return `^{\\textit{${markdown}}}`;
+      }
+
+      default: {
+        return content.text;
+      }
+    }
+  });
+  return texts.join('');
+}
+
+/* Until KaTeX#923 is merged, KaTeX doesn't have a mechanism to generate
+ * links. We'll hack around it by writing our link in markdown syntax and
+ * replacing it in the generated HTML.
+ */
+export function renderKaTeX(contents, inTable = false) {
+  const asHtml = katex.renderToString(
+    texFromContents(contents, inTable), { displayMode: true });
+  return asHtml.replace(
+    // The rather nasty markdown-url regex
+    /\[([^\]]*)\]\(([^\\)]*)\)/g,
+    // Use React for html escaping
+    (_, linkText, linkUrl) => renderToStaticMarkup(<a href={linkUrl}>{ linkText }</a>),
+  );
+}
 
 
 export default function TeXMath({ docNode }) {
+  const math = renderKaTeX(docNode.content, docNode.hasAncestor('table'));
   /* eslint-disable react/no-danger */
-  const math = katex.renderToString(docNode.text, { displayMode: true });
   return (
     <div id={docNode.identifier}>
       <div dangerouslySetInnerHTML={{ __html: math }} />
@@ -16,8 +55,11 @@ export default function TeXMath({ docNode }) {
 
 TeXMath.propTypes = {
   docNode: PropTypes.shape({
+    contents: PropTypes.arrayOf(PropTypes.shape({
+      content_type: PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
+    })),
     identifier: PropTypes.string.isRequired,
-    text: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/ui/util/document-node.js
+++ b/ui/util/document-node.js
@@ -26,4 +26,12 @@ export default class DocumentNode {
   firstWithNodeType(nodeType) {
     return this.firstMatch(n => n.node_type === nodeType);
   }
+
+  /* Cleanup: does this node have nodeType in its lineage/ as a parent.
+   * e.g. table */
+  hasAncestor(nodeType) {
+    const ancestorTypes = this.identifier.split('__').map(
+      ident => ident.split('_')[0]);
+    return ancestorTypes.includes(nodeType);
+  }
 }


### PR DESCRIPTION
This hacks around some missing functionality in KaTeX (the ability to include
links) by inserting markdown syntax for a link and replacing it with an `a`
tag _after_ running it through the KaTeX transform.

This should get simpler once KhanAcademy/KaTeX#923 is merged, but until then, I think it'll do.

Note that the anchor this links to won't be functional until #654 is merged.

This should resolve #625 

## Looks like
<img width="675" alt="screen shot 2017-11-15 at 5 53 35 pm" src="https://user-images.githubusercontent.com/326918/32864633-ef6b8200-ca2d-11e7-94be-11a812dae20a.png">
