### PR TITLE
Set random seed in test_filter_agency_by_abbr to avoid random failures

### DIFF
--- a/api/reqs/tests/views_simple_tests.py
+++ b/api/reqs/tests/views_simple_tests.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 from model_mommy import mommy
 from rest_framework.test import APIClient
@@ -7,6 +9,9 @@ from reqs.models import Agency
 
 @pytest.mark.django_db
 def test_filter_agency_by_abbr():
+    # This is a workaround for https://github.com/18F/omb-eregs/issues/673.
+    random.seed(1)
+
     mommy.make(Agency)
     fbi = mommy.make(Agency, abbr='FBI')
     gsa = mommy.make(Agency, name='General Services Administration')


### PR DESCRIPTION
It appears [model mommy uses `random` for its randomness](https://github.com/vandersonmota/model_mommy/blob/development/model_mommy/random_gen.py), which means that calling [`random.seed()`](https://docs.python.org/2/library/random.html#random.seed) with a consistent value should make individual test results reproducible.

Currently this fix just calls `random.seed(1)` at the beginning of `test_filter_agency_by_abbr`, which is the test that is particularly susceptible to random failures, as mentioned in #673 (and which repeated itself in #690 for me).

An alternative fix might be to add some kind of fancy pytest fixture that *always* sets the random seed at the beginning of every test function, ensuring that *all* tests produce consistent and reproducible results. Do we have a preference?
