### PR TITLE
Create/highlight "Footnotes" section of ToC

### DIFF
--- a/ui/__tests__/components/document/footnotes.test.js
+++ b/ui/__tests__/components/document/footnotes.test.js
@@ -1,0 +1,26 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { Footnotes } from '../../../components/document/footnotes';
+import DocumentNode from '../../../util/document-node';
+
+describe('<Footnotes />', () => {
+  it('includes the id', () => {
+    const result = shallow(<Footnotes footnotes={[]} id="ididid" />);
+    expect(result.prop('id')).toBe('ididid');
+  });
+  it('renders footnotes at the bottom', () => {
+    const footnotes = [
+      new DocumentNode({ identifier: '1' }),
+      new DocumentNode({ identifier: '2' }),
+      new DocumentNode({ identifier: '3' }),
+    ];
+    const result = shallow(<Footnotes footnotes={footnotes} id="" />);
+    expect(result.hasClass('bottom-footnotes')).toBe(true);
+    const components = result.find('Footnote');
+    expect(components).toHaveLength(3);
+    expect(components.at(0).prop('docNode').identifier).toBe('1');
+    expect(components.at(1).prop('docNode').identifier).toBe('2');
+    expect(components.at(2).prop('docNode').identifier).toBe('3');
+  });
+});

--- a/ui/__tests__/components/node-renderers/policy.test.js
+++ b/ui/__tests__/components/node-renderers/policy.test.js
@@ -67,23 +67,4 @@ describe('<Policy />', () => {
     const date = result.find('LabeledText').first();
     expect(date.children().text()).toEqual('some date here');
   });
-  it('renders footnotes at the bottom', () => {
-    const docNode = new DocumentNode({
-      meta: {
-        ...meta,
-        descendant_footnotes: [
-          new DocumentNode({ identifier: '1' }),
-          new DocumentNode({ identifier: '2' }),
-          new DocumentNode({ identifier: '3' }),
-        ],
-      },
-    });
-
-    const result = shallow(<Policy docNode={docNode} />);
-    const footnotes = result.find('.bottom-footnotes Footnote');
-    expect(footnotes).toHaveLength(3);
-    expect(footnotes.at(0).prop('docNode').identifier).toBe('1');
-    expect(footnotes.at(1).prop('docNode').identifier).toBe('2');
-    expect(footnotes.at(2).prop('docNode').identifier).toBe('3');
-  });
 });

--- a/ui/__tests__/pages/document.test.js
+++ b/ui/__tests__/pages/document.test.js
@@ -58,15 +58,31 @@ describe('getInitialProps()', () => {
     const result = await getInitialProps({ query: {} });
     expect(result).toEqual({ statusCode: 404 });
   });
-  it('triggers a document reset', async () => {
+  describe('document reset', () => {
     const tableOfContents = { children: [], identifier: 'idid', title: 'ttt' };
-    endpoints.document.fetchOne = jest.fn(() => ({ meta: {
-      policy: { issuance: '2001-02-03' },
-      table_of_contents: tableOfContents,
-    } }));
+    const policy = { issuance: '2001-02-03' };
     const store = { dispatch: jest.fn() };
 
-    await getInitialProps({ query: {}, store });
-    expect(store.dispatch).toHaveBeenCalledWith(loadDocument(tableOfContents));
+    it('bases hasFootnotes on the proper fields', async () => {
+      endpoints.document.fetchOne = jest.fn(() => ({ meta: {
+        descendant_footnotes: [],
+        policy,
+        table_of_contents: tableOfContents,
+      } }));
+
+      await getInitialProps({ query: {}, store });
+      expect(store.dispatch).toHaveBeenCalledWith(
+        loadDocument(tableOfContents, false));
+
+      endpoints.document.fetchOne = jest.fn(() => ({ meta: {
+        descendant_footnotes: [1, 2, 3],
+        policy,
+        table_of_contents: tableOfContents,
+      } }));
+
+      await getInitialProps({ query: {}, store });
+      expect(store.dispatch).toHaveBeenCalledWith(
+        loadDocument(tableOfContents, true));
+    });
   });
 });

--- a/ui/__tests__/pages/document.test.js
+++ b/ui/__tests__/pages/document.test.js
@@ -26,6 +26,25 @@ describe('<Document />', () => {
     expect(nav).toHaveLength(1);
     expect(nav.prop('isRoot')).toBe(true);
   });
