### PR TITLE
Allow nested content

### DIFF
--- a/api/document/serializers/doc_cursor.py
+++ b/api/document/serializers/doc_cursor.py
@@ -1,7 +1,8 @@
 from rest_framework import serializers
 
 from document.models import DocNode
-from document.serializers.content import ContentListSerializer
+from document.serializers.content import (NestedAnnotationSerializer,
+                                          nest_annotations)
 from document.serializers.meta import Meta, MetaSerializer
 
 
@@ -42,9 +43,12 @@ class DocCursorSerializer(serializers.ModelSerializer):
 
     def get_content(self, instance):
         """Include all annotations of the text."""
-        return ContentListSerializer(
-            instance.annotations(),
+        annotations = nest_annotations(
+            instance.annotations(), len(instance.text))
+        return NestedAnnotationSerializer(
+            annotations,
             context={'cursor': self.cursor, 'parent_serializer': self},
+            many=True,
         ).data
 
     def get_meta(self, instance):

--- a/api/document/tests/serializers/content_test.py
+++ b/api/document/tests/serializers/content_test.py
@@ -1,0 +1,105 @@
+from model_mommy import mommy
+
+from document.models import ExternalLink, PlainText
+from document.serializers import content
+
+
+def test_nest_annotations_no_overlapping():
+    annotations = [
+        mommy.prepare(ExternalLink, start=4, end=8),
+        mommy.prepare(ExternalLink, start=10, end=12),
+    ]
+    result = content.nest_annotations(annotations, 20)
+    assert len(result) == 5
+    assert [(r.start, r.end) for r in result] == [
+        (0, 4), (4, 8), (8, 10), (10, 12), (12, 20),
+    ]
+    assert [r.annotation_class for r in result] == [
+        PlainText, ExternalLink, PlainText, ExternalLink, PlainText,
+    ]
+
+
+def test_nest_annotations_entirely_nested():
+    annotations = [
+        mommy.prepare(ExternalLink, start=4, end=8),
+        mommy.prepare(ExternalLink, start=6, end=7),
+        mommy.prepare(ExternalLink, start=2, end=10),
+    ]
+    result = content.nest_annotations(annotations, 20)
+    assert len(result) == 3
+    assert [(r.start, r.end) for r in result] == [(0, 2), (2, 10), (10, 20)]
+    root = result[1]
+
+    assert len(root.children) == 3
+    assert [(c.start, c.end) for c in root.children] == [
+        (2, 4), (4, 8), (8, 10)]
+
+    parent = root.children[1]
+    assert len(parent.children) == 3
+    assert [(c.start, c.end) for c in parent.children] == [
+        (4, 6), (6, 7), (7, 8)]
+
+
+def test_nest_annotations_initial_nesting():
+    """These annotations share a start index."""
+    annotations = [
+        mommy.prepare(ExternalLink, start=0, end=5),
+        mommy.prepare(ExternalLink, start=0, end=10),
+    ]
+
+    result = content.nest_annotations(annotations, 20)
+    assert len(result) == 2
+    assert [(r.start, r.end) for r in result] == [(0, 10), (10, 20)]
+
+    root = result[0]
+    assert len(root.children) == 2
+    assert [(c.start, c.end) for c in root.children] == [(0, 5), (5, 10)]
+    assert [c.annotation_class for c in root.children] == [
+        ExternalLink, PlainText]
+
+
+def test_nest_annotations_symmetric_difference():
+    """These annotations overlap but aren't contained."""
+    annotations = [
+        mommy.prepare(ExternalLink, start=0, end=10),
+        mommy.prepare(ExternalLink, start=5, end=20),
+    ]
+    result = content.nest_annotations(annotations, 20)
+    assert len(result) == 2
+    assert [(r.start, r.end) for r in result] == [(0, 10), (10, 20)]
+    assert [r.annotation_class for r in result] == [ExternalLink, PlainText]
+
+    root = result[0]
+    assert len(root.children) == 2
+    assert [(c.start, c.end) for c in root.children] == [(0, 5), (5, 10)]
+    assert [c.annotation_class for c in root.children] == [
+        PlainText, ExternalLink]
+
+
+def test_wrap_unwrapped_nesting():
+    """PlainText should be the leaf nodes."""
+    root = content.NestableAnnotation(
+        mommy.prepare(ExternalLink, start=0, end=20), None)
+    parent = content.NestableAnnotation(
+        mommy.prepare(ExternalLink, start=5, end=15), root)
+    child = content.NestableAnnotation(
+        mommy.prepare(ExternalLink, start=8, end=12), parent)
+    aunt = content.NestableAnnotation(
+        mommy.prepare(ExternalLink, start=18, end=20), root)
+    root.wrap_unwrapped()
+
+    assert [(c.start, c.end) for c in root.children] == [
+        (0, 5), (5, 15), (15, 18), (18, 20)]
+    assert [c.annotation_class for c in root.children] == [
+        PlainText, ExternalLink, PlainText, ExternalLink]
+
+    assert [(c.start, c.end) for c in parent.children] == [
+        (5, 8), (8, 12), (12, 15)]
+    assert [c.annotation_class for c in parent.children] == [
+        PlainText, ExternalLink, PlainText]
+
+    assert [(c.start, c.end) for c in child.children] == [(8, 12)]
+    assert [c.annotation_class for c in child.children] == [PlainText]
+
+    assert [(c.start, c.end) for c in aunt.children] == [(18, 20)]
+    assert [c.annotation_class for c in aunt.children] == [PlainText]

--- a/api/document/tests/serializers/doc_cursor_test.py
+++ b/api/document/tests/serializers/doc_cursor_test.py
@@ -52,6 +52,7 @@ def test_end_to_end():
                 'meta': {},
                 'content': [{
                     'content_type': '__text__',
+                    'inlines': [],
                     'text': 'Section 1',
                 }],
                 'children': [],
@@ -86,6 +87,7 @@ def test_end_to_end():
                                 'meta': {},
                                 'content': [{
                                     'content_type': '__text__',
+                                    'inlines': [],
                                     'text': 'Paragraph (a)(1)',
                                 }],
                                 'children': [],
@@ -173,9 +175,15 @@ def test_footnote_citations():
     assert result['content'] == [
         {
             'content_type': '__text__',
+            'inlines': [],
             'text': 'Some',
         }, {
             'content_type': 'footnote_citation',
+            'inlines': [{
+                'content_type': '__text__',
+                'inlines': [],
+                'text': '1',
+            }],
             'text': '1',
             'footnote_node': doc_cursor.DocCursorSerializer(
                 para['footnote_1'],
@@ -183,9 +191,15 @@ def test_footnote_citations():
             ).data,
         }, {
             'content_type': '__text__',
+            'inlines': [],
             'text': ' message',
         }, {
             'content_type': 'footnote_citation',
+            'inlines': [{
+                'content_type': '__text__',
+                'inlines': [],
+                'text': '2',
+            }],
             'text': '2',
             'footnote_node': doc_cursor.DocCursorSerializer(
                 para['footnote_2'],
@@ -193,6 +207,7 @@ def test_footnote_citations():
             ).data,
         }, {
             'content_type': '__text__',
+            'inlines': [],
             'text': ' here',
         }
     ]
@@ -214,13 +229,20 @@ def test_external_links():
     assert result['content'] == [
         {
             'content_type': '__text__',
+            'inlines': [],
             'text': 'Go over '
         }, {
             'content_type': 'external_link',
+            'inlines': [{
+                'content_type': '__text__',
+                'inlines': [],
+                'text': 'there',
+            }],
             'href': 'http://example.com/aaa',
             'text': 'there',
         }, {
             'content_type': '__text__',
+            'inlines': [],
             'text': '!',
         }
     ]

--- a/api/requirements.in
+++ b/api/requirements.in
@@ -1,6 +1,5 @@
 boto3
 cfenv
-collections-extended
 django>=1.11,<1.12
 django-admin-interface
 django-cas-ng

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -9,7 +9,6 @@ botocore==1.7.4           # via boto3, s3transfer
 certifi==2017.7.27.1      # via requests
 cfenv==0.5.3
 chardet==3.0.4            # via requests
-collections-extended==0.10.1
 decorator==4.1.2          # via networkx
 dj-database-url==0.4.2
 django-admin-interface==0.5.2

--- a/api/requirements_dev.txt
+++ b/api/requirements_dev.txt
@@ -12,7 +12,6 @@ botocore==1.7.4
 certifi==2017.7.27.1
 cfenv==0.5.3
 chardet==3.0.4
-collections-extended==0.10.1
 colorama==0.3.9           # via pytest-watch
 coverage==4.4.1           # via pytest-cov
 decorator==4.1.2


### PR DESCRIPTION
This alters the API to include nested inline elements as a tree structure, with PlainText/__text__ leaf nodes. Parent content's "text" attribute continues to include the full text, so there's no immediate need for a corresponding change in the UI.

This should resolve #689 