### PR TITLE
Mobile, in-document navigation

### DIFF
--- a/ui/__tests__/components/document/floating-nav.test.js
+++ b/ui/__tests__/components/document/floating-nav.test.js
@@ -32,4 +32,12 @@ describe('<FloatingNav />', () => {
     expect(button.hasClass('active')).toBe(true);
     expect(button.text()).toBe('✕');
   });
+  it('passes a "close" onClick handler to the DocumentNav', () => {
+    const result = shallow(<FloatingNav />);
+    result.setState({ open: true });
+    const onClick = result.children().find(DocumentNav).prop('onClick');
+    expect(result.state('open')).toBe(true);
+    onClick();
+    expect(result.state('open')).toBe(false);
+  });
 });

--- a/ui/__tests__/components/document/floating-nav.test.js
+++ b/ui/__tests__/components/document/floating-nav.test.js
@@ -1,0 +1,35 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import FloatingNav from '../../../components/document/floating-nav';
+import DocumentNav from '../../../components/document/navigation';
+
+describe('<FloatingNav />', () => {
+  it('is wrapped in a Sticky', () => {
+    const result = shallow(<FloatingNav />);
+    expect(result.name()).toBe('Sticky');
+  });
+  it('displays a DocumentNav when open', () => {
+    const result = shallow(<FloatingNav />);
+    expect(result.children().find(DocumentNav)).toHaveLength(0);
+    result.setState({ open: true });
+    expect(result.children().find(DocumentNav)).toHaveLength(1);
+  });
+  it('has has a button to toggle states', () => {
+    const result = shallow(<FloatingNav />);
+    expect(result.state('open')).toBe(false);
+    result.children().find('.menu-button').simulate('click');
+    expect(result.state('open')).toBe(true);
+  });
+  it('toggles text and classes on the button', () => {
+    const result = shallow(<FloatingNav />);
+    let button = result.children().find('.menu-button');
+    expect(button.hasClass('active')).toBe(false);
+    expect(button.text()).toBe('Jump to section');
+
+    result.setState({ open: true });
+    button = result.children().find('.menu-button');
+    expect(button.hasClass('active')).toBe(true);
+    expect(button.text()).toBe('✕');
+  });
+});

--- a/ui/__tests__/components/document/floating-nav.test.js
+++ b/ui/__tests__/components/document/floating-nav.test.js
@@ -4,6 +4,14 @@ import React from 'react';
 import FloatingNav from '../../../components/document/floating-nav';
 import DocumentNav from '../../../components/document/navigation';
 
