### PR TITLE
Minor style updates

### DIFF
--- a/ui/css/module/_footnotes.scss
+++ b/ui/css/module/_footnotes.scss
@@ -29,7 +29,7 @@ $triangle-border-vertical-offset: ($triangle-dimensions-value + $footnote-vertic
   border: 1px solid $color-cool-blue-lighter;
   border-radius: 4px;
   padding: 2px 4px;
-  font-size: 0.7em;
+  font-size: 0.7rem;
   margin-left: .3em;
   background-color: $color-white; // override any highlighting
   position: relative;
@@ -72,7 +72,7 @@ $triangle-border-vertical-offset: ($triangle-dimensions-value + $footnote-vertic
   }
 
   .node-footnote {
-    font-size: 0.9em;
+    font-size: 0.9rem;
     display: block;
   }
 
@@ -81,8 +81,8 @@ $triangle-border-vertical-offset: ($triangle-dimensions-value + $footnote-vertic
     @extend .col;
     @extend .col-1;
     width: 2.5em;
-    font-size: .9em;
-    line-height: 1.5em;
+    font-size: .9rem;
+    line-height: 1.5rem;
     text-align: right;
     padding-right: .5em;
   }
@@ -128,8 +128,8 @@ $triangle-border-vertical-offset: ($triangle-dimensions-value + $footnote-vertic
   .citation-marker {
     @include font-san-serif-bold();
     @include paragraph-marker();
-    font-size: .875em;
-    line-height: 1em; // like font-text, except adjusting for bold
+    font-size: .875rem;
+    line-height: 1rem; // like font-text, except adjusting for bold
   }
 
   .footnote-text,
@@ -138,7 +138,7 @@ $triangle-border-vertical-offset: ($triangle-dimensions-value + $footnote-vertic
     @extend .m0;
     color: $color-gray-medium;
     font-size: .875em;
-    line-height: 1.125em;
+    line-height: 1.125rem;
   }
 }
 

--- a/ui/css/module/_footnotes.scss
+++ b/ui/css/module/_footnotes.scss
@@ -48,6 +48,10 @@ $triangle-border-vertical-offset: ($triangle-dimensions-value + $footnote-vertic
 }
 
 .inline-footnote {
+  > cite {
+    line-height: 1em;   // Maintain paragraph line height
+  }
+
   .node-footnote-content {
     display: block;
     width: 100%;

--- a/ui/css/module/_tables.scss
+++ b/ui/css/module/_tables.scss
@@ -13,8 +13,9 @@ tfoot {
 }
 
 .basic-table {
+  margin-top: 2rem;
   font-size: .9rem;
-  margin-bottom: 40px;
+  margin-bottom: 3rem;
 
   th,
   td {


### PR DESCRIPTION
Pulls in some of the content from #679 and adds a tweak to footnote citation line height:

## Before
<img width="689" alt="screen shot 2017-11-29 at 3 24 41 pm" src="https://user-images.githubusercontent.com/326918/33402693-5f41b998-d52b-11e7-86ae-4bec0f482b2c.png">

## After
<img width="684" alt="screen shot 2017-11-29 at 3 24 50 pm" src="https://user-images.githubusercontent.com/326918/33402692-5f357a7a-d52b-11e7-8662-5de25df3ab42.png">