### PR TITLE
UI for inline requirements

### DIFF
--- a/api/document/serializers/content.py
+++ b/api/document/serializers/content.py
@@ -31,7 +31,7 @@ class NestableAnnotation:
     def __contains__(self, child: Annotation):
         """We are not allowing non-nested overlapping annotation, so we won't
         compare ends when determining nesting."""
-        return self.start <= child.start and self.end >= child.start
+        return self.start <= child.start and self.end > child.start
 
     def __repr__(self):
         return (f'NestableAnnotation({repr(self.annotation)}) '

--- a/api/document/tests/serializers/content_test.py
+++ b/api/document/tests/serializers/content_test.py
@@ -40,6 +40,19 @@ def test_nest_annotations_entirely_nested():
         (4, 6), (6, 7), (7, 8)]
 
 
+def test_nest_annotations_adjacent():
+    """Annotations next to each other are not nested."""
+    annotations = [
+        mommy.prepare(ExternalLink, start=0, end=10),
+        mommy.prepare(ExternalLink, start=10, end=20),
+    ]
+
+    result = content.nest_annotations(annotations, 20)
+    assert len(result) == 2
+    assert [(r.start, r.end) for r in result] == [(0, 10), (10, 20)]
+    assert [r.annotation_class for r in result] == [ExternalLink, ExternalLink]
+
+
 def test_nest_annotations_initial_nesting():
     """These annotations share a start index."""
     annotations = [

--- a/ui/__tests__/components/content-renderers/external-link.test.js
+++ b/ui/__tests__/components/content-renderers/external-link.test.js
@@ -5,7 +5,11 @@ import ExternalLink from '../../../components/content-renderers/external-link';
 
 describe('<ExternalLink />', () => {
   describe('general properties', () => {
-    const content = { href: 'http://example.com/aaa', text: 'aLink' };
+    const content = {
+      href: 'http://example.com/aaa',
+      inlines: [{ content_type: '__text__', text: 'aLink' }],
+      text: 'aLink',
+    };
     const result = shallow(<ExternalLink content={content} />);
 
     it('is a Link', () => {
@@ -15,13 +19,18 @@ describe('<ExternalLink />', () => {
       expect(result.prop('href')).toBe('http://example.com/aaa');
     });
     it('includes the content text', () => {
-      expect(result.children().first().text()).toBe('aLink');
+      expect(result.find('PlainText').prop('content')).toEqual(
+        content.inlines[0]);
     });
   });
 
   describe('print-url style', () => {
     it('is present when the link url is non-obvious', () => {
-      const content = { href: 'http://example.com/aaa', text: 'not-that-url' };
+      const content = {
+        href: 'http://example.com/aaa',
+        inlines: [],
+        text: 'not-that-url',
+      };
       const result = shallow(<ExternalLink content={content} />);
 
       expect(result.hasClass('print-url')).toBe(true);
@@ -30,6 +39,7 @@ describe('<ExternalLink />', () => {
     it('is not present when the link url is obvious', () => {
       const content = {
         href: 'http://example.com/aaa',
+        inlines: [],
         text: 'http://example.com/aaa',
       };
       const result = shallow(<ExternalLink content={content} />);
@@ -50,7 +60,8 @@ describe('<ExternalLink />', () => {
       ['http://example.com/page.html.tgz', 'fa-file-o'],
     ].forEach(([href, className]) => {
       it(`works correctly for ${href}`, () => {
-        const rendered = shallow(<ExternalLink content={{ href, text: '' }} />);
+        const content = { href, inlines: [], text: '' };
+        const rendered = shallow(<ExternalLink content={content} />);
         expect(rendered.find('.fa').hasClass(className)).toBe(true);
       });
     });

--- a/ui/__tests__/components/content-renderers/requirement.test.js
+++ b/ui/__tests__/components/content-renderers/requirement.test.js
@@ -1,0 +1,35 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Requirement from '../../../components/content-renderers/requirement';
+
+describe('<Requirement />', () => {
+  it('includes an icon', () => {
+    const result = shallow(<Requirement content={{ inlines: [] }} />);
+    const icons = result.find('.fa');
+    expect(icons).toHaveLength(1);
+    expect(icons.hasClass('fa-star')).toBe(true);
+  });
+  it('includes all inlines', () => {
+    const content = {
+      inlines: [
+        { content_type: '__text__', text: 'Some ' },
+        { content_type: 'external_link',
+          href: 'http://example.com/place',
+          inlines: [{ content_type: '__text__', text: 'link' }],
+          text: 'link',
+        },
+        { content_type: '__text__', text: ' here.' },
+      ],
+    };
+    const result = shallow(<Requirement content={content} />);
+    const externalLinks = result.find('ExternalLink');
+    expect(externalLinks).toHaveLength(1);
+    expect(externalLinks.prop('content')).toEqual(content.inlines[1]);
+
+    const plainTexts = result.find('PlainText');
+    expect(plainTexts).toHaveLength(2);
+    expect(plainTexts.first().prop('content')).toEqual(content.inlines[0]);
+    expect(plainTexts.last().prop('content')).toEqual(content.inlines[2]);
+  });
+});

--- a/ui/components/content-renderers/external-link.js
+++ b/ui/components/content-renderers/external-link.js
@@ -5,6 +5,7 @@ import React from 'react';
 import URL from 'url-parse';
 
 import Link from '../link';
+import renderContents from '../../util/render-contents';
 
 export default function ExternalLink({ content }) {
   const classNames = ['external-link-content'];
@@ -19,7 +20,7 @@ export default function ExternalLink({ content }) {
   }
   return (
     <Link className={classNames.join(' ')} href={content.href}>
-      { content.text }
+      { renderContents(content.inlines) }
       &nbsp;
       <i className={`fa ${iconName}`} aria-hidden="true" />
     </Link>
@@ -27,8 +28,8 @@ export default function ExternalLink({ content }) {
 }
 ExternalLink.propTypes = {
   content: PropTypes.shape({
+    inlines: PropTypes.arrayOf(PropTypes.shape({})), // recursive
     href: PropTypes.string.isRequired,
-    text: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/ui/components/content-renderers/requirement.js
+++ b/ui/components/content-renderers/requirement.js
@@ -1,0 +1,17 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import renderContents from '../../util/render-contents';
+
+export default function Requirement({ content }) {
+  return (
+    <span className="requirement-content">
+      <i className="fa fa-star" aria-hidden="true" />&nbsp;{ renderContents(content.inlines) }
+    </span>
+  );
+}
+Requirement.propTypes = {
+  content: PropTypes.shape({
+    inlines: PropTypes.arrayOf(PropTypes.shape({})), // recursive
+  }).isRequired,
+};

--- a/ui/css/base/_colors.scss
+++ b/ui/css/base/_colors.scss
@@ -56,5 +56,6 @@ $color-shadow:               rgba(#000, 0.3) !default;
 
 // New pallet
 $pallet-blue:                #1067a6 !default;
+$pallet-canary:              #ffee99 !default;
 $pallet-sunshine:            #fffae3 !default;
 $pallet-yellow-dark:         #f3ecc9 !default;

--- a/ui/css/module/_footnotes.scss
+++ b/ui/css/module/_footnotes.scss
@@ -5,6 +5,7 @@
   padding: 2px 4px;
   font-size: 0.6em;
   margin-left: .3em;
+  background-color: $color-white; // override any highlighting
 
   &.active {
     border-color: $color-primary-darker;

--- a/ui/css/module/_requirements.scss
+++ b/ui/css/module/_requirements.scss
@@ -29,3 +29,9 @@
 .organize-tabs {
   font-size: 1.125rem;
 }
+
+.requirement-content {
+  background-color: $pallet-canary;
+  border-right: 3px solid $color-black;
+  padding-right: 4px;
+}

--- a/ui/util/render-contents.js
+++ b/ui/util/render-contents.js
@@ -3,6 +3,7 @@ import React from 'react';
 import ExternalLink from '../components/content-renderers/external-link';
 import FootnoteCitation from '../components/content-renderers/footnote-citation';
 import PlainText from '../components/content-renderers/plain-text';
+import Requirement from '../components/content-renderers/requirement';
 
 /* Looks up the React Component for each element in the contents field and
  * renders it */
@@ -10,6 +11,7 @@ export default function renderContents(contents, overrideMapping = null) {
   const contentMapping = {
     external_link: ExternalLink,
     footnote_citation: FootnoteCitation,
+    requirement: Requirement,
     ...(overrideMapping || {}),
   };
 


### PR DESCRIPTION
This is the mirror of #706, taking the data from the API and displaying it in the user interface. It also allows external links to include other types of annotations and fixes an issue with the nesting logic.

Looks like (with #706 and #712)
<img width="706" alt="screen shot 2017-11-29 at 5 00 50 pm" src="https://user-images.githubusercontent.com/326918/33405091-eb4a6986-d534-11e7-9f98-2bf0ccf88262.png">
