### PR TITLE
Account for floating nav offset in more places

### DIFF
--- a/ui/components/document/footnotes.js
+++ b/ui/components/document/footnotes.js
@@ -8,6 +8,7 @@ import Footnote from '../node-renderers/footnote';
 export function Footnotes({ id, footnotes }) {
   return (
     <div className="bottom-footnotes" id={id}>
+      <hr className="bottom-footnotes-border" />
       { footnotes.map(fn => <Footnote key={fn.identifier} docNode={fn} />) }
     </div>
   );

--- a/ui/components/node-renderers/table/tfoot.js
+++ b/ui/components/node-renderers/table/tfoot.js
@@ -14,7 +14,7 @@ function deriveColspan(docNode) {
 
 export default function Tfoot({ docNode }) {
   const footnotes = docNode.meta.descendantFootnotes.map(ft => (
-    <div className="clearfix" key={ft.identifier} id={`${ft.identifier}-table`}>
+    <div className="clearfix footnote" key={ft.identifier} id={`${ft.identifier}-table`}>
       <div className="footnote-marker">{ft.marker}</div>
       <div className="footnote-text">{ renderContents(ft.content) }</div>
     </div>

--- a/ui/css/module/_document.scss
+++ b/ui/css/module/_document.scss
@@ -115,6 +115,7 @@
 @media #{$on-mobile} {
   $size-of-floating-nav: 3rem;
 
+  .node-policy::before,
   .node-section::before {
     content: ' ';
     display: block;

--- a/ui/css/module/_document.scss
+++ b/ui/css/module/_document.scss
@@ -115,6 +115,7 @@
 @media #{$on-mobile} {
   $size-of-floating-nav: 3rem;
 
+  .bottom-footnotes::before,
   .node-policy::before,
   .node-section::before {
     content: ' ';

--- a/ui/css/module/_document.scss
+++ b/ui/css/module/_document.scss
@@ -117,7 +117,8 @@
 
   .bottom-footnotes::before,
   .node-policy::before,
-  .node-section::before {
+  .node-section::before,
+  .table-footer .footnote::before {
     content: ' ';
     display: block;
     height: $size-of-floating-nav;

--- a/ui/css/module/_footnotes.scss
+++ b/ui/css/module/_footnotes.scss
@@ -111,9 +111,13 @@ $footnote-vertical-margin: 24px;
 }
 
 .bottom-footnotes {
-  border-top: 1px solid $color-blue;
-  margin-top: 2.5em;
-  padding-top: .75em;
+  margin-top: 2rem;
+
+  .bottom-footnotes-border {
+    border: none;
+    border-bottom: 1px solid $color-blue;
+    margin-bottom: .75rem;
+  }
 
   .node-footnote {
     @extend .clearfix;


### PR DESCRIPTION
Notably:
* The "Top" link
* The "Footnotes" link
* Links to footnotes at the bottom of a table

Unfortunately, we can't do something like `[id]::before {` because it creates a line break before inline elements.

## Before
<img width="773" alt="screen shot 2017-12-15 at 10 02 28 am" src="https://user-images.githubusercontent.com/326918/34047676-02e4a02e-e17f-11e7-9f24-96ae504b9df1.png">
<img width="772" alt="screen shot 2017-12-15 at 10 02 11 am" src="https://user-images.githubusercontent.com/326918/34047677-02f1864a-e17f-11e7-8354-c08a6504e048.png">
<img width="773" alt="screen shot 2017-12-15 at 10 02 00 am" src="https://user-images.githubusercontent.com/326918/34047679-036b41b0-e17f-11e7-881b-92073c918fac.png">


## After
<img width="778" alt="screen shot 2017-12-15 at 10 01 25 am" src="https://user-images.githubusercontent.com/326918/34047630-e32f9c48-e17e-11e7-9fd5-f22b75e121ef.png">
<img width="773" alt="screen shot 2017-12-15 at 10 01 10 am" src="https://user-images.githubusercontent.com/326918/34047631-e341c350-e17e-11e7-90e0-923707b90614.png">
<img width="770" alt="screen shot 2017-12-15 at 10 00 52 am" src="https://user-images.githubusercontent.com/326918/34047632-e35d377a-e17e-11e7-9954-74aac2a012a9.png">
