### PR TITLE
Prefer .toHaveLength() over .length).toEqual().

### DIFF
--- a/ui/__tests__/components/contact-email.test.js
+++ b/ui/__tests__/components/contact-email.test.js
@@ -11,7 +11,7 @@ describe('<ContactEmail />', () => {
     expect(mailtext).toBeTruthy(); // ContactEmail.defaultProps.text should have a value.
     const result = mount(<ContactEmail />);
     it('Has the expected href value', () => {
-      expect(result.find(expr).length).toEqual(1);
+      expect(result.find(expr)).toHaveLength(1);
     });
     it('Has the expected text value', () => {
       expect(result.find(expr).text()).toEqual(mailtext);
@@ -20,7 +20,7 @@ describe('<ContactEmail />', () => {
   describe('when given a text prop', () => {
     const result = mount(<ContactEmail text="something" />);
     it('Has the expected href value', () => {
-      expect(result.find(expr).length).toEqual(1);
+      expect(result.find(expr)).toHaveLength(1);
     });
     it('Has the expected text value', () => {
       expect(result.find(expr).text()).toEqual('something');

--- a/ui/__tests__/components/disclaimer.test.js
+++ b/ui/__tests__/components/disclaimer.test.js
@@ -12,11 +12,11 @@ describe('<Disclaimer />', () => {
     });
     it('has the disclaimer-flag img element', () => {
       const result = mount(<Disclaimer />);
-      expect(result.find('img.usa-disclaimer-flag').length).toEqual(1);
+      expect(result.find('img.usa-disclaimer-flag')).toHaveLength(1);
     });
     it('has the right contact email', () => {
       const result = mount(<Disclaimer />);
-      expect(result.find('a').length).toEqual(1);
+      expect(result.find('a')).toHaveLength(1);
       expect(result.find(`a[href="mailto:${email}"]`).text()).toEqual(`Email ${email}`);
     });
   });

--- a/ui/__tests__/components/link.test.js
+++ b/ui/__tests__/components/link.test.js
@@ -16,7 +16,7 @@ describe('<Link />', () => {
   describe('when given a `route` prop', () => {
     it('renders registered routes as links', () => {
       const result = shallow(<Link route={'route-one'}>hi</Link>);
-      expect(result.find('a').length).toEqual(1);
+      expect(result.find('a')).toHaveLength(1);
     });
     it('logs an error if the route is not registered', () => {
       const spy = jest.spyOn(console, 'error').mockImplementation(() => null);

--- a/ui/__tests__/components/pagers.test.js
+++ b/ui/__tests__/components/pagers.test.js
@@ -15,19 +15,19 @@ describe('<Pagers />', () => {
   it('shows zero pages when there are no results', () => {
     const result = shallow(<Pagers {...pagerArgs(0)} />);
     expect(result.text()).toMatch(/0 of 0/);
-    expect(result.find('LinkRoutes').length).toEqual(0);
+    expect(result.find('LinkRoutes')).toHaveLength(0);
   });
 
   it('shows one page when there are less than 25 results', () => {
     const result = shallow(<Pagers {...pagerArgs(10)} />);
     expect(result.text()).toMatch(/1 of 1/);
-    expect(result.find('LinkRoutes').length).toEqual(0);
+    expect(result.find('LinkRoutes')).toHaveLength(0);
   });
 
   it('shows a right arrow but no left arrow when on page 1', () => {
     const result = shallow(<Pagers {...pagerArgs(100, { page: '1' })} />);
     expect(result.text()).toMatch(/1 of 4/);
-    expect(result.find('Link').length).toEqual(1);
+    expect(result.find('Link')).toHaveLength(1);
     expect(result.childAt(0).name()).toBeNull();
     expect(result.childAt(1).name()).toEqual('Link');
   });
@@ -35,7 +35,7 @@ describe('<Pagers />', () => {
   it('shows a left arrow but no right arrow when on final page', () => {
     const result = shallow(<Pagers {...pagerArgs(100, { page: '4' })} />);
     expect(result.text()).toMatch(/4 of 4/);
-    expect(result.find('Link').length).toEqual(1);
+    expect(result.find('Link')).toHaveLength(1);
     expect(result.childAt(0).name()).toEqual('Link');
     expect(result.childAt(1).name()).toBeNull();
   });
@@ -43,7 +43,7 @@ describe('<Pagers />', () => {
   it('shows both arrows if on an intermediary page', () => {
     const result = shallow(<Pagers {...pagerArgs(100, { page: '2' })} />);
     expect(result.text()).toMatch(/2 of 4/);
-    expect(result.find('Link').length).toEqual(2);
+    expect(result.find('Link')).toHaveLength(2);
     expect(result.childAt(0).name()).toEqual('Link');
     expect(result.childAt(1).name()).toBeNull();
     expect(result.childAt(2).name()).toEqual('Link');

--- a/ui/__tests__/pages/privacy.test.js
+++ b/ui/__tests__/pages/privacy.test.js
@@ -11,7 +11,7 @@ describe('<PrivacyView />', () => {
   });
   it('has the right header', () => {
     const result = shallow(<PrivacyView />);
-    expect(result.find('h2').length).toEqual(1);
+    expect(result.find('h2')).toHaveLength(1);
     expect(result.find('h2').text()).toEqual('Privacy Policy');
   });
 });


### PR DESCRIPTION
eslint-plugin-jest added a rule around preferring toHaveLength() in 21.3.0;
let's follow it.