### PR TITLE
Add desktop navigation

### DIFF
--- a/ui/__tests__/components/document/navigation-heading.test.js
+++ b/ui/__tests__/components/document/navigation-heading.test.js
@@ -1,0 +1,51 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import NavigationHeading from '../../../components/document/navigation-heading';
+
+describe('<NavigationHeading />', () => {
+  it('works with no children', () => {
+    const tocNode = { children: [], identifier: '', title: '' };
+    const result = shallow(<NavigationHeading tocNode={tocNode} />);
+    const links = result.find('Link');
+    expect(links).toHaveLength(1);
+  });
+  it('includes appropriate text', () => {
+    const tocNode = { children: [], identifier: '', title: 'Some Title' };
+    const result = shallow(<NavigationHeading tocNode={tocNode} />);
+    expect(result.find('Link').children().text()).toBe('Some Title');
+  });
+  it('links to the right place', () => {
+    const tocNode = { children: [], identifier: 'some-id', title: '' };
+    const result = shallow(<NavigationHeading tocNode={tocNode} />);
+    expect(result.find('Link').prop('href')).toBe('#some-id');
+  });
+  it('allows only one level of nesting', () => {
+    const tocNode = {
+      identifier: 'root',
+      title: '',
+      children: [
+        { children: [], identifier: 'child-a', title: 'Child A' },
+        { identifier: 'child-b',
+          title: 'Child B',
+          children: [
+            { children: [], identifier: 'subchild-i', title: 'Subchild I' },
+            { children: [], identifier: 'subchild-ii', title: 'Subchild II' },
+          ],
+        },
+        { children: [], identifier: 'child-c', title: 'Child C' },
+      ],
+    };
+    const result = shallow(<NavigationHeading tocNode={tocNode} />);
+    const links = result.find('Link');
+    expect(links).toHaveLength(4);
+    expect(links.at(0).prop('href')).toBe('#root');
+    expect(links.at(1).prop('href')).toBe('#child-a');
+    expect(links.at(1).children().text()).toBe('Child A');
+    expect(links.at(2).prop('href')).toBe('#child-b');
+    expect(links.at(2).children().text()).toBe('Child B');
+    expect(links.at(3).prop('href')).toBe('#child-c');
+    expect(links.at(3).children().text()).toBe('Child C');
+  });
+});
+

--- a/ui/__tests__/components/document/navigation.test.js
+++ b/ui/__tests__/components/document/navigation.test.js
@@ -1,0 +1,48 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import DocumentNav from '../../../components/document/navigation';
+import DocumentNode from '../../../util/document-node';
+
+describe('<DocumentNav />', () => {
+  it('generates a "Top" link', () => {
+    const docNode = new DocumentNode({ meta: { table_of_contents: {
+      children: [], identifier: 'some-id', title: 'Some Title',
+    } } });
+    const result = shallow(<DocumentNav docNode={docNode} />);
+    const links = result.find('Link');
+    expect(links).toHaveLength(1);
+    expect(links.children().text()).toBe('Top');
+    expect(links.prop('href')).toBe('#some-id');
+  });
+  it('includes all of the table of contents', () => {
+    const docNode = new DocumentNode({ meta: { table_of_contents: {
+      children: [
+        { identifier: 'thing1', title: 'Thing1', children: [] },
+        { identifier: 'thing2', title: 'Thing2', children: [] },
+        { identifier: 'thing3', title: 'Thing3', children: [] },
+      ],
+      identifier: 'some-id',
+      title: 'Some Title',
+    } } });
+    const result = shallow(<DocumentNav docNode={docNode} />);
+    const links = result.find('NavigationHeading');
+    expect(links).toHaveLength(3);
+    expect(links.at(0).prop('tocNode').title).toBe('Thing1');
+    expect(links.at(1).prop('tocNode').title).toBe('Thing2');
+    expect(links.at(2).prop('tocNode').title).toBe('Thing3');
+  });
+  it('includes passed in className', () => {
+    const docNode = new DocumentNode({ meta: { table_of_contents: {
+      children: [], identifier: '', title: '',
+    } } });
+    const noClass = shallow(<DocumentNav docNode={docNode} />);
+    expect(noClass.hasClass('document-nav')).toBe(true);
+
+    const someClass = shallow(
+      <DocumentNav className="some thing" docNode={docNode} />);
+    expect(someClass.hasClass('document-nav')).toBe(true);
+    expect(someClass.hasClass('some')).toBe(true);
+    expect(someClass.hasClass('thing')).toBe(true);
+  });
+});

