### PR TITLE
Only log warnings from pdfminer

### DIFF
--- a/api/omb_eregs/settings.py
+++ b/api/omb_eregs/settings.py
@@ -237,6 +237,10 @@ LOGGING = {
             'handlers': ['console'],
             'level': 'INFO',
         },
+        'pdfminer': {
+            'handlers': ['console'],
+            'level': 'WARNING',
+        },
     }
 }
 


### PR DESCRIPTION
pdfminer has a *lot* of informational logging output, which spams the logs during development, so this changes it to only log warnings/errors.

The change in behavior can be seen by running e.g. `manage.py pdf_fonts data/2016/m_16_19_1.pdf`.
