### PR TITLE
Lint ombpdf, and a few other fixes

### DIFF
--- a/api/ombpdf/document.py
+++ b/api/ombpdf/document.py
@@ -1,15 +1,12 @@
+import logging
 from collections import Counter
 from decimal import Decimal
-import logging
-import math
 
 from pdfminer import layout
 
-from . import fontsize
-from . import util
+from . import fontsize, util
 from .annotators import AnnotatorTracker
 from .eqnamedtuple import eqnamedtuple
-
 
 logger = logging.getLogger(__name__)
 
@@ -128,6 +125,7 @@ class OMBTextCharacter(AnnotatableMixin):
             self.annotation == char.annotation and
             self.fontsize == char.fontsize
         )
+
 
 class OMBTextLine(list, AnnotatableMixin):
     # Distance one edge can be from another to be considered more or less

--- a/api/ombpdf/download_pdfs.py
+++ b/api/ombpdf/download_pdfs.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import requests
 from tqdm import tqdm
 
-
 ROOT_DIR = Path(__file__).parent.parent / 'data'
 
 DOMAIN = "obamawhitehouse.archives.gov"

--- a/api/ombpdf/fontsize.py
+++ b/api/ombpdf/fontsize.py
@@ -1,7 +1,7 @@
 import re
 import weakref
-from decimal import Decimal
 from collections import Counter, namedtuple
+from decimal import Decimal
 
 from pdfminer import layout
 

--- a/api/ombpdf/footnotes.py
+++ b/api/ombpdf/footnotes.py
@@ -1,19 +1,10 @@
 import re
-from textwrap import TextWrapper
 from decimal import Decimal
+from textwrap import TextWrapper
 
-from pdfminer import layout
-
-from .document import (
-    OMBDocument,
-    OMBFootnoteCitation,
-    OMBFootnote,
-    OMBPageNumber
-)
 from . import util
-from .fontsize import FontSize
+from .document import OMBFootnote, OMBFootnoteCitation
 from .horizlines import get_horizontal_lines
-
 
 NUMBER_RE = re.compile(r'[0-9]')
 

--- a/api/ombpdf/horizlines.py
+++ b/api/ombpdf/horizlines.py
@@ -4,18 +4,17 @@ from pdfminer import layout
 
 from . import util
 
-
 HorizontalLine = namedtuple('HorizontalLine', ['y', 'start', 'end'])
 
 # Maximum height of a horizontal line (in points, I think).
 MAX_LINE_HEIGHT = 4.0
+
 
 def get_horizontal_lines(page):
     hlines = []
     for rect in util.iter_flattened_layout(page.ltpage, layout.LTRect):
         x0, y0 = rect.pts[0]
         x1, y1 = rect.pts[2]
-        height = y1 - y0
         if y1 - y0 < MAX_LINE_HEIGHT:
             hlines.append(HorizontalLine((y0 + y1) / 2, x0, x1))
     for line in util.iter_flattened_layout(page.ltpage, layout.LTLine):

--- a/api/ombpdf/html.py
+++ b/api/ombpdf/html.py
@@ -1,7 +1,7 @@
 from html import escape
 
