### PR TITLE
Tweak mobile header, begin to standardize on media

### DIFF
--- a/ui/components/navbar.js
+++ b/ui/components/navbar.js
@@ -20,7 +20,7 @@ export default function Navbar({ showSearch }) {
     <div className="overflow-auto">
       <div className="flex items-center navbar">
         <img
-          className="pl2 pr1"
+          className="mobile-hide pl2 pr1"
           alt="US flag"
           width="50"
           height="50"

--- a/ui/css/base/_media-queries.scss
+++ b/ui/css/base/_media-queries.scss
@@ -1,0 +1,33 @@
+$breakpoint-xs-sm-dim: 640px; // basscss' default (= 40em)
+$breakpoint-sm-md-dim: 832px; // basscss' default (= 52em)
+$breakpoint-md-lg-dim: 1024px; // basscss's default (= 64em)
+
+$breakpoint-mobile-desktop-dim: $breakpoint-sm-md-dim;
+
+// These vars are used in basscss
+$breakpoint-sm: '(min-width: #{$breakpoint-xs-sm-dim})';
+$breakpoint-md: '(min-width: #{$breakpoint-sm-md-dim})';
+$breakpoint-lg: '(min-width: #{$breakpoint-md-lg-dim})';
+
+$on-mobile: '(max-width: #{$breakpoint-mobile-desktop-dim - 1})';
+$on-desktop: $breakpoint-md;
+
+@mixin hide-on-mobile() {
+  @media #{$on-mobile} {
+    display: none;
+  }
+}
+
+@mixin hide-on-desktop() {
+  @media #{$on-desktop} {
+    display: none;
+  }
+}
+
+.mobile-hide {
+  @include hide-on-mobile();
+}
+
+.desktop-hide {
+  @include hide-on-desktop();
+}

--- a/ui/css/layout/_markers.scss
+++ b/ui/css/layout/_markers.scss
@@ -1,28 +1,28 @@
-$marker-width-xs: 24px;
-$marker-whitespace-xs: 4px;
-$marker-width-md: $marker-width-xs + 8;
-$marker-whitespace-md: $marker-whitespace-xs + 4;
+$marker-width-mobile: 24px;
+$marker-whitespace-mobile: 4px;
+$marker-width-desktop: $marker-width-mobile + 8;
+$marker-whitespace-desktop: $marker-whitespace-mobile + 4;
 
 @mixin paragraph-marker() {
   @extend .col;
   @extend .right-align;
-  width: $marker-width-xs;
-  margin-right: $marker-whitespace-xs;
+  width: $marker-width-mobile;
+  margin-right: $marker-whitespace-mobile;
   display: inline-block;
 
-  @media #{$breakpoint-md} {
-    width: $marker-width-md;
-    margin-right: $marker-whitespace-md;
+  @media #{$on-desktop} {
+    width: $marker-width-desktop;
+    margin-right: $marker-whitespace-desktop;
   }
 }
 
 @mixin paragraph-with-marker() {
   @extend .col;
   @extend .col-11;
-  width: calc(100% - #{$marker-width-xs + $marker-whitespace-xs});
+  width: calc(100% - #{$marker-width-mobile + $marker-whitespace-mobile});
   word-wrap: break-word;
 
-  @media #{$breakpoint-md} {
-    width: calc(100% - #{$marker-width-md + $marker-whitespace-md});
+  @media #{$on-desktop} {
+    width: calc(100% - #{$marker-width-desktop + $marker-whitespace-desktop});
   }
 }

--- a/ui/css/layout/_typography.scss
+++ b/ui/css/layout/_typography.scss
@@ -127,7 +127,7 @@ p {
   line-height: 1.69rem;
 }
 
-@media #{$breakpoint-md} {
+@media #{$on-desktop} {
   h1,
   .h1 {
     font-size: 2rem;

--- a/ui/css/main.scss
+++ b/ui/css/main.scss
@@ -13,6 +13,7 @@ $fa-font-path: '~font-awesome/fonts';
 @import 'base/colors';
 @import 'base/base';
 @import 'base/fonts';
+@import 'base/media-queries';
 @import 'base/util';
 
 @import 'layout/typography';

--- a/ui/css/module/_header.scss
+++ b/ui/css/module/_header.scss
@@ -1,4 +1,5 @@
 .usa-disclaimer {
+  @include hide-on-mobile();
   background-color: $color-white;
   color: $color-gray;
   font-size: 0.75rem;
@@ -27,13 +28,19 @@
 .navbar-title {
   display: inline-block;
   color: $color-white;
-  font-size: 1.75rem;
-  font-weight: bold;
-  line-height: 2.25rem;
+  font-size: 1rem;
+  font-weight: normal;
+  line-height: 1rem;
   margin-bottom: .67em;
   margin-top: .67em;
   -webkit-margin-before: 0.67em;
   -webkit-margin-after: 0.67em;
+
+  @media #{$on-desktop} {
+    font-size: 1.75rem;
+    font-weight: bold;
+    line-height: 2.25rem;
+  }
 
   sup {
     font-size: 0.625rem;

--- a/ui/pages/document.js
+++ b/ui/pages/document.js
@@ -43,12 +43,12 @@ export function Document({ docNode }) {
   const footnotes = doc.meta.descendantFootnotes;
   return (
     <div className="document-container clearfix max-width-4">
-      <div className="col col-3 sm-hide xs-hide">
+      <div className="col col-3 mobile-hide">
         <StartupSticky bottomBoundary=".document-container">
           <DocumentNav isRoot />
         </StartupSticky>
       </div>
-      <div className="col col-1 sm-hide xs-hide">&nbsp;</div>
+      <div className="col col-1 mobile-hide">&nbsp;</div>
       <div className="col-12 md-col-6 col">
         { renderNode(doc) }
         { footnotes.length ?


### PR DESCRIPTION
As part of #734, this adds some scss to differentiate mobile from desktop views. It then uses those to tweak the mobile header. @rtwell's agreed that these changes are a step in the right direction (though we won't implement a full redesign this sprint).

Looks like:
<img width="1222" alt="screen shot 2017-12-13 at 11 03 28 am" src="https://user-images.githubusercontent.com/326918/33948643-601a1d36-dff5-11e7-94f1-ea70d26b0143.png">
<img width="400" alt="screen shot 2017-12-13 at 11 03 12 am" src="https://user-images.githubusercontent.com/326918/33948644-6027a118-dff5-11e7-8163-77767b6b96fd.png">