+/* We nest a bit deeply, but need to access a particular part of the Component
+ * tree many times. */
+function jsBody(floatingNav) {
+  return floatingNav // Sticky
+    .children().find('ConditionalRender')
+    .childAt(1);
+}
+
 describe('<FloatingNav />', () => {
   it('is wrapped in a Sticky', () => {
     const result = shallow(<FloatingNav />);
@@ -11,31 +19,31 @@ describe('<FloatingNav />', () => {
   });
   it('displays a DocumentNav when open', () => {
     const result = shallow(<FloatingNav />);
-    expect(result.children().find(DocumentNav)).toHaveLength(0);
+    expect(jsBody(result).find(DocumentNav)).toHaveLength(0);
     result.setState({ open: true });
-    expect(result.children().find(DocumentNav)).toHaveLength(1);
+    expect(jsBody(result).find(DocumentNav)).toHaveLength(1);
   });
   it('has has a button to toggle states', () => {
     const result = shallow(<FloatingNav />);
     expect(result.state('open')).toBe(false);
-    result.children().find('.menu-button').simulate('click');
+    jsBody(result).find('.menu-button').simulate('click');
     expect(result.state('open')).toBe(true);
   });
   it('toggles text and classes on the button', () => {
     const result = shallow(<FloatingNav />);
-    let button = result.children().find('.menu-button');
+    let button = jsBody(result).find('.menu-button');
     expect(button.hasClass('active')).toBe(false);
     expect(button.text()).toBe('Jump to section');
 
     result.setState({ open: true });
-    button = result.children().find('.menu-button');
+    button = jsBody(result).find('.menu-button');
     expect(button.hasClass('active')).toBe(true);
     expect(button.text()).toBe('✕');
   });
   it('passes a "close" onClick handler to the DocumentNav', () => {
     const result = shallow(<FloatingNav />);
     result.setState({ open: true });
-    const onClick = result.children().find(DocumentNav).prop('onClick');
+    const onClick = jsBody(result).find(DocumentNav).prop('onClick');
     expect(result.state('open')).toBe(true);
     onClick();
     expect(result.state('open')).toBe(false);

--- a/ui/__tests__/components/document/navigation/index.test.js
+++ b/ui/__tests__/components/document/navigation/index.test.js
@@ -2,6 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import { DocumentNav } from '../../../../components/document/navigation';
+import NavLink from '../../../../components/document/navigation/nav-link';
 
 describe('<DocumentNav />', () => {
   const emptyToC = { children: [], identifier: 'ididid', title: 'ttt' };
@@ -11,7 +12,7 @@ describe('<DocumentNav />', () => {
       expect(result.hasClass('document-nav')).toBe(true);
     });
     it('generates a "Top" link', () => {
-      const links = result.find('Connect(NavLink)');
+      const links = result.find(NavLink);
       expect(links).toHaveLength(1);
       expect(links.prop('identifier')).toBe('ididid');
       expect(links.prop('title')).toBe('Top');
@@ -33,7 +34,7 @@ describe('<DocumentNav />', () => {
       ],
     };
     const result = shallow(<DocumentNav tableOfContents={toc} />);
-    const links = result.find('Connect(NavLink)');
+    const links = result.find(NavLink);
     expect(links).toHaveLength(3);
     expect(links.at(0).prop('identifier')).toBe('child1');
     expect(links.at(0).prop('title')).toBe('A Child');
@@ -51,5 +52,10 @@ describe('<DocumentNav />', () => {
     expect(result.hasClass('some')).toBe(true);
     expect(result.hasClass('klazzes')).toBe(true);
   });
+  it('passes onClick functions down', () => {
+    const onClick = jest.fn();
+    const result = shallow(
+      <DocumentNav onClick={onClick} isRoot tableOfContents={emptyToC} />);
+    expect(result.find(NavLink).prop('onClick')).toBe(onClick);
+  });
 });
-

--- a/ui/__tests__/components/document/navigation/nav-link.test.js
+++ b/ui/__tests__/components/document/navigation/nav-link.test.js
@@ -36,4 +36,11 @@ describe('<NavLink />', () => {
     expect(preventDefault).toHaveBeenCalled();
     expect(jump).toHaveBeenCalledWith('#ididid');
   });
+  it('triggers passed in onClick', () => {
+    const onClick = jest.fn();
+    const result = shallow(<NavLink identifier="" onClick={onClick} title="" />);
+    expect(onClick).not.toHaveBeenCalled();
+    result.find('Link').simulate('click', { preventDefault: jest.fn() });
+    expect(onClick).toHaveBeenCalled();
+  });
 });

--- a/ui/__tests__/components/document/sidebar-nav.test.js
+++ b/ui/__tests__/components/document/sidebar-nav.test.js
@@ -1,0 +1,25 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import DocumentNav from '../../../components/document/navigation';
+import SidebarNav from '../../../components/document/sidebar-nav';
+
+describe('<SidebarNav />', () => {
+  it('includes a sticky DocumentNav', () => {
+    const result = shallow(<SidebarNav />);
+    const sticky = result.find('Sticky');
+    expect(sticky).toHaveLength(1);
+    expect(sticky.children().type()).toBe(DocumentNav);
+  });
+  it('passes className', () => {
+    const result = shallow(<SidebarNav className="some classes here" />);
+    expect(result.hasClass('some')).toBe(true);
+    expect(result.hasClass('classes')).toBe(true);
+    expect(result.hasClass('here')).toBe(true);
+  });
+  it('passes bottomBoundary', () => {
+    const result = shallow(<SidebarNav bottomBoundary=".a-selector" />);
+    expect(result.find('Sticky').prop('bottomBoundary')).toBe('.a-selector');
+  });
+});
+

--- a/ui/__tests__/pages/document.test.js
+++ b/ui/__tests__/pages/document.test.js
@@ -19,12 +19,11 @@ describe('<Document />', () => {
     expect(renderNode).toHaveBeenCalledTimes(1);
     expect(renderNode).toHaveBeenCalledWith(new DocumentNode(docNode));
   });
-  it('includes the DocumentNav', () => {
+  it('includes the SidebarNav', () => {
     renderNode.mockImplementationOnce(() => null);
     const result = shallow(<Document docNode={{ identifier: 'abc' }} />);
-    const nav = result.find('Connect(DocumentNav)');
+    const nav = result.find('SidebarNav');
     expect(nav).toHaveLength(1);
-    expect(nav.prop('isRoot')).toBe(true);
   });
   it('does not include Footnotes if none are present', () => {
     renderNode.mockImplementationOnce(() => null);

--- a/ui/components/document/floating-nav.js
+++ b/ui/components/document/floating-nav.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import ConditionalRender from '../conditional-render';
 import Sticky from '../startup-sticky';
 import DocumentNav from './navigation';
 
@@ -15,17 +16,23 @@ export default class FloatingNav extends React.Component {
     return (
       <Sticky innerZ="100">
         <div className="document-floating-nav md-hide lg-hide">
-          <div className="clearfix button-container">
-            <button
-              className={`col col-6 menu-button${this.state.open ? ' active' : ''}`}
-              onClick={buttonClick}
-            >
-              <span className="button-text">
-                { this.state.open ? '✕' : 'Jump to section' }
-              </span>
-            </button>
-          </div>
-            <DocumentNav className="fixed" onClick={linkClick} isRoot /> : null }
+          <ConditionalRender>
+            <DocumentNav isRoot />
+            <React.Fragment>
+              <div className="clearfix button-container">
+                <button
+                  className={`col col-6 menu-button${this.state.open ? ' active' : ''}`}
+                  onClick={buttonClick}
+                >
+                  <span className="button-text">
+                    { this.state.open ? '✕' : 'Jump to section' }
+                  </span>
+                </button>
+              </div>
+              { this.state.open ?
+                <DocumentNav className="fixed" onClick={linkClick} isRoot /> : null }
+            </React.Fragment>
+          </ConditionalRender>
         </div>
       </Sticky>
     );

--- a/ui/components/document/floating-nav.js
+++ b/ui/components/document/floating-nav.js
@@ -10,20 +10,22 @@ export default class FloatingNav extends React.Component {
   }
 
   render() {
+    const buttonClick = () => this.setState({ open: !this.state.open });
+    const linkClick = () => this.setState({ open: false });
     return (
       <Sticky innerZ="100">
         <div className="document-floating-nav md-hide lg-hide">
           <div className="clearfix button-container">
             <button
               className={`col col-6 menu-button${this.state.open ? ' active' : ''}`}
-              onClick={() => this.setState({ open: !this.state.open })}
+              onClick={buttonClick}
             >
               <span className="button-text">
                 { this.state.open ? '✕' : 'Jump to section' }
               </span>
             </button>
           </div>
-          { this.state.open ? <DocumentNav className="fixed" isRoot /> : null }
+            <DocumentNav className="fixed" onClick={linkClick} isRoot /> : null }
         </div>
       </Sticky>
     );

--- a/ui/components/document/floating-nav.js
+++ b/ui/components/document/floating-nav.js
@@ -24,9 +24,9 @@ export default class FloatingNav extends React.Component {
                   className={`col col-6 menu-button${this.state.open ? ' active' : ''}`}
                   onClick={buttonClick}
                 >
-                  <span className="button-text">
-                    { this.state.open ? '✕' : 'Jump to section' }
-                  </span>
+                  { this.state.open ?
+                    '✕' :
+                    <span className="include-divider">Jump to section</span>}
                 </button>
               </div>
               { this.state.open ?

--- a/ui/components/document/floating-nav.js
+++ b/ui/components/document/floating-nav.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import Sticky from '../startup-sticky';
+import DocumentNav from './navigation';
+
+export default class FloatingNav extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { open: false };
+  }
+
+  render() {
+    return (
+      <Sticky innerZ="100">
+        <div className="document-floating-nav md-hide lg-hide">
+          <div className="clearfix button-container">
+            <button
+              className={`col col-6 menu-button${this.state.open ? ' active' : ''}`}
+              onClick={() => this.setState({ open: !this.state.open })}
+            >
+              <span className="button-text">
+                { this.state.open ? '✕' : 'Jump to section' }
+              </span>
+            </button>
+          </div>
+          { this.state.open ? <DocumentNav className="fixed" isRoot /> : null }
+        </div>
+      </Sticky>
+    );
+  }
+}
+

--- a/ui/components/document/navigation/index.js
+++ b/ui/components/document/navigation/index.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import NavLink from './nav-link';
 
 
-export function DocumentNav({ className, isRoot, tableOfContents }) {
+export function DocumentNav({ className, isRoot, onClick, tableOfContents }) {
   const { identifier } = tableOfContents;
   const classes = ['list-reset'];
   if (className) {
@@ -15,16 +15,21 @@ export function DocumentNav({ className, isRoot, tableOfContents }) {
     classes.push('document-nav');
   }
   const children = tableOfContents.children.map(tocNode => (
-    <NavLink identifier={tocNode.identifier} key={tocNode.identifier} title={tocNode.title}>
+    <NavLink
+      identifier={tocNode.identifier}
+      key={tocNode.identifier}
+      onClick={onClick}
+      title={tocNode.title}
+    >
       { tocNode.children.length ?
-        <DocumentNav className="sub-sections" tableOfContents={tocNode} /> :
+        <DocumentNav className="sub-sections" onClick={onClick} tableOfContents={tocNode} /> :
         null }
     </NavLink>
   ));
 
   return (
     <ol className={classes.join(' ')}>
-      { isRoot ? <NavLink identifier={identifier} title="Top" /> : null }
+      { isRoot ? <NavLink identifier={identifier} onClick={onClick} title="Top" /> : null }
       { children }
     </ol>
   );
@@ -32,6 +37,7 @@ export function DocumentNav({ className, isRoot, tableOfContents }) {
 DocumentNav.propTypes = {
   className: PropTypes.string,
   isRoot: PropTypes.bool,
+  onClick: PropTypes.func,
   tableOfContents: PropTypes.shape({
     children: PropTypes.arrayOf(PropTypes.shape({})).isRequired, // recursive
     identifier: PropTypes.string.isRequired,
@@ -41,6 +47,7 @@ DocumentNav.propTypes = {
 DocumentNav.defaultProps = {
   className: '',
   isRoot: false,
+  onClick: () => {},
 };
 
 function mapStateToProps({ tableOfContents }) {

--- a/ui/components/document/navigation/nav-link.js
+++ b/ui/components/document/navigation/nav-link.js
@@ -5,18 +5,16 @@ import { connect } from 'react-redux';
 
 import Link from '../../link';
 
-function scrollTo(anchor) {
-  return (e) => {
+export function NavLink({ active, children, identifier, onClick, title }) {
+  const compoundOnClick = (e) => {
+    onClick(e);
     e.preventDefault();
-    jump(`#${anchor}`);
+    jump(`#${identifier}`);
   };
-}
-
-export function NavLink({ active, children, identifier, title }) {
   const className = `document-nav-heading${active ? ' active' : ''}`;
   return (
     <li>
-      <Link className={className} href={`#${identifier}`} onClick={scrollTo(identifier)}>
+      <Link className={className} href={`#${identifier}`} onClick={compoundOnClick}>
         <div className="document-nav-container">{ title }</div>
       </Link>
       { children }
@@ -27,11 +25,13 @@ NavLink.propTypes = {
   active: PropTypes.bool,
   children: PropTypes.node,
   identifier: PropTypes.string.isRequired,
+  onClick: PropTypes.func,
   title: PropTypes.string.isRequired,
 };
 NavLink.defaultProps = {
   active: false,
   children: null,
+  onClick: () => {},
 };
 
 function mapStateToProps({ currentSection }, { identifier }) {

--- a/ui/components/document/sidebar-nav.js
+++ b/ui/components/document/sidebar-nav.js
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Sticky from '../startup-sticky';
+import DocumentNav from './navigation';
+
+export default function SidebarNav({ className, bottomBoundary }) {
+  return (
+    <div className={className}>
+      <Sticky bottomBoundary={bottomBoundary}>
+        <DocumentNav className="document-sidebar-nav" isRoot />
+      </Sticky>
+    </div>
+  );
+}
+SidebarNav.propTypes = {
+  className: PropTypes.string,
+  bottomBoundary: Sticky.propTypes.bottomBoundary,
+};
+SidebarNav.defaultProps = {
+  className: '',
+  bottomBoundary: 0,
+};

--- a/ui/components/startup-sticky.js
+++ b/ui/components/startup-sticky.js
@@ -1,0 +1,19 @@
+import Sticky from 'react-stickynode';
+
+export default class StartupSticky extends Sticky {
+  componentDidMount() {
+    super.componentDidMount();
+    const scrollEvent = {
+      scroll: {
+        delta: 1, // down
+        top: window.scrollY,
+      },
+    };
+    // react-sticky's initialization isn't actually complete until the state
+    // change *after* componentDidMount. Therefore, we add a callback to fire
+    // after that state change...
+    /* eslint-disable react/no-did-mount-set-state */
+    this.setState({}, () => this.handleScroll(null, scrollEvent));
+    /* eslint-enable react/no-did-mount-set-state */
+  }
+}

--- a/ui/css/base/_colors.scss
+++ b/ui/css/base/_colors.scss
@@ -3,9 +3,10 @@ $color-gray:                #727375;
 $color-lt-gray:             #cecfd1;
 $color-white:               #ffffff;
 
+$color-navy:                #112e51;
 $color-blue:                #1067a6;
-$color-lt-blue:             #bfe2f0;
-$color-sky:                 #e5f6fd;
+$color-lt-blue:             #88d8f6;
+$color-sky:                 #edfcff;
 
 $color-ochre:               #8c7c2a;
 $color-gold:                #ffdc37;

--- a/ui/css/base/_util.scss
+++ b/ui/css/base/_util.scss
@@ -1,3 +1,9 @@
 .nowrap {
   white-space: nowrap;
 }
+
+@mixin reset-button() {
+  border: 0;
+  border-radius: 0;
+  cursor: pointer;
+}

--- a/ui/css/module/_document.scss
+++ b/ui/css/module/_document.scss
@@ -52,3 +52,61 @@
     padding-left: 1rem;
   }
 }
+
+.document-floating-nav {
+  .button-container {
+    background-color: $color-sky;
+  }
+
+  .menu-button {
+    @include reset-button();
+    background-color: $color-sky;
+    color: $color-blue;
+    font-size: 1rem;
+    line-height: 1.3rem;
+    padding-bottom: .75rem;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: .75rem;
+
+    &.active {
+      background-color: $color-blue;
+      color: $color-white;
+    }
+  }
+
+  .button-text {
+    border-right: 1px solid $color-lt-gray;
+    display: block;
+  }
+
+  // A slightly different set of styles from .document-sidebar-nav
+  .document-nav {
+    background-color: $color-blue;
+    margin: 0;
+    width: 100%;
+  }
+
+  .document-nav-container {
+    padding-bottom: 1rem;
+    padding-top: 1rem;
+    border-bottom: 1px solid $color-navy;
+  }
+
+  .sub-sections .document-nav-container {
+    margin-left: 1rem;
+  }
+
+  .document-nav-heading {
+    color: $color-white;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .document-nav-heading:hover,
+  .document-nav-heading.active {
+    background-color: $color-navy;
+    border-left: 0.25rem solid $color-white;
+    padding-left: 0.75rem;
+  }
+}

--- a/ui/css/module/_document.scss
+++ b/ui/css/module/_document.scss
@@ -75,7 +75,7 @@
     }
   }
 
-  .button-text {
+  .include-divider {
     border-right: 1px solid $color-lt-gray;
     display: block;
   }

--- a/ui/css/module/_document.scss
+++ b/ui/css/module/_document.scss
@@ -18,32 +18,37 @@
   margin-bottom: 8px;
 }
 
-.document-nav .sub-sections {
-  padding-left: 1rem;
-}
-
 .document-nav-heading {
-  $spacing: 1rem;
-  $active-width: 0.5rem;
-
-  border-bottom: 1px solid $color-lt-blue;
   display: block;
   font-size: 1rem;
   line-height: 1.3rem;
+
+  .sub-sections & {
+    font-size: 0.875rem;
+  }
+}
+
+.document-sidebar-nav {
+  $spacing: 1rem;
+  $active-width: 0.5rem;
 
   .document-nav-container {
     padding: $spacing;
     padding-left: $spacing + $active-width;
   }
 
-  &:hover .document-nav-container,
-  &.active .document-nav-container {
+  .document-nav-heading {
+    border-bottom: 1px solid $color-lt-blue;
+  }
+
+  .document-nav-heading:hover .document-nav-container,
+  .document-nav-heading.active .document-nav-container {
     background-color: $color-sky;
     border-left: $active-width solid $color-blue;
     padding-left: $spacing;
   }
 
-  .sub-sections & {
-    font-size: 0.875rem;
+  .sub-sections {
+    padding-left: 1rem;
   }
 }

--- a/ui/css/module/_document.scss
+++ b/ui/css/module/_document.scss
@@ -110,3 +110,17 @@
     padding-left: 0.75rem;
   }
 }
+
+// Adjust for floating-nav covering text
+@media #{$on-mobile} {
+  $size-of-floating-nav: 3rem;
+
+  .node-section::before {
+    content: ' ';
+    display: block;
+    height: $size-of-floating-nav;
+    margin-top: -$size-of-floating-nav;
+    pointer-events: none;
+    visibility: hidden;
+  }
+}

--- a/ui/pages/document.js
+++ b/ui/pages/document.js
@@ -1,10 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Sticky from 'react-stickynode';
 
 import wrapPage from '../components/app-wrapper';
 import Footnotes from '../components/document/footnotes';
-import DocumentNav from '../components/document/navigation';
+import SidebarNav from '../components/document/sidebar-nav';
 import { loadDocument } from '../store/actions';
 import { documentData, propagate404 } from '../util/api/queries';
 import DocumentNode from '../util/document-node';
@@ -20,34 +19,13 @@ const headerFooterParams = {
  * sending a mock scroll event (resizing won't get us into the "fixed" state)
  * on mount to the DOM.
  */
-class StartupSticky extends Sticky {
-  componentDidMount() {
-    super.componentDidMount();
-    const scrollEvent = {
-      scroll: {
-        delta: 1, // down
-        top: window.scrollY,
-      },
-    };
-    // react-sticky's initialization isn't actually complete until the state
-    // change *after* componentDidMount. Therefore, we add a callback to fire
-    // after that state change...
-    /* eslint-disable react/no-did-mount-set-state */
-    this.setState({}, () => this.handleScroll(null, scrollEvent));
-    /* eslint-enable react/no-did-mount-set-state */
-  }
-}
 
 export function Document({ docNode }) {
   const doc = new DocumentNode(docNode);
   const footnotes = doc.meta.descendantFootnotes;
   return (
     <div className="document-container clearfix max-width-4">
-      <div className="col col-3 mobile-hide">
-        <StartupSticky bottomBoundary=".document-container">
-          <DocumentNav isRoot />
-        </StartupSticky>
-      </div>
+      <SidebarNav bottomBoundary=".document-container" className="col col-3 mobile-hide" />
       <div className="col col-1 mobile-hide">&nbsp;</div>
       <div className="col-12 md-col-6 col">
         { renderNode(doc) }

--- a/ui/pages/document.js
+++ b/ui/pages/document.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import wrapPage from '../components/app-wrapper';
+import FloatingNav from '../components/document/floating-nav';
 import Footnotes from '../components/document/footnotes';
 import SidebarNav from '../components/document/sidebar-nav';
 import { loadDocument } from '../store/actions';
@@ -24,15 +25,18 @@ export function Document({ docNode }) {
   const doc = new DocumentNode(docNode);
   const footnotes = doc.meta.descendantFootnotes;
   return (
-    <div className="document-container clearfix max-width-4">
-      <SidebarNav bottomBoundary=".document-container" className="col col-3 mobile-hide" />
-      <div className="col col-1 mobile-hide">&nbsp;</div>
-      <div className="col-12 md-col-6 col">
-        { renderNode(doc) }
-        { footnotes.length ?
-          <Footnotes footnotes={footnotes} id="document-footnotes" /> : null }
+    <React.Fragment>
+      <FloatingNav />
+      <div className="document-container clearfix max-width-4">
+        <SidebarNav bottomBoundary=".document-container" className="col col-3 mobile-hide" />
+        <div className="col col-1 mobile-hide">&nbsp;</div>
+        <div className="col-12 md-col-6 col">
+          { renderNode(doc) }
+          { footnotes.length ?
+            <Footnotes footnotes={footnotes} id="document-footnotes" /> : null }
+        </div>
       </div>
-    </div>
+    </React.Fragment>
   );
 }
 Document.propTypes = {


### PR DESCRIPTION
Building on on #766 and #769, this adds a first pass at mobile, in-document navigation. This component has an open/closed state and is progressively enhanced out of the "open" state for modern JS users.

Some caveats:
* It doesn't try to resolve the heading-under-floating-title issue.
* This'll need to use the fixed sticky library from #762 once it's merged.
* Code climate rightfully points out some deeply-nested styles. I'd prefer if we didn't have these, but I also don't see a nice way out.

Looks like
## Before open
<img width="541" alt="screen shot 2017-12-14 at 10 09 53 am" src="https://user-images.githubusercontent.com/326918/33999390-5a4b3502-e0b8-11e7-8e0a-c0f336d3c59b.png">

## Opened
<img width="537" alt="screen shot 2017-12-14 at 10 10 08 am" src="https://user-images.githubusercontent.com/326918/33999389-5a35197a-e0b8-11e7-9fdf-cc8317879678.png">

## No-JS/old browser
<img width="539" alt="screen shot 2017-12-14 at 10 10 38 am" src="https://user-images.githubusercontent.com/326918/33999388-5a209752-e0b8-11e7-9491-3cb74f843521.png">

