### PR TITLE
Ensure all /pages are wrapped.

### DIFF
--- a/ui/__tests__/components/app-wrapper.test.js
+++ b/ui/__tests__/components/app-wrapper.test.js
@@ -44,6 +44,11 @@ describe('wrapPage()', () => {
 
       expect(results.initialState).toEqual(initialState);
     });
+    it('allows an empty dataFn', async () => {
+      const Wrapped = wrapPage(ExamplePage);
+      const results = await Wrapped.getInitialProps({ some: 'input' });
+      expect(results.initialProps).toEqual({}); // no-op
+    });
   });
   describe('render()', () => {
     const Wrapped = wrapPage(ExamplePage, jest.fn());

--- a/ui/components/app-wrapper.js
+++ b/ui/components/app-wrapper.js
@@ -23,6 +23,8 @@ Router.onRouteChangeStart = NProgress.start;
 
 export default function wrapPage(Page, dataFn, headerFooterParams) {
   const hfParams = headerFooterParams || { showSearch: true };
+  const noop = () => ({});
+  const fetchFn = dataFn || noop;
   function WrappedPage(props) {
     if (props.err || props.statusCode) {
       return <ErrorView err={props.err} statusCode={props.statusCode} />;
@@ -42,7 +44,7 @@ export default function wrapPage(Page, dataFn, headerFooterParams) {
 
   WrappedPage.getInitialProps = async (ctx) => {
     try {
-      return await dataFn(ctx);
+      return await fetchFn(ctx);
     } catch (err) {
       return { err };
     }

--- a/ui/pages/privacy.js
+++ b/ui/pages/privacy.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
+import wrapPage from '../components/app-wrapper';
 import { email, ContactEmail } from '../components/contact-email';
-import HeaderFooter from '../components/header-footer';
 import Link from '../components/link';
 
 export function PrivacyView() {
@@ -128,4 +128,4 @@ export function PrivacyView() {
   );
 }
 
-export default () => <HeaderFooter><PrivacyView /></HeaderFooter>;
+export default wrapPage(PrivacyView);


### PR DESCRIPTION
The app-wrapper sets up redux (along with some error handling, etc.), so it's
important it be called at all entrypoints. Notably, if a user can do AJAX, but
initially loads the privacy page (which wasn't wrapped), they'll receive an
error when trying to use redux on the document page.

To do this, we needed to allow pages to have a no-op data fetching function.