-from .document import (OMBFootnoteCitation, OMBFootnote, OMBPageNumber,
-                       OMBParagraph, OMBListItemMarker)
+from .document import (OMBFootnote, OMBFootnoteCitation, OMBListItemMarker,
+                       OMBPageNumber, OMBParagraph)
 
 
 HTML_INTRO = """\

--- a/api/ombpdf/lists.py
+++ b/api/ombpdf/lists.py
@@ -2,7 +2,6 @@ import re
 
 from .document import OMBListItem, OMBListItemMarker
 
-
 UL_RE = re.compile(r'^• ')
 
 OL_RE = re.compile(r'^([0-9]+|[A-Za-z])\. ')

--- a/api/ombpdf/pagenumbers.py
+++ b/api/ombpdf/pagenumbers.py
@@ -2,7 +2,6 @@ import re
 
 from .document import OMBPageNumber
 
-
 PAGE_NUMBER_RE = re.compile(r'^([0-9]+)$')
 
 

--- a/api/ombpdf/paragraphs.py
+++ b/api/ombpdf/paragraphs.py
@@ -2,7 +2,6 @@ import re
 
 from .document import OMBParagraph
 
-
 PARAGRAPH_END_RE = re.compile(r'.+\.\s*$')
 
 MAX_INDENT = 48

--- a/api/ombpdf/rawlayout.py
+++ b/api/ombpdf/rawlayout.py
@@ -1,5 +1,5 @@
-from html import escape
 from decimal import Decimal
+from html import escape
 
 
 def to_px_style_attr(**kwargs):
@@ -52,4 +52,4 @@ def to_html(doc):
             chunks.append(f'</div>')
         chunks.append(f'</div>\n')
 
-    return (''.join(chunks), dict(legend=legend))
+    return (''.join(chunks), {'legend': legend})

--- a/api/ombpdf/semhtml.py
+++ b/api/ombpdf/semhtml.py
@@ -23,39 +23,39 @@ class HTMLWriter(semtree.Writer):
 
     # Below are Writer methods.
 
-    def begin_Document(self, doc):
+    def begin_document(self, doc):
         self.chunks.append(
             f'<title>Semantic HTML output for {doc.title}</title>\n'
         )
 
-    def end_Document(self, doc):
+    def end_document(self, doc):
         pass
 
-    def begin_Heading(self, heading):
+    def begin_heading(self, heading):
         self.chunks.append(f'<h{heading.level}>')
 
-    def end_Heading(self, heading):
+    def end_heading(self, heading):
         self.chunks.append(f'</h{heading.level}>\n')
 
-    def begin_Paragraph(self, p):
+    def begin_paragraph(self, p):
         self.chunks.append(f'<p>')
 
-    def end_Paragraph(self, p):
+    def end_paragraph(self, p):
         self.chunks.append(f'</p>\n')
 
-    def begin_List(self, li):
+    def begin_list(self, li):
         self.chunks.append('<ol>' if li.is_ordered else '<ul>')
 
-    def end_List(self, li):
+    def end_list(self, li):
         self.chunks.append('</ol>\n' if li.is_ordered else '</ul>\n')
 
-    def begin_ListItem(self, p):
+    def begin_list_item(self, p):
         self.chunks.append(f'<li>')
 
-    def end_ListItem(self, p):
+    def end_list_item(self, p):
         self.chunks.append(f'</li>\n')
 
-    def create_FootnoteCitation(self, cit):
+    def create_footnote_citation(self, cit):
         cit_id = self.id_for_footnote_citation(cit.number)
         self.footnote_citations[cit.number] = cit_id
         self.chunks.append(
@@ -64,14 +64,14 @@ class HTMLWriter(semtree.Writer):
             f'{cit.number}</a></sup>'
         )
 
-    def begin_FootnoteList(self, fl):
+    def begin_footnote_list(self, fl):
         self.chunks.append('<h2>Footnotes</h2>\n')
         self.chunks.append('<dl>\n')
 
-    def end_FootnoteList(self, fl):
+    def end_footnote_list(self, fl):
         self.chunks.append('</dl>\n')
 
-    def create_Footnote(self, f):
+    def create_footnote(self, f):
         self.chunks.append(f'<dt id="{self.id_for_footnote(f.number)}">'
                            f'{f.number}</dt>\n')
         self.chunks.append(f'<dd>{f.text}')

--- a/api/ombpdf/semtree.py
+++ b/api/ombpdf/semtree.py
@@ -1,3 +1,4 @@
+import re
 from contextlib import contextmanager
 
 from . import document
@@ -62,7 +63,7 @@ class Writer:
     Here's an example of the way the double dispatching works:
 
         >>> class MyWriter(Writer):
-        ...     def create_FootnoteCitation(self, cit):
+        ...     def create_footnote_citation(self, cit):
         ...         print(f"Creating footnote citation {cit.number}!")
 
         >>> writer = MyWriter()
@@ -70,8 +71,14 @@ class Writer:
         Creating footnote citation 1!
     '''
 
+    # https://stackoverflow.com/a/1176023
+    def _camelcase_to_underscores(self, name):
+        s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+        return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+
     def _dispatch_method(self, prefix, el):
-        method = getattr(self, f'{prefix}_{el.__class__.__name__}')
+        uname = self._camelcase_to_underscores(el.__class__.__name__)
+        method = getattr(self, f'{prefix}_{uname}')
         method(el)
 
     def begin_element(self, el):

--- a/api/ombpdf/semtree.py
+++ b/api/ombpdf/semtree.py
@@ -18,7 +18,8 @@ class Document(Element):
         self.title = title
 
 
-class Paragraph(Element): pass
+class Paragraph(Element):
+    pass
 
 
 class List(Element):
@@ -26,7 +27,8 @@ class List(Element):
         self.is_ordered = is_ordered
 
 
-class ListItem(Element): pass
+class ListItem(Element):
+    pass
 
 
 class Heading(Element):
@@ -41,7 +43,8 @@ class FootnoteCitation(Element):
         self.number = number
 
 
-class FootnoteList(Element): pass
+class FootnoteList(Element):
+    pass
 
 
 class Footnote(Element):

--- a/api/ombpdf/tests/bbox.py
+++ b/api/ombpdf/tests/bbox.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 
 from .conftest import load_document
 
-
 BboxInfo = namedtuple('BboxInfo', [
     'pdf',
     'page',
@@ -15,10 +14,11 @@ BboxInfo = namedtuple('BboxInfo', [
 
 RAWLAYOUT_URL_RE = re.compile(r'^.+\/rawlayout\/(.*)\?bbox=([0-9.,]+).*$')
 
+
 def parse_rawlayout_url(url):
     '''
-    >>> parse_rawlayout_url('http://localhost:5000/rawlayout/2016/m_16_19_1.pdf?bbox=4,515,16.9375,559,93.9375#4')
-    BboxInfo(pdf='2016/m_16_19_1.pdf', page=4, x0=515.0, y0=16.9375, x1=559.0, y1=93.9375)
+    >>> parse_rawlayout_url('http://localhost:5000/rawlayout/2016/m_16_19_1.pdf?bbox=4,515,16.9375,559,93.9375#4')  # NOQA
+    BboxInfo(pdf='2016/m_16_19_1.pdf', page=4, x0=515.0, y0=16.9375, x1=559.0, y1=93.9375)  # NOQA
 
     >>> parse_rawlayout_url('blah')
     Traceback (most recent call last):

--- a/api/ombpdf/tests/conftest.py
+++ b/api/ombpdf/tests/conftest.py
@@ -1,8 +1,7 @@
 import pytest
 
+from ombpdf import document, util
 from ombpdf.download_pdfs import download
-from ombpdf import util, document
-
 
 pages_cache = {}
 

--- a/api/ombpdf/tests/test_doctests.py
+++ b/api/ombpdf/tests/test_doctests.py
@@ -1,0 +1,21 @@
+import doctest
+from importlib import import_module
+
+import pytest
+
+
+@pytest.mark.parametrize('module_name', [
+    'ombpdf.fontsize',
+    'ombpdf.eqnamedtuple',
+    'ombpdf.paragraphs',
+    'ombpdf.rawlayout',
+    'ombpdf.semtree',
+])
+def test_doctests(module_name):
+    _, test_count = doctest.testmod(
+        import_module(module_name),
+        report=True,
+        verbose=True,
+        raise_on_error=True
+    )
+    assert test_count > 0

--- a/api/ombpdf/tests/test_eqnamedtuple.py
+++ b/api/ombpdf/tests/test_eqnamedtuple.py
@@ -2,14 +2,14 @@ from ombpdf.eqnamedtuple import eqnamedtuple
 
 
 def test_name_works():
-    Blah = eqnamedtuple('Blah', ['u'])
+    Blah = eqnamedtuple('Blah', ['u'])  # NOQA
 
     assert Blah.__name__ == 'Blah'
 
 
 def test_eq_works():
-    Foo = eqnamedtuple('Foo', ['foo'])
-    Bar = eqnamedtuple('Bar', ['bar'])
+    Foo = eqnamedtuple('Foo', ['foo'])  # NOQA
+    Bar = eqnamedtuple('Bar', ['bar'])  # NOQA
 
     assert Foo(1) != Bar(1)
     assert Foo(1) == Foo(1)

--- a/api/ombpdf/tests/test_headings.py
+++ b/api/ombpdf/tests/test_headings.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
-from ombpdf.fontsize import FontSize, FontName
 from ombpdf import headings
+from ombpdf.fontsize import FontName, FontSize
 from ombpdf.headings import Style
 
 

--- a/api/ombpdf/tests/test_html.py
+++ b/api/ombpdf/tests/test_html.py
@@ -2,8 +2,8 @@ import re
 from pathlib import Path
 
 from ombpdf.html import to_html
-from .snapshot import assert_snapshot_matches
 
+from .snapshot import assert_snapshot_matches
 
 MY_DIR = Path(__file__).parent
 

--- a/api/ombpdf/tests/test_lists.py
+++ b/api/ombpdf/tests/test_lists.py
@@ -2,6 +2,7 @@ import pytest
 
 from ombpdf.document import OMBListItem, OMBListItemMarker
 from ombpdf.lists import annotate_lists
+
 from . import bbox
 
 
@@ -70,7 +71,7 @@ def test_lists_are_annotated_on_m_15_17(m_15_17_doc):
 
 @pytest.mark.xfail(raises=AssertionError)
 def test_unordered_2():
-    doc, _, lines = bbox.find_lines('http://localhost:5000/rawlayout/2011/m11-29.pdf?bbox=2,67,554.390625,560,737.390625#2')
+    doc, _, lines = bbox.find_lines('http://localhost:5000/rawlayout/2011/m11-29.pdf?bbox=2,67,554.390625,560,737.390625#2')  # NOQA
     doc.annotators.require('lists')
     for line in lines:
         assert isinstance(line.annotation, OMBListItem)

--- a/api/ombpdf/tests/test_pagenumbers.py
+++ b/api/ombpdf/tests/test_pagenumbers.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ombpdf import pagenumbers
+
 from . import bbox
 
 
@@ -15,7 +16,7 @@ def test_annotate_page_numbers_works(m_16_19_doc):
 @pytest.mark.xfail(raises=AssertionError,
                    reason="https://github.com/18F/omb-pdf/issues/1")
 def test_page_numbers_with_weird_line_ordering_are_recognized():
-    doc, _, line = bbox.find_line('http://localhost:5000/rawlayout/2016/m_16_19_1.pdf?bbox=4,515,16.9375,559,93.9375#4')
+    doc, _, line = bbox.find_line('http://localhost:5000/rawlayout/2016/m_16_19_1.pdf?bbox=4,515,16.9375,559,93.9375#4')  # NOQA
 
     doc.annotators.require('page_numbers')
     assert line.annotation == pagenumbers.OMBPageNumber(4)

--- a/api/ombpdf/tests/test_paragraphs.py
+++ b/api/ombpdf/tests/test_paragraphs.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ombpdf import paragraphs
+
 from . import bbox
 
 
@@ -36,7 +37,7 @@ def test_annotate_paragraphs_works_with_indents(m_15_17_doc):
 
 @pytest.mark.xfail(raises=AssertionError)
 def test_indents_2():
-    doc, _, lines = bbox.find_lines('http://localhost:5000/rawlayout/2011/m11-29.pdf?bbox=1,61,240.5,546,313.5#1')
+    doc, _, lines = bbox.find_lines('http://localhost:5000/rawlayout/2011/m11-29.pdf?bbox=1,61,240.5,546,313.5#1')  # NOQA
     doc.annotators.require('paragraphs')
     for line in lines:
         assert isinstance(line.annotation, paragraphs.OMBParagraph)

--- a/api/ombpdf/tests/test_semhtml.py
+++ b/api/ombpdf/tests/test_semhtml.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 from ombpdf.semhtml import to_html
-from .snapshot import assert_snapshot_matches
 
+from .snapshot import assert_snapshot_matches
 
 MY_DIR = Path(__file__).parent
 

--- a/api/ombpdf/tests/test_webapp.py
+++ b/api/ombpdf/tests/test_webapp.py
@@ -1,7 +1,8 @@
 import pytest
 
 from ombpdf.download_pdfs import download
-#import ombpdf.webapp
+
+# import ombpdf.webapp
 
 
 PDFPATH = '2016/m_16_19_1.pdf'
@@ -12,8 +13,8 @@ def webapp():
     # Ensure we have at least one PDF for the webapp to process.
     download(PDFPATH)
 
-    ombpdf.webapp.app.testing = True
-    return ombpdf.webapp.app.test_client()
+    # ombpdf.webapp.app.testing = True
+    # return ombpdf.webapp.app.test_client()
 
 
 @pytest.mark.skip(reason="Need to convert webapp to Django first!")

--- a/api/ombpdf/underlines.py
+++ b/api/ombpdf/underlines.py
@@ -1,6 +1,5 @@
 from .horizlines import get_horizontal_lines
 
-
 # Percentage of bbox height underline can be from bottom of a line's bbox.
 MAX_LINE_BBOX_DIST = 0.25
 

--- a/api/ombpdf/util.py
+++ b/api/ombpdf/util.py
@@ -1,4 +1,4 @@
-from pdfminer import converter, pdfinterp, layout
+from pdfminer import converter, layout, pdfinterp
 from pdfminer.pdfpage import PDFPage
 
 

--- a/api/requirements.in
+++ b/api/requirements.in
@@ -17,4 +17,4 @@ psycopg2
 python-dateutil
 requests
 whitenoise
-pdfminer.six==20170720
+pdfminer.six

--- a/api/setup.cfg
+++ b/api/setup.cfg
@@ -7,7 +7,6 @@ testpaths=document/tests ereqs_admin/tests reqs/tests
 exclude = 
     */migrations/*.py,
     node_modules,
-    ombpdf,
     .venv-dev,
     .venv-prod
 


### PR DESCRIPTION
Following up on #757, this re-enables linting on ombpdf and a few other things.

## Notes

* Wow, I didn't know about the actual [`isort` command-line program](https://pypi.python.org/pypi/isort). That made some of this a lot easier!

* The visitor pattern used for serializing semantic trees used to do dynamic dispatch by calling a method that had a camel-cased class name in it, but this upset the linter for obvious reasons, so I changed the convention to use an underscored version of the class name instead.

* Doctests from `ombpdf` are now tested. As mentioned in #757, enabling doctest finding in pytest across the whole codebase resulted in a mysterious segfault, and there didn't seem to be any way to scope doctest-finding only to specific directories, so instead I just added a `test_doctests.py` suite that manually runs the doctests. I also preferred to keep them as doctests, rather than convert them to normal tests, because I think they helped document the code they described.