--- a/ui/__tests__/pages/document.test.js
+++ b/ui/__tests__/pages/document.test.js
@@ -12,8 +12,14 @@ describe('<Document />', () => {
     renderNode.mockImplementationOnce(() => <span>Stuff</span>);
     const docNode = { children: [], some: 'thing' };
     const result = shallow(<Document docNode={docNode} />);
-    expect(result.text()).toBe('Stuff');
+    expect(result.text()).toMatch(/Stuff/);
     expect(renderNode).toHaveBeenCalledTimes(1);
     expect(renderNode).toHaveBeenCalledWith(new DocumentNode(docNode));
+  });
+  it('includes the DocumentNav', () => {
+    renderNode.mockImplementationOnce(() => null);
+    const result = shallow(<Document docNode={{ identifier: 'abc' }} />);
+    expect(result.find('DocumentNav')).toHaveLength(1);
+    expect(result.find('DocumentNav').prop('docNode').identifier).toBe('abc');
   });
 });

--- a/ui/components/document/navigation-heading.js
+++ b/ui/components/document/navigation-heading.js
@@ -3,22 +3,24 @@ import React from 'react';
 
 import Link from '../link';
 
+function linkify(tocNode) {
+  return (
+    <Link className="document-nav-heading" href={`#${tocNode.identifier}`}>
+      <div className="document-nav-container">{ tocNode.title }</div>
+    </Link>
+  );
+}
+
 /* Displays a link with a section's title along with links for its subtitles.
  * We only handle 2 levels of navigation. */
 export default function NavigationHeading({ tocNode }) {
   const subsections = tocNode.children.map(tocChild => (
-    <li key={tocChild.identifier}>
-      <Link className="section-heading" href={`#${tocChild.identifier}`}>
-        <div className="heading-container">{ tocChild.title }</div>
-      </Link>
-    </li>
+    <li key={tocChild.identifier}>{ linkify(tocChild) }</li>
   ));
 
   return (
     <li>
-      <Link className="section-heading" href={`#${tocNode.identifier}`}>
-        <div className="heading-container">{ tocNode.title }</div>
-      </Link>
+      { linkify(tocNode) }
       { subsections.length ?
         <ol className="list-reset sub-sections">{ subsections }</ol> : null }
     </li>

--- a/ui/components/document/navigation-heading.js
+++ b/ui/components/document/navigation-heading.js
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Link from '../link';
+
+/* Displays a link with a section's title along with links for its subtitles.
+ * We only handle 2 levels of navigation. */
+export default function NavigationHeading({ tocNode }) {
+  const subsections = tocNode.children.map(tocChild => (
+    <li key={tocChild.identifier}>
+      <Link className="section-heading" href={`#${tocChild.identifier}`}>
+        <div className="heading-container">{ tocChild.title }</div>
+      </Link>
+    </li>
+  ));
+
+  return (
+    <li>
+      <Link className="section-heading" href={`#${tocNode.identifier}`}>
+        <div className="heading-container">{ tocNode.title }</div>
+      </Link>
+      { subsections.length ?
+        <ol className="list-reset sub-sections">{ subsections }</ol> : null }
+    </li>
+  );
+}
+NavigationHeading.propTypes = {
+  tocNode: PropTypes.shape({
+    children: PropTypes.arrayOf(PropTypes.shape({
+      identifier: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+    })).isRequired,
+    identifier: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/ui/components/document/navigation.js
+++ b/ui/components/document/navigation.js
@@ -15,8 +15,8 @@ export default function DocumentNav({ className, docNode }) {
   return (
     <ol className={classes.join(' ')}>
       <li>
-        <Link className="section-heading" href={`#${tableOfContents.identifier}`}>
-          <div className="heading-container">Top</div>
+        <Link className="document-nav-heading" href={`#${tableOfContents.identifier}`}>
+          <div className="document-nav-container">Top</div>
         </Link>
       </li>
       { tableOfContents.children.map(tocNode =>

--- a/ui/components/document/navigation.js
+++ b/ui/components/document/navigation.js
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Link from '../link';
+import DocumentNode from '../../util/document-node';
+import NavigationHeading from './navigation-heading';
+
+
+export default function DocumentNav({ className, docNode }) {
+  const { tableOfContents } = docNode.meta;
+  const classes = ['list-reset', 'document-nav'];
+  if (className) {
+    classes.push(className);
+  }
+  return (
+    <ol className={classes.join(' ')}>
+      <li>
+        <Link className="section-heading" href={`#${tableOfContents.identifier}`}>
+          <div className="heading-container">Top</div>
+        </Link>
+      </li>
+      { tableOfContents.children.map(tocNode =>
+        <NavigationHeading key={tocNode.identifier} tocNode={tocNode} />) }
+    </ol>
+  );
+}
+DocumentNav.propTypes = {
+  className: PropTypes.string,
+  docNode: PropTypes.instanceOf(DocumentNode).isRequired,
+};
+DocumentNav.defaultProps = {
+  className: '',
+};

--- a/ui/components/node-renderers/policy.js
+++ b/ui/components/node-renderers/policy.js
@@ -56,7 +56,7 @@ export default function Policy({ docNode }) {
         </LabeledText>
       </header>
       { docNode.children.map(renderNode) }
-      { footnotes(docNode.meta.descendant_footnotes.map(f => new DocumentNode(f))) }
+      { footnotes(docNode.meta.descendantFootnotes) }
     </div>
   );
 }

--- a/ui/components/node-renderers/table/tfoot.js
+++ b/ui/components/node-renderers/table/tfoot.js
@@ -13,7 +13,7 @@ function deriveColspan(docNode) {
 }
 
 export default function Tfoot({ docNode }) {
-  const footnotes = docNode.meta.descendant_footnotes.map(ft => (
+  const footnotes = docNode.meta.descendantFootnotes.map(ft => (
     <div className="clearfix" key={ft.identifier} id={`${ft.identifier}-table`}>
       <div className="footnote-marker">{ft.marker}</div>
       <div className="footnote-text">{ renderContents(ft.content) }</div>

--- a/ui/css/base/_colors.scss
+++ b/ui/css/base/_colors.scss
@@ -5,6 +5,7 @@ $color-white:               #ffffff;
 
 $color-blue:                #1067a6;
 $color-lt-blue:             #bfe2f0;
+$color-sky:                 #e5f6fd;
 
 $color-ochre:               #8c7c2a;
 $color-gold:                #ffdc37;

--- a/ui/css/layout/_layout.scss
+++ b/ui/css/layout/_layout.scss
@@ -11,14 +11,6 @@ body {
 }
 
 .document-container {
-  .node-policy {
-    @extend .col-12;
-    @extend .md-col-8;
-    @extend .col;
-  }
-
-  @extend .clearfix;
-  @extend .max-width-4;
   margin: 0 auto;
   padding-top: 2em;
   padding-bottom: 4em;

--- a/ui/css/module/_document.scss
+++ b/ui/css/module/_document.scss
@@ -19,29 +19,29 @@
 }
 
 .document-nav {
-  $indent: 1rem;
+  $spacing: 1rem;
+  $active-width: 0.5rem;
 
   .section-heading {
     border-bottom: 1px solid $color-lt-blue;
     display: block;
     font-size: 1rem;
-    padding-left: $indent;
+    line-height: 1.3rem;
   }
 
   .heading-container {
-    padding-bottom: 1rem;
-    padding-top: 1rem;
+    padding: $spacing;
+    padding-left: $spacing + $active-width;
   }
 
   .section-heading:hover .heading-container {
     background-color: $color-sky;
-    border-left: ($indent / 2) solid $color-blue;
-    margin-left: -$indent;
-    padding-left: $indent / 2;
+    border-left: $active-width solid $color-blue;
+    padding-left: $spacing;
   }
 
   .sub-sections {
-    padding-left: $indent;
+    padding-left: $spacing;
 
     .section-heading {
       font-size: 0.875rem;

--- a/ui/css/module/_document.scss
+++ b/ui/css/module/_document.scss
@@ -17,3 +17,34 @@
 .original-link-container {
   margin-bottom: 8px;
 }
+
+.document-nav {
+  $indent: 1rem;
+
+  .section-heading {
+    border-bottom: 1px solid $color-lt-blue;
+    display: block;
+    font-size: 1rem;
+    padding-left: $indent;
+  }
+
+  .heading-container {
+    padding-bottom: 1rem;
+    padding-top: 1rem;
+  }
+
+  .section-heading:hover .heading-container {
+    background-color: $color-sky;
+    border-left: ($indent / 2) solid $color-blue;
+    margin-left: -$indent;
+    padding-left: $indent / 2;
+  }
+
+  .sub-sections {
+    padding-left: $indent;
+
+    .section-heading {
+      font-size: 0.875rem;
+    }
+  }
+}

--- a/ui/css/module/_document.scss
+++ b/ui/css/module/_document.scss
@@ -18,33 +18,31 @@
   margin-bottom: 8px;
 }
 
-.document-nav {
+.document-nav .sub-sections {
+  padding-left: 1rem;
+}
+
+.document-nav-heading {
   $spacing: 1rem;
   $active-width: 0.5rem;
 
-  .section-heading {
-    border-bottom: 1px solid $color-lt-blue;
-    display: block;
-    font-size: 1rem;
-    line-height: 1.3rem;
-  }
+  border-bottom: 1px solid $color-lt-blue;
+  display: block;
+  font-size: 1rem;
+  line-height: 1.3rem;
 
-  .heading-container {
+  .document-nav-container {
     padding: $spacing;
     padding-left: $spacing + $active-width;
   }
 
-  .section-heading:hover .heading-container {
+  &:hover .document-nav-container {
     background-color: $color-sky;
     border-left: $active-width solid $color-blue;
     padding-left: $spacing;
   }
 
-  .sub-sections {
-    padding-left: $spacing;
-
-    .section-heading {
-      font-size: 0.875rem;
-    }
+  .sub-sections & {
+    font-size: 0.875rem;
   }
 }

--- a/ui/pages/document.js
+++ b/ui/pages/document.js
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
+import React from 'react';
 
 import wrapPage from '../components/app-wrapper';
+import DocumentNav from '../components/document/navigation';
 import { documentData } from '../util/api/queries';
 import DocumentNode from '../util/document-node';
 import renderNode from '../util/render-node';
@@ -8,11 +10,19 @@ import renderNode from '../util/render-node';
 
 const headerFooterParams = {
   showSearch: true,
-  wrapperClassName: 'document-container',
 };
 
 export function Document({ docNode }) {
-  return renderNode(new DocumentNode(docNode));
+  const doc = new DocumentNode(docNode);
+  return (
+    <div className="document-container clearfix max-width-4">
+      <DocumentNav className="col col-3 sm-hide xs-hide" docNode={doc} />
+      <div className="col col-1 sm-hide xs-hide">&nbsp;</div>
+      <div className="col-12 md-col-6 col">
+        { renderNode(doc) }
+      </div>
+    </div>
+  );
 }
 Document.propTypes = {
   docNode: PropTypes.shape({}).isRequired,

--- a/ui/util/document-node.js
+++ b/ui/util/document-node.js
@@ -1,3 +1,27 @@
+export class Meta {
+  constructor(args) {
+    const fieldValues = args || {};
+    // policy meta data (e.g. slugs, pdf url, etc.)  associated with this
+    // document
+    this.policy = fieldValues.policy || {};
+
+    // footnotes referenced in this DocumentNode or its children. E.g. used to
+    // consolidate footnotes in tables
+    // DocumentNode will be defined before this constructor is called
+    /* eslint-disable no-use-before-define */
+    this.descendantFootnotes = (
+      fieldValues.descendantFootnotes || fieldValues.descendant_footnotes || []
+    ).map(f => new DocumentNode(f));
+    /* eslint-enable no-use-before-define */
+
+    // title of this DocumentNode and any of its children. E.g. used in
+    // navigation
+    this.tableOfContents = (
+      fieldValues.table_of_contents || fieldValues.tableOfContents || {}
+    );
+  }
+}
+
 export default class DocumentNode {
   constructor(args) {
     const fieldValues = args || {};
@@ -28,7 +52,7 @@ export default class DocumentNode {
     this.children = (fieldValues.children || []).map(c => new DocumentNode(c));
 
     // node-level meta data, such as footnotes within a table
-    this.meta = fieldValues.meta || {};
+    this.meta = new Meta(fieldValues.meta);
   }
 
   linearize() {


### PR DESCRIPTION
This adds components to represent the document navigation menu. It uses the data from #737 for population (meaning we'll need to re-import that doc).

This does _not_ implement mobile, navigation stickiness, or highlighting the user's current position (which are all separate tickets).

Looks like
<img width="1208" alt="screen shot 2017-12-06 at 3 43 47 pm" src="https://user-images.githubusercontent.com/326918/33684523-86b4ab86-da9c-11e7-816f-01ae0471d27b.png">

Should resolve #733 