### PR TITLE
Work around react-stickynode bug.

### DIFF
--- a/ui/pages/document.js
+++ b/ui/pages/document.js
@@ -14,15 +14,39 @@ const headerFooterParams = {
   showSearch: true,
 };
 
+/* react-stickynode has an annoying bug
+ * https://github.com/yahoo/react-stickynode/issues/61 around not loading
+ * correctly if linking to the middle of a page. This hacks around that by
+ * sending a mock scroll event (resizing won't get us into the "fixed" state)
+ * on mount to the DOM.
+ */
+class StartupSticky extends Sticky {
+  componentDidMount() {
+    super.componentDidMount();
+    const scrollEvent = {
+      scroll: {
+        delta: 1, // down
+        top: window.scrollY,
+      },
+    };
+    // react-sticky's initialization isn't actually complete until the state
+    // change *after* componentDidMount. Therefore, we add a callback to fire
+    // after that state change...
+    /* eslint-disable react/no-did-mount-set-state */
+    this.setState({}, () => this.handleScroll(null, scrollEvent));
+    /* eslint-enable react/no-did-mount-set-state */
+  }
+}
+
 export function Document({ docNode }) {
   const doc = new DocumentNode(docNode);
   const footnotes = doc.meta.descendantFootnotes;
   return (
     <div className="document-container clearfix max-width-4">
       <div className="col col-3 sm-hide xs-hide">
-        <Sticky bottomBoundary=".document-container">
+        <StartupSticky bottomBoundary=".document-container">
           <DocumentNav isRoot />
-        </Sticky>
+        </StartupSticky>
       </div>
       <div className="col col-1 sm-hide xs-hide">&nbsp;</div>
       <div className="col-12 md-col-6 col">


### PR DESCRIPTION
Our "Sticky" library has a bug around activation on initial page load. This
works around that by triggering a mock scroll event on DOM mount.