### PR TITLE
Style footnotes & their citations in tables

### DIFF
--- a/ui/components/content-renderers/footnote-citation-in-table.js
+++ b/ui/components/content-renderers/footnote-citation-in-table.js
@@ -5,7 +5,11 @@ import Link from '../link';
 
 export default function FootnoteCitationInTable({ content }) {
   const href = `#${content.footnote_node.identifier}-table`;
-  return <sup><Link href={href}>{ content.text }</Link></sup>;
+  return (
+    <sup className="footnote-citation-in-table">
+      <Link href={href}>{ content.text }</Link>
+    </sup>
+  );
 }
 FootnoteCitationInTable.propTypes = {
   content: PropTypes.shape({

--- a/ui/components/node-renderers/table/tfoot.js
+++ b/ui/components/node-renderers/table/tfoot.js
@@ -14,8 +14,8 @@ function deriveColspan(docNode) {
 export default function Tfoot({ docNode }) {
   const footnotes = docNode.meta.descendant_footnotes.map(ft => (
     <div className="clearfix" key={ft.identifier} id={`${ft.identifier}-table`}>
-      <div className="col col-1">{ft.marker}</div>
-      <div className="col col-11">{ renderContents(ft.content) }</div>
+      <div className="footnote-marker">{ft.marker}</div>
+      <div className="footnote-text">{ renderContents(ft.content) }</div>
     </div>
   ));
   if (footnotes.length === 0) {
@@ -24,7 +24,7 @@ export default function Tfoot({ docNode }) {
   return (
     <tfoot>
       <tr>
-        <td colSpan={deriveColspan(docNode)} className="border">
+        <td colSpan={deriveColspan(docNode)} className="table-footer">
           <h1 className="h4">Footnotes for table</h1>
           { footnotes }
         </td>

--- a/ui/css/base/_colors.scss
+++ b/ui/css/base/_colors.scss
@@ -56,3 +56,4 @@ $color-shadow:               rgba(#000, 0.3) !default;
 
 // New pallet
 $pallet-blue:                #1067a6 !default;
+$pallet-sunshine:            #fffae3 !default;

--- a/ui/css/main.scss
+++ b/ui/css/main.scss
@@ -30,6 +30,7 @@
 @import 'module/homepage';
 @import 'module/loading-indicator';
 @import 'module/listitem';
+@import 'module/tables';
 
 @import 'state/print';
 @import 'state/ie';

--- a/ui/css/module/_tables.scss
+++ b/ui/css/module/_tables.scss
@@ -1,0 +1,20 @@
+.table-footer {
+  background-color: $pallet-sunshine;
+  padding: 1em;
+
+  .h4 {
+    color: $color-black;
+    margin-top: 0;
+  }
+
+  .footnote-marker {
+    @include font-san-serif-bold();
+    @include paragraph-marker();
+    font-size: 0.75em;
+  }
+
+  .footnote-text {
+    @include paragraph-with-marker();
+    font-style: italic;
+  }
+}

--- a/ui/css/module/_tables.scss
+++ b/ui/css/module/_tables.scss
@@ -18,3 +18,9 @@
     font-style: italic;
   }
 }
+
+.footnote-citation-in-table {
+  font-size: 0.75em;
+  line-height: 1em;
+  margin-left: 0.25em;
+}


### PR DESCRIPTION
Adds the gold background and adjusts spacing, font-sizes for footnotes at the bottom of tables and footnote citations within tables.

## Looks like
<img width="701" alt="screen shot 2017-11-15 at 6 53 34 pm" src="https://user-images.githubusercontent.com/326918/32866568-6f370e98-ca36-11e7-9a4c-2f3bc3ecb299.png">
<img width="737" alt="screen shot 2017-11-15 at 6 53 25 pm" src="https://user-images.githubusercontent.com/326918/32866569-6f41583a-ca36-11e7-8abd-5a95b9e61add.png">
