### PR TITLE
Copy derived fonts to container in CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
           command: |
             docker-compose run --rm webpack
             docker cp holder:/usr/src/app/ui/static/styles.css ./ui/static/styles.css
+            docker cp holder:/usr/src/app/ui/static/font/. ./ui/static/font
       - run:
           name: API Unit tests
           environment:


### PR DESCRIPTION
We pull some fonts from a node library and place them in the "static"
directory *within a remote container*. We need to bring them to the local file
system so they can be used when deploying.

This [successfully deploys](https://circleci.com/gh/18F/omb-eregs/828).