### PR TITLE
Use checkPropTypes() in Policy constructor

### DIFF
--- a/ui/util/policy.js
+++ b/ui/util/policy.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 
 export default class Policy {
   constructor(policy) {
+    PropTypes.checkPropTypes(Policy.propTypes, policy, 'property', 'Policy');
     Object.assign(this, policy);
     Object.freeze(this);
   }
@@ -27,11 +28,13 @@ export default class Policy {
   }
 }
 
-Policy.shape = PropTypes.shape({
+Policy.propTypes = {
   id: PropTypes.number,
   title_with_number: PropTypes.string,
   relevant_reqs: PropTypes.number,
   total_reqs: PropTypes.number,
   has_docnode: PropTypes.bool,
   omb_policy_id: PropTypes.string,
-});
+};
+
+Policy.shape = PropTypes.shape(Policy.propTypes);


### PR DESCRIPTION
So one thing I'm realizing as we move some of these structs into classes (see e.g. #687) is that we're potentially losing some of the nice development affordances and self-documentation that React provides via `propTypes`.  I noticed, though, that there is a [`PropTypes.checkPropTypes`](PropTypes.checkPropTypes) function that allows properties to be checked manually. According to the documentation, "this function is safe to call in production, as it will be replaced by an empty function", so we don't need to guard it with an `if (process.env.NODE_ENV != 'production')` statement.

Thoughts?