+  it('does not include Footnotes if none are present', () => {
+    renderNode.mockImplementationOnce(() => null);
+    const result = shallow(<Document docNode={{}} />);
+    const footnotes = result.find('Connect(withScrollTracking(Footnotes))');
+    expect(footnotes).toHaveLength(0);
+  });
+  it('includes Footnotes', () => {
+    renderNode.mockImplementationOnce(() => null);
+    const docNode = { meta: { descendant_footnotes: [
+      { identifier: 'footnote_1' }, { identifier: 'footnote_2' },
+    ] } };
+    const result = shallow(<Document docNode={docNode} />);
+    const footnotes = result.find('Connect(withScrollTracking(Footnotes))');
+    expect(footnotes).toHaveLength(1);
+    expect(footnotes.prop('id')).toBe('document-footnotes');
+    expect(footnotes.prop('footnotes').map(f => f.identifier)).toEqual(
+      ['footnote_1', 'footnote_2'],
+    );
+  });
 });
 
 describe('getInitialProps()', () => {

--- a/ui/__tests__/store.test.js
+++ b/ui/__tests__/store.test.js
@@ -26,7 +26,7 @@ describe('footnote functionality', () => {
 describe('loading a new document', () => {
   it('clears existing footnotes', () => {
     const state = { ...initialState, openedFootnote: 'footnote' };
-    const result = reducer(state, loadDocument({ children: [] }));
+    const result = reducer(state, loadDocument({ children: [] }, false));
     expect(result.openedFootnote).toBe('');
   });
   it('sets the table of contents', () => {
@@ -35,7 +35,7 @@ describe('loading a new document', () => {
       identifier: 'idid',
       title: 'ttt',
     };
-    const result = reducer(initialState, loadDocument(tableOfContents));
+    const result = reducer(initialState, loadDocument(tableOfContents, false));
     expect(result.tableOfContents).toEqual(tableOfContents);
   });
   it('trims the table of contents', () => {
@@ -53,7 +53,7 @@ describe('loading a new document', () => {
       }],
     };
     const { tableOfContents: root } = reducer(
-      initialState, loadDocument(tableOfContents));
+      initialState, loadDocument(tableOfContents, false));
     expect(root.identifier).toBe('root');
     expect(root.children).toHaveLength(1);
     const [level1] = root.children;
@@ -62,6 +62,23 @@ describe('loading a new document', () => {
     const [level2] = level1.children;
     expect(level2.identifier).toBe('level-2');
     expect(level2.children).toHaveLength(0);
+  });
+  it('adds footnotes if applicable', () => {
+    const tableOfContents = {
+      children: [],
+      identifier: 'idid',
+      title: 'ttt',
+    };
+    const noFootnotes = reducer(initialState, loadDocument(tableOfContents, false));
+    expect(noFootnotes.tableOfContents.children).toHaveLength(0);
+
+    const withFootnotes = reducer(initialState, loadDocument(tableOfContents, true));
+    expect(withFootnotes.tableOfContents.children).toHaveLength(1);
+    expect(withFootnotes.tableOfContents.children[0]).toEqual({
+      children: [],
+      identifier: 'document-footnotes',
+      title: 'Footnotes',
+    });
   });
 });
 

--- a/ui/__tests__/util/with-scroll-tracking.test.js
+++ b/ui/__tests__/util/with-scroll-tracking.test.js
@@ -1,19 +1,13 @@
 import { mount } from 'enzyme';
-import PropTypes from 'prop-types';
 import React from 'react';
 import { createStore } from 'redux';
 
 import initialState from '../../store/initial-state';
 import withScrollTracking from '../../util/with-scroll-tracking';
 
-function MyComponent({ docNode }) {
-  return docNode.identifier;
+function MyComponent() {
+  return <div>Not seen</div>;
 }
-MyComponent.propTypes = {
-  docNode: PropTypes.shape({
-    identifier: PropTypes.string.isRequired,
-  }).isRequired,
-};
 
 describe('withScrollTracking', () => {
   const startState = {
@@ -28,18 +22,16 @@ describe('withScrollTracking', () => {
   };
 
   it('does not wrap components which are not in the toc', () => {
-    const docNode = { identifier: 'not-in-toc' };
     const Wrapped = withScrollTracking(MyComponent);
     const store = createStore(state => state, startState);
-    const result = mount(<Wrapped docNode={docNode} store={store} />);
+    const result = mount(<Wrapped id="not-in-toc" store={store} />);
     // 2 levels of HOC: React-Redux, WithScrollTracking
     expect(result.children().children().type()).toBe(MyComponent);
   });
   it('wraps toc components with Waypoint', () => {
-    const docNode = { identifier: 'child-1' };
     const Wrapped = withScrollTracking(MyComponent);
     const store = createStore(state => state, startState);
-    const result = mount(<Wrapped docNode={docNode} store={store} />);
+    const result = mount(<Wrapped id="child-1" store={store} />);
     // 2 levels of HOC: React-Redux, WithScrollTracking
     expect(result.children().children().name()).toBe('Waypoint');
   });

--- a/ui/components/document/footnotes.js
+++ b/ui/components/document/footnotes.js
@@ -1,0 +1,17 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import DocumentNode from '../../util/document-node';
+import Footnote from '../node-renderers/footnote';
+
+export default function Footnotes({ id, footnotes }) {
+  return (
+    <div className="bottom-footnotes" id={id}>
+      { footnotes.map(fn => <Footnote key={fn.identifier} docNode={fn} />) }
+    </div>
+  );
+}
+Footnotes.propTypes = {
+  id: PropTypes.string.isRequired,
+  footnotes: PropTypes.arrayOf(PropTypes.instanceOf(DocumentNode)).isRequired,
+};

--- a/ui/components/document/footnotes.js
+++ b/ui/components/document/footnotes.js
@@ -2,9 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import DocumentNode from '../../util/document-node';
+import withScrollTracking from '../../util/with-scroll-tracking';
 import Footnote from '../node-renderers/footnote';
 
-export default function Footnotes({ id, footnotes }) {
+export function Footnotes({ id, footnotes }) {
   return (
     <div className="bottom-footnotes" id={id}>
       { footnotes.map(fn => <Footnote key={fn.identifier} docNode={fn} />) }
@@ -15,3 +16,5 @@ Footnotes.propTypes = {
   id: PropTypes.string.isRequired,
   footnotes: PropTypes.arrayOf(PropTypes.instanceOf(DocumentNode)).isRequired,
 };
+
+export default withScrollTracking(Footnotes);

--- a/ui/components/node-renderers/policy.js
+++ b/ui/components/node-renderers/policy.js
@@ -5,7 +5,6 @@ import DocumentNode from '../../util/document-node';
 import renderNode from '../../util/render-node';
 import LabeledText from '../labeled-text';
 import Link from '../link';
-import Footnote from './footnote';
 import From from './from';
 
 function findNodeText(docNode, nodeType, modelValue) {
@@ -14,20 +13,6 @@ function findNodeText(docNode, nodeType, modelValue) {
     return containingNode.text;
   }
   return modelValue;
-}
-
-function footnotes(footnoteList) {
-  if (footnoteList.length === 0) {
-    return null;
-  }
-  const rendered = footnoteList.map(fn => (
-    <Footnote key={fn.identifier} docNode={fn} />
-  ));
-  return (
-    <div className="bottom-footnotes">
-      { rendered }
-    </div>
-  );
 }
 
 
@@ -56,7 +41,6 @@ export default function Policy({ docNode }) {
         </LabeledText>
       </header>
       { docNode.children.map(renderNode) }
-      { footnotes(docNode.meta.descendantFootnotes) }
     </div>
   );
 }

--- a/ui/pages/document.js
+++ b/ui/pages/document.js
@@ -40,7 +40,9 @@ Document.propTypes = {
 export async function getInitialProps(props) {
   return propagate404(async () => {
     const { docNode } = await documentData(props);
-    props.store.dispatch(loadDocument(docNode.meta.table_of_contents));
+    const tableOfContents = docNode.meta.table_of_contents;
+    const hasFootnotes = docNode.meta.descendant_footnotes.length > 0;
+    props.store.dispatch(loadDocument(tableOfContents, hasFootnotes));
     return { docNode };
   });
 }

--- a/ui/pages/document.js
+++ b/ui/pages/document.js
@@ -3,6 +3,7 @@ import React from 'react';
 import Sticky from 'react-stickynode';
 
 import wrapPage from '../components/app-wrapper';
+import Footnotes from '../components/document/footnotes';
 import DocumentNav from '../components/document/navigation';
 import { loadDocument } from '../store/actions';
 import { documentData, propagate404 } from '../util/api/queries';
@@ -15,6 +16,7 @@ const headerFooterParams = {
 
 export function Document({ docNode }) {
   const doc = new DocumentNode(docNode);
+  const footnotes = doc.meta.descendantFootnotes;
   return (
     <div className="document-container clearfix max-width-4">
       <div className="col col-3 sm-hide xs-hide">
@@ -25,6 +27,8 @@ export function Document({ docNode }) {
       <div className="col col-1 sm-hide xs-hide">&nbsp;</div>
       <div className="col-12 md-col-6 col">
         { renderNode(doc) }
+        { footnotes.length ?
+          <Footnotes footnotes={footnotes} id="document-footnotes" /> : null }
       </div>
     </div>
   );

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -30,10 +30,22 @@ const trimTableOfContents = (depth, tableOfContents) => {
   };
 };
 
-export const loadDocument = tableOfContents => ({
-  tableOfContents: trimTableOfContents(2, tableOfContents),
-  type: LOAD_DOCUMENT,
-});
+const footnotesToC = {
+  children: [],
+  identifier: 'document-footnotes',
+  title: 'Footnotes',
+};
+
+export const loadDocument = (tableOfContents, hasFootnotes) => {
+  const trimmed = trimTableOfContents(2, tableOfContents);
+  if (hasFootnotes) {
+    trimmed.children.push(footnotesToC);
+  }
+  return {
+    tableOfContents: trimmed,
+    type: LOAD_DOCUMENT,
+  };
+};
 
 export const openFootnote = footnoteIdentifier => ({
   footnoteIdentifier,

--- a/ui/store/reducer.js
+++ b/ui/store/reducer.js
@@ -14,9 +14,10 @@ export function allIds(toc) {
 
 export function deriveCurrentSection(tableOfContents, visibleSections) {
   const ids = allIds(tableOfContents);
+  const firstSection = ids.length ? ids[0] : '';
   ids.reverse();
   const match = ids.find(id => visibleSections.includes(id));
-  return match || (ids.length ? ids[ids.length - 1] : '');
+  return match || firstSection;
 }
 
 export default function reducer(state = initialState, action) {

--- a/ui/util/render-node.js
+++ b/ui/util/render-node.js
@@ -38,6 +38,6 @@ export default function renderNode(docNode) {
     th,
   };
   const NodeComponent = nodeMapping[docNode.nodeType] || Fallback;
-  const props = { docNode, key: docNode.identifier };
+  const props = { docNode, id: docNode.identifier, key: docNode.identifier };
   return <NodeComponent {...props} />;
 }

--- a/ui/util/with-scroll-tracking.js
+++ b/ui/util/with-scroll-tracking.js
@@ -8,16 +8,16 @@ import { allIds } from '../store/reducer';
 
 /* We only want to wrap components which are in the table of contents to limit
  * the amount of state changes */
-function mapStateToProps({ tableOfContents }, { docNode }) {
+function mapStateToProps({ tableOfContents }, { id }) {
   return {
-    trackScroll: allIds(tableOfContents).includes(docNode.identifier),
+    trackScroll: allIds(tableOfContents).includes(id),
   };
 }
 
-function mapDispatchToProps(dispatch, { docNode }) {
+function mapDispatchToProps(dispatch, { id }) {
   return {
-    onEnter: () => dispatch(enterSection(docNode.identifier)),
-    onLeave: () => dispatch(exitSection(docNode.identifier)),
+    onEnter: () => dispatch(enterSection(id)),
+    onLeave: () => dispatch(exitSection(id)),
   };
 }
 


### PR DESCRIPTION
Building on #752 ([diff](https://github.com/18F/omb-eregs/compare/735-hl-section...735-hl-footnotes)), this adds a "Footnotes" section to the bottom of the table of contents (when footnotes are present). It also wraps the footnotes with scroll tracking to highlight the correct section.

Looks like:
![scroll-tracking](https://user-images.githubusercontent.com/326918/33890819-4ffd72f0-df22-11e7-92ad-be17e0ee9c39.gif)
