### PR TITLE
Add 'pybash' and 'nodebash' commands to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,6 +161,15 @@ services:
     ports: []
     depends_on: []
 
+  pybash:
+    <<: *DEV_API
+    entrypoint: .docker/wait_for_db_then .docker/activate_then bash
+    command: ''
+
+  nodebash:
+    <<: *DEV_UI
+    entrypoint: .docker/deps_ok_then .docker/modify_path_then bash
+    command: ''
 
 volumes:
   database_data:

--- a/ui/.docker/modify_path_then
+++ b/ui/.docker/modify_path_then
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export PATH=$PATH:$PWD/node_modules/.bin
+
+exec "$@"


### PR DESCRIPTION
I've been using these commands from my own machine for a while--except I have them as shell scripts, basically--and I thought it might be convenient to have them as commands in our `docker-compose.yml`:

* `docker-compose run --rm pybash` starts a bash session in the Python container, providing easy access to any Python-related tooling with minimal fuss.

* `docker-compose run --rm nodebash` does the same, but for the node container. It also adds the ui's `node_modules/.bin` to the `PATH` for easy access to node tooling.

There's a few reasons why I prefer these over the various commands that are currently in our `docker-compose.yml`:

* Starting up docker always takes a little while, and this setup time adds up when running multiple commands in quick succession.  In contrast, the `*bash` commands require only one-time setup, and then you can run however many commands you want without having to wait for docker.

* Shell auto-completion of commands, filenames, and directories doesn't work particularly well from the docker host, especially if said docker host is a Windows machine. 

* There are lots of small utilities that come with individual node/python packages that are inconvenient to keep adding to `docker-compose.yml`, but which are very easy to run from a bash session with a `PATH` set up properly. For example, there's currently no easy way I know of to run `eslint` on just one file, but from a nodebash session it's just `eslint <filename>`.

  Another way to put it is that having direct access to a shell session with the correct paths set up makes it easy for a developer to leverage their pre-existing knowledge of language-specific command-line tooling, without having to constantly look at a `docker-compose.yml` or a `package.json`'s `scripts` section to figure out how to do what they want.
