### PR TITLE
Minor style fixes from footnotes and document

### DIFF
--- a/ui/css/layout/_markers.scss
+++ b/ui/css/layout/_markers.scss
@@ -3,15 +3,23 @@ $marker-whitespace-xs: 4px;
 $marker-width-md: $marker-width-xs + 8;
 $marker-whitespace-md: $marker-whitespace-xs + 4;
 
-@mixin paragraph-marker() {
+@mixin paragraph-marker($width: normal) {
   @extend .col;
   @extend .right-align;
-  width: $marker-width-xs;
+  @if $width == 'auto' {
+    width: $width;
+  } @else {
+    width: $marker-width-xs;
+  }
   margin-right: $marker-whitespace-xs;
   display: inline-block;
 
   @media #{$breakpoint-md} {
-    width: $marker-width-md;
+    @if $width == 'auto' {
+      width: $width;
+    } @else {
+      width: $marker-width-md;
+    }
     margin-right: $marker-whitespace-md;
   }
 }

--- a/ui/css/module/_document.scss
+++ b/ui/css/module/_document.scss
@@ -15,7 +15,7 @@
 }
 
 .original-link::after {
-  @extend .external-link;
+  background: url('/static/img/external-link.svg') no-repeat right;
   content: '';
   display: inline-block;
   width: 16px;

--- a/ui/css/module/_footnotes.scss
+++ b/ui/css/module/_footnotes.scss
@@ -3,7 +3,7 @@
   border: 1px solid $color-cool-blue-lighter;
   border-radius: 4px;
   padding: 2px 4px;
-  font-size: 0.6em;
+  font-size: 0.6rem;
   margin-left: .3em;
 
   &.active {
@@ -38,7 +38,7 @@
   }
 
   .node-footnote {
-    font-size: 0.9em;
+    font-size: 0.9rem;
     display: block;
   }
 
@@ -47,8 +47,8 @@
     @extend .col;
     @extend .col-1;
     width: 2.5em;
-    font-size: .9em;
-    line-height: 1.5em;
+    font-size: .9rem;
+    line-height: 1.5rem;
     text-align: right;
     padding-right: .5em;
   }
@@ -94,8 +94,8 @@
   .citation-marker {
     @include font-san-serif-bold();
     @include paragraph-marker();
-    font-size: .875em;
-    line-height: 1em; // like font-text, except adjusting for bold
+    font-size: .875rem;
+    line-height: 1rem; // like font-text, except adjusting for bold
   }
 
   .footnote-text,
@@ -104,7 +104,7 @@
     @extend .m0;
     color: $color-gray-medium;
     font-size: .875em;
-    line-height: 1.125em;
+    line-height: 1.125rem;
   }
 }
 

--- a/ui/css/module/_listitem.scss
+++ b/ui/css/module/_listitem.scss
@@ -10,6 +10,10 @@
   .list-item-text {
     @include paragraph-with-marker();
   }
+
+  .node-paragraph {
+    margin-bottom: 0;
+  }
 }
 
 .node-paragraph {

--- a/ui/css/module/_listitem.scss
+++ b/ui/css/module/_listitem.scss
@@ -11,3 +11,14 @@
     @include paragraph-with-marker();
   }
 }
+
+.node-paragraph {
+  .list-item-marker,
+  .list-item-text {
+    line-height: 1.69rem;
+  }
+
+  .list-item-marker {
+    font-size: .9rem;
+  }
+}

--- a/ui/css/module/_listitem.scss
+++ b/ui/css/module/_listitem.scss
@@ -11,7 +11,11 @@
     @include paragraph-with-marker();
   }
 
-  .node-paragraph {
+  .node-paragraph{
+    margin-bottom: 8px;
+  }
+
+  .node-paragraph::last-child {
     margin-bottom: 0;
   }
 }

--- a/ui/css/module/_tables.scss
+++ b/ui/css/module/_tables.scss
@@ -59,7 +59,7 @@ table {
 
   .footnote-marker {
     @include font-san-serif-bold();
-    @include paragraph-marker();
+    @include paragraph-marker(auto);
     font-size: 0.75em;
   }
 

--- a/ui/css/module/_tables.scss
+++ b/ui/css/module/_tables.scss
@@ -13,8 +13,9 @@ tfoot {
 }
 
 .basic-table {
+  margin-top: 2rem;
   font-size: .9rem;
-  margin-bottom: 40px;
+  margin-bottom: 3rem;
 
   th,
   td {


### PR DESCRIPTION
# What

Correcting some style artifacts.

<img width="725" alt="screen shot 2017-11-17 at 12 41 28 pm" src="https://user-images.githubusercontent.com/1332366/32961024-038c4b94-cb95-11e7-8661-64c11740b43f.png">
<img width="279" alt="screen shot 2017-11-17 at 12 38 21 pm" src="https://user-images.githubusercontent.com/1332366/32961025-04efa31e-cb95-11e7-9ccc-19869212efc2.png">
<img width="480" alt="screen shot 2017-11-17 at 12 44 29 pm" src="https://user-images.githubusercontent.com/1332366/32961057-15805eee-cb95-11e7-9cce-0d9af99d8d7a.png">
<img width="514" alt="screen shot 2017-11-17 at 12 53 45 pm" src="https://user-images.githubusercontent.com/1332366/32961415-6fb8585c-cb96-11e7-8f86-647a243909a7.png">
