### PR TITLE
Remove extraneous divs/spans.

### DIFF
--- a/ui/components/content-renderers/plain-text.js
+++ b/ui/components/content-renderers/plain-text.js
@@ -1,9 +1,8 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 
 export default function PlainText({ content }) {
-  return <span>{ content.text }</span>;
+  return content.text;
 }
 PlainText.propTypes = {
   content: PropTypes.shape({

--- a/ui/components/header-footer.js
+++ b/ui/components/header-footer.js
@@ -67,30 +67,28 @@ function faviconTags() {
 export default function HeaderFooter({ children, showSearch, wrapperClassName }) {
   const klasses = ['container', wrapperClassName].join(' ');
 
-  return (
-    <div>
-      <Head>
-        <title>OMB Policy Library (Beta)</title>
-        <link rel="stylesheet" href="/static/styles.css" />
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-alpha1/katex.min.css" integrity="sha384-8QOKbPtTFvh/lMY0qPVbXj9hDh+v8US0pD//FcoYFst2lCIf0BmT58+Heqj0IGyx" crossOrigin="anonymous" />
-        <script
-          async
-          type="text/javascript"
-          id="_fed_an_ua_tag"
-          src="https://dap.digitalgov.gov/Universal­Federated­Analytics­Min.js?agency=EOP&subagency=OMB"
-        />
-        { faviconTags() }
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </Head>
-      <Disclaimer />
-      <Navbar showSearch={showSearch} />
-      <div className={klasses}>
-        {children}
-      </div>
-      <Footer />
-      <script src="/static/ie.js" />
-    </div>
-  );
+  return [
+    <Head key="head">
+      <title>OMB Policy Library (Beta)</title>
+      <link rel="stylesheet" href="/static/styles.css" />
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-alpha1/katex.min.css" integrity="sha384-8QOKbPtTFvh/lMY0qPVbXj9hDh+v8US0pD//FcoYFst2lCIf0BmT58+Heqj0IGyx" crossOrigin="anonymous" />
+      <script
+        async
+        type="text/javascript"
+        id="_fed_an_ua_tag"
+        src="https://dap.digitalgov.gov/Universal­Federated­Analytics­Min.js?agency=EOP&subagency=OMB"
+      />
+      { faviconTags() }
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+    </Head>,
+    <Disclaimer key="disclaimer" />,
+    <Navbar key="navbar" showSearch={showSearch} />,
+    <div key="body" className={klasses}>
+      {children}
+    </div>,
+    <Footer key="footer" />,
+    <script key="footer-script" src="/static/ie.js" />,
+  ];
 }
 
 HeaderFooter.propTypes = {

--- a/ui/components/policies/policies-view.js
+++ b/ui/components/policies/policies-view.js
@@ -10,17 +10,15 @@ export default function PoliciesView({ policies, count, topicsIds }) {
   const singular = 'policy';
   const plural = 'policies';
 
-  return (
-    <div>
-      <ThingCounterContainer count={count} singular={singular} plural={plural} />
-      <ul className="policy-list list-reset">
-        { policies.map(policy =>
-          <PolicyView key={policy.id} policy={new Policy(policy)} topicsIds={topicsIds} />,
-        )}
-      </ul>
-      <PagersContainer count={count} route="policies" />
-    </div>
-  );
+  return [
+    <ThingCounterContainer count={count} key="counter" singular={singular} plural={plural} />,
+    <ul className="policy-list list-reset" key="policy-list">
+      { policies.map(policy =>
+        <PolicyView key={policy.id} policy={new Policy(policy)} topicsIds={topicsIds} />,
+      )}
+    </ul>,
+    <PagersContainer count={count} key="pager" route="policies" />,
+  ];
 }
 PoliciesView.propTypes = {
   policies: PropTypes.arrayOf(Policy.shape),

--- a/ui/components/requirements/requirements-view.js
+++ b/ui/components/requirements/requirements-view.js
@@ -8,19 +8,17 @@ import ThingCounterContainer from '../thing-counters';
 export default function RequirementsView({ requirements, count }) {
   const singular = 'requirement';
   const plural = 'requirements';
-  return (
-    <div>
-      <ThingCounterContainer count={count} singular={singular} plural={plural} />
-      <ul className="requirement-list list-reset">
-        { requirements.map(requirement => (
-          <li key={requirement.req_id} className="gray-border border rounded mb2">
-            <Requirement requirement={requirement} />
-          </li>
-        )) }
-      </ul>
-      <PagersContainer count={count} route="requirements" />
-    </div>
-  );
+  return [
+    <ThingCounterContainer count={count} key="counter" singular={singular} plural={plural} />,
+    <ul className="requirement-list list-reset" key="reqs">
+      { requirements.map(requirement => (
+        <li key={requirement.req_id} className="gray-border border rounded mb2">
+          <Requirement requirement={requirement} />
+        </li>
+      )) }
+    </ul>,
+    <PagersContainer count={count} key="pager" route="requirements" />,
+  ];
 }
 const requirementProps = PropTypes.shape({
   id: PropTypes.number,


### PR DESCRIPTION
We had been wrapping these elements in a div or a span because React <16
didn't know how to render "partial" elements: plain strings or array.

This isn't a huge change in terms of file size (we drop ~2k off M-16-18), but
it does make the markup much cleaner.