### PR TITLE
Remove focus outline.

### DIFF
--- a/ui/css/module/_footnotes.scss
+++ b/ui/css/module/_footnotes.scss
@@ -33,7 +33,7 @@
 
   // It's ok to add outline: none here for accessibility purposes.
   // For more details, see: https://youtu.be/ifW_oy9hajU
-  .citation-wrapper[tabindex="-1"] {
+  .footnote-wrapper[tabindex="-1"] {
     outline: none;
   }
 


### PR DESCRIPTION
This style was accidentally lost in some class renaming and PR splitting.

## Before

<img width="734" alt="screen shot 2017-11-16 at 9 48 09 pm" src="https://user-images.githubusercontent.com/326918/32926952-fe8c3848-cb17-11e7-9c87-edac0d2f8e65.png">

## After

<img width="700" alt="screen shot 2017-11-16 at 9 48 21 pm" src="https://user-images.githubusercontent.com/326918/32926951-fe7ef728-cb17-11e7-8c3a-014a456b2796.png">
