### PR TITLE
Standardize "Policy" object across three pages

### DIFF
--- a/ui/__tests__/components/homepage/new-policy-view.test.js
+++ b/ui/__tests__/components/homepage/new-policy-view.test.js
@@ -2,14 +2,15 @@ import { mount } from 'enzyme';
 import React from 'react';
 
 import NewPolicyView from '../../../components/homepage/new-policy-view';
+import Policy from '../../../util/policy';
 
 describe('<NewPolicyView />', () => {
-  const policy = {
+  const policy = new Policy({
     id: 42,
     title_with_number: 'Title with A Number',
+    issuance: '1900-01-04',
     issuing_body: 'Somebody',
-    issuance_pretty: 'January 4, 1900',
-  };
+  });
   const result = mount(<NewPolicyView policy={policy} />);
 
   it('includes expected fields', () => {

--- a/ui/__tests__/components/node-renderers/policy.test.js
+++ b/ui/__tests__/components/node-renderers/policy.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import Policy from '../../../components/node-renderers/policy';
 import DocumentNode from '../../../util/document-node';
+import PolicyObj from '../../../util/policy';
 import {
   itIncludesTheIdentifier,
   itRendersChildNodes,
@@ -13,12 +14,12 @@ jest.mock('../../../util/render-node');
 describe('<Policy />', () => {
   const meta = {
     descendant_footnotes: [],
-    policy: {
-      issuance_pretty: 'March 3, 2003',
+    policy: new PolicyObj({
+      issuance: '2003-03-03',
       omb_policy_id: 'M-44-55',
       original_url: 'http://example.com/thing.pdf',
       title: 'Magistrate',
-    },
+    }),
   };
   itIncludesTheIdentifier(Policy, { meta });
   itRendersChildNodes(Policy, { meta });

--- a/ui/__tests__/pages/policies.test.js
+++ b/ui/__tests__/pages/policies.test.js
@@ -2,10 +2,11 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import { PoliciesContainer } from '../../pages/policies';
+import Policy from '../../util/policy';
 
 describe('<PoliciesContainer />', () => {
   const pagedPolicies = {
-    results: [{ thing: 1 }, { thing: 2 }],
+    results: [{ id: 9 }, { id: 12 }],
     count: 2,
   };
   const result = shallow(<PoliciesContainer pagedPolicies={pagedPolicies} />);
@@ -28,8 +29,8 @@ describe('<PoliciesContainer />', () => {
   it('has correct pageContent', () => {
     const pageContent = result.prop('pageContent');
 
-    expect(pageContent.props.policies).toEqual(pagedPolicies.results);
-    expect(pageContent.props.count).toEqual(pagedPolicies.count);
+    pageContent.props.policies.forEach(p => expect(p).toBeInstanceOf(Policy));
+    expect(pageContent.props.policies.map(p => p.id)).toEqual([9, 12]);
   });
 
   it('has configured selectedFilters', () => {

--- a/ui/__tests__/util/api/queries.test.js
+++ b/ui/__tests__/util/api/queries.test.js
@@ -1,7 +1,6 @@
 import {
   cleanSearchParams,
   documentData,
-  formatIssuance,
   homepageData,
   policiesData,
   redirectQuery,
@@ -13,17 +12,6 @@ jest.mock('../../../util/api/endpoints');
 
 const error404 = new Error('Not Found');
 error404.response = { status: 404 };
-
-describe('formatIssuance', () => {
-  it('handles reasonable input', () => {
-    const result = formatIssuance({ issuance: '2001-12-20' });
-    expect(result.issuance_pretty).toEqual('December 20, 2001');
-  });
-  it('fails gracefully', () => {
-    const result = formatIssuance({ issuance: null });
-    expect(result.issuance_pretty).toEqual('Invalid date');
-  });
-});
 
 describe('homepageData', () => {
   it('makes the correct request', () => {

--- a/ui/__tests__/util/api/queries.test.js
+++ b/ui/__tests__/util/api/queries.test.js
@@ -114,10 +114,7 @@ describe('documentData()', () => {
     expect(result).toEqual({
       docNode: {
         meta: {
-          policy: {
-            issuance: '2012-12-12',
-            issuance_pretty: 'December 12, 2012',
-          },
+          policy: { issuance: '2012-12-12' },
         },
       },
     });

--- a/ui/__tests__/util/api/queries.test.js
+++ b/ui/__tests__/util/api/queries.test.js
@@ -40,17 +40,6 @@ describe('homepageData', () => {
       expect(recentPolicies.map(r => r.id)).toEqual([1, 2, 3, 4]);
     });
   });
-  it('formats issuance date', () => {
-    endpoints.topics.fetchResults.mockImplementationOnce(() =>
-      Promise.resolve([{ issuance: '2002-03-04' }, { issuance: '2020-11-10' }]),
-    );
-    return homepageData().then(({ recentPolicies }) => {
-      expect(recentPolicies.map(r => r.issuance_pretty)).toEqual([
-        'March 4, 2002',
-        'November 10, 2020',
-      ]);
-    });
-  });
 });
 
 describe('cleanSearchParams()', () => {

--- a/ui/__tests__/util/policy.test.js
+++ b/ui/__tests__/util/policy.test.js
@@ -39,4 +39,19 @@ describe('Policy', () => {
       });
     });
   });
+
+  describe('issuancePretty()', () => {
+    it('handles reasonable input', () => {
+      const policyObj = new Policy({ issuance: '2001-12-20' });
+      expect(policyObj.issuancePretty()).toEqual('December 20, 2001');
+    });
+    it('fails gracefully with null', () => {
+      const policyObj = new Policy({ issuance: null });
+      expect(policyObj.issuancePretty()).toEqual('Invalid date');
+    });
+    it('fails gracefully with a nonsense string', () => {
+      const policyObj = new Policy({ issuance: 'sjdnajkshdhasj' });
+      expect(policyObj.issuancePretty()).toEqual('Invalid date');
+    });
+  });
 });

--- a/ui/__tests__/util/policy.test.js
+++ b/ui/__tests__/util/policy.test.js
@@ -18,12 +18,6 @@ describe('Policy', () => {
     expect(policy({ id: 4 }).id).toBe(4);
   });
 
-  it('Serializes (via JSON) to the original passed-in object', () => {
-    expect(JSON.parse(JSON.stringify(new Policy({ blah: 1 })))).toEqual({
-      blah: 1,
-    });
-  });
-
   describe('hasDocument()', () => {
     it('returns false if the policy has no document', () => {
       expect(policy({ has_docnode: false }).hasDocument()).toBe(false);

--- a/ui/components/homepage/new-policy-view.js
+++ b/ui/components/homepage/new-policy-view.js
@@ -1,23 +1,21 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { policyLinkTag } from '../requirements/policy-link';
+
+import Policy from '../../util/policy';
+import Link from '../link';
 
 export default function NewPolicyView({ policy }) {
-  const policyLink = policyLinkTag(policy);
   return (
     <li className="inline-block col col-6 pr2 mb2">
-      { policyLink }
+      <Link route="policies" params={{ id__in: policy.id }}>
+        { policy.titleWithNumber }
+      </Link>
       <div className="h5">
-        { policy.issuing_body }, { policy.issuance_pretty }
+        { policy.issuingBody }, { policy.issuancePretty() }
       </div>
     </li>
   );
 }
 NewPolicyView.propTypes = {
-  policy: PropTypes.shape({
-    id: PropTypes.number,
-    issuance_pretty: PropTypes.string,
-    issuing_body: PropTypes.string,
-    title_with_number: PropTypes.string,
-  }).isRequired,
+  policy: PropTypes.instanceOf(Policy).isRequired,
 };

--- a/ui/components/node-renderers/policy.js
+++ b/ui/components/node-renderers/policy.js
@@ -24,20 +24,20 @@ export default function Policy({ docNode }) {
     <div className="node-policy" id={docNode.identifier}>
       <header className="document-header clearfix">
         <div className="bold">
-          { findNodeText(docNode, 'policyNum', policyMeta.omb_policy_id) }
+          { findNodeText(docNode, 'policyNum', policyMeta.ombPolicyId) }
         </div>
         <div>{ findNodeText(docNode, 'policyTitle', '') }</div>
         <h2 className="h1 document-heading">
           { findNodeText(docNode, 'subject', policyMeta.title) }
         </h2>
         <div className="original-link-container">
-          <Link className="original-link" href={policyMeta.original_url}>
+          <Link className="original-link" href={policyMeta.originalUrl}>
             See original&nbsp;<i className="fa fa-external-link" aria-hidden="true" />
           </Link>
         </div>
         { fromNode ? <From docNode={fromNode} /> : null }
         <LabeledText id="issuance" label="Issued on:">
-          { findNodeText(docNode, 'published', policyMeta.issuance_pretty) }
+          { findNodeText(docNode, 'published', policyMeta.issuancePretty()) }
         </LabeledText>
       </header>
       { docNode.children.map(renderNode) }

--- a/ui/components/policies/policies-view.js
+++ b/ui/components/policies/policies-view.js
@@ -14,14 +14,14 @@ export default function PoliciesView({ policies, count, topicsIds }) {
     <ThingCounterContainer count={count} key="counter" singular={singular} plural={plural} />,
     <ul className="policy-list list-reset" key="policy-list">
       { policies.map(policy =>
-        <PolicyView key={policy.id} policy={new Policy(policy)} topicsIds={topicsIds} />,
+        <PolicyView key={policy.id} policy={policy} topicsIds={topicsIds} />,
       )}
     </ul>,
     <PagersContainer count={count} key="pager" route="policies" />,
   ];
 }
 PoliciesView.propTypes = {
-  policies: PropTypes.arrayOf(Policy.shape),
+  policies: PropTypes.arrayOf(PropTypes.instanceOf(Policy)),
   count: PropTypes.number,
   topicsIds: PropTypes.string,
 };

--- a/ui/components/policies/policy-view.js
+++ b/ui/components/policies/policy-view.js
@@ -9,9 +9,9 @@ export default function PolicyView({ policy, topicsIds }) {
     policy__id__in: policy.id,
     topics__id__in: topicsIds,
   };
-  const relevantReqCount = policy.relevant_reqs >= 100 ? '99+' : policy.relevant_reqs;
+  const relevantReqCount = policy.relevantReqs >= 100 ? '99+' : policy.relevantReqs;
   const countClass = relevantReqCount === '99+' ? 'ninety-nine-plus' : '';
-  let policyTitle = policy.title_with_number;
+  let policyTitle = policy.titleWithNumber;
 
   if (policy.hasDocument()) {
     policyTitle = (
@@ -37,11 +37,11 @@ export default function PolicyView({ policy, topicsIds }) {
                 {relevantReqCount}
               </Link>
             </div> of&nbsp;
-            {policy.total_reqs} requirements
+            {policy.totalReqs} requirements
              match your search
           </div>
           <div className="sm-col sm-col-12 md-col-4 right-align">
-            <Link href={policy.original_url}>
+            <Link href={policy.originalUrl}>
               View original&nbsp;<i className="fa fa-external-link" aria-hidden="true" />
             </Link>
           </div>

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -7,6 +7,7 @@ import { ContactEmail } from '../components/contact-email';
 import Link from '../components/link';
 import Search from '../components/search/search';
 import { homepageData } from '../util/api/queries';
+import Policy from '../util/policy';
 
 export function Homepage({ recentPolicies }) {
   return (
@@ -72,7 +73,8 @@ export function Homepage({ recentPolicies }) {
         <div className="landing-section">
           <h3>New policies</h3>
           <ol className="list-reset clearfix">
-            {recentPolicies.map(p => <NewPolicyView policy={p} key={p.id} />)}
+            {recentPolicies.map(p =>
+              <NewPolicyView policy={new Policy(p)} key={p.id} />)}
           </ol>
         </div>
       </section>

--- a/ui/pages/policies.js
+++ b/ui/pages/policies.js
@@ -8,6 +8,7 @@ import ExistingFilters from '../components/filters/existing-container';
 import FilterListView from '../components/filters/list-view';
 import SelectorContainer from '../components/filters/selector';
 import { policiesData } from '../util/api/queries';
+import Policy from '../util/policy';
 
 const fieldNames = {
   agencies: 'requirements__all_agencies__id__in',
@@ -42,7 +43,7 @@ export function PoliciesContainer({
       filterControls={filterControls}
       pageContent={
         <PoliciesView
-          policies={pagedPolicies.results}
+          policies={pagedPolicies.results.map(p => new Policy(p))}
           count={pagedPolicies.count}
           topicsIds={existingTopics.map(t => t.id).join(',')}
         />
@@ -64,7 +65,7 @@ PoliciesContainer.propTypes = {
   existingPolicies: ExistingFilters.propTypes.policies,
   existingTopics: ExistingFilters.propTypes.topics,
   pagedPolicies: PropTypes.shape({
-    results: PoliciesView.propTypes.policies,
+    results: PropTypes.arrayOf(PropTypes.shape({})), // see Policy constructor
     count: PoliciesView.propTypes.count,
   }),
 };

--- a/ui/util/api/queries.js
+++ b/ui/util/api/queries.js
@@ -156,7 +156,5 @@ export function redirectQuery(query, insertParam, idToInsert) {
 
 export async function documentData({ query }) {
   const docNode = await endpoints.document.fetchOne(query.policyId);
-  const policy = formatIssuance(docNode.meta.policy);
-  docNode.meta = { ...docNode.meta, policy };
   return { docNode };
 }

--- a/ui/util/api/queries.js
+++ b/ui/util/api/queries.js
@@ -30,9 +30,7 @@ export async function propagate404(fn) {
 
 export async function homepageData() {
   const results = await endpoints.policies.fetchResults({ ordering: '-issuance' });
-  return {
-    recentPolicies: results.slice(0, NUM_POLICIES).map(formatIssuance),
-  };
+  return { recentPolicies: results.slice(0, NUM_POLICIES) };
 }
 
 export function policiesData({ query }) {

--- a/ui/util/api/queries.js
+++ b/ui/util/api/queries.js
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import PropTypes from 'prop-types';
 import validator from 'validator';
 
@@ -7,15 +6,6 @@ import { apiNameField, search } from '../../lookup-search';
 import { routes } from '../../routes';
 
 const NUM_POLICIES = 4;
-// See https://momentjs.com/docs/#/displaying/ for options
-const DATE_FORMAT = 'MMMM D, YYYY';
-
-export function formatIssuance(policy) {
-  return {
-    ...policy,
-    issuance_pretty: moment(policy.issuance).format(DATE_FORMAT),
-  };
-}
 
 export async function propagate404(fn) {
   try {

--- a/ui/util/document-node.js
+++ b/ui/util/document-node.js
@@ -1,9 +1,11 @@
+import Policy from './policy';
+
 export class Meta {
   constructor(args) {
     const fieldValues = args || {};
     // policy meta data (e.g. slugs, pdf url, etc.)  associated with this
     // document
-    this.policy = fieldValues.policy || {};
+    this.policy = new Policy(fieldValues.policy || {});
 
     // footnotes referenced in this DocumentNode or its children. E.g. used to
     // consolidate footnotes in tables

--- a/ui/util/policy.js
+++ b/ui/util/policy.js
@@ -1,13 +1,19 @@
+import moment from 'moment';
 /**
  * The Policy class wraps the policy structure returned by the API
  * and adds a number of convenience methods to it.  It's intended to be
  * immutable; no state is stored in it.
  */
 
+// See https://momentjs.com/docs/#/displaying/ for options
+const DATE_FORMAT = 'MMMM D, YYYY';
+
 export default class Policy {
   constructor(initial) {
     this.hasDocnode = initial.hasDocnode || initial.has_docnode || false;
     this.id = initial.id || '';
+    this.issuance = initial.issuance || '';
+    this.issuingBody = initial.issuingBody || initial.issuing_body || '';
     this.ombPolicyId = initial.ombPolicyId || initial.omb_policy_id || '';
     this.originalUrl = initial.originalUrl || initial.original_url || '';
     this.relevantReqs = initial.relevantReqs || initial.relevant_reqs || 0;
@@ -27,5 +33,9 @@ export default class Policy {
         policyId: this.ombPolicyId,
       },
     };
+  }
+
+  issuancePretty() {
+    return moment(this.issuance, 'YYYY-MM-DD').format(DATE_FORMAT);
   }
 }

--- a/ui/util/policy.js
+++ b/ui/util/policy.js
@@ -17,6 +17,7 @@ export default class Policy {
     this.ombPolicyId = initial.ombPolicyId || initial.omb_policy_id || '';
     this.originalUrl = initial.originalUrl || initial.original_url || '';
     this.relevantReqs = initial.relevantReqs || initial.relevant_reqs || 0;
+    this.title = initial.title || '';
     this.titleWithNumber = initial.titleWithNumber || initial.title_with_number || '';
     this.totalReqs = initial.totalReqs || initial.total_reqs || 0;
     Object.freeze(this);

--- a/ui/util/policy.js
+++ b/ui/util/policy.js
@@ -3,25 +3,30 @@ import PropTypes from 'prop-types';
 /**
  * The Policy class wraps the policy structure returned by the API
  * and adds a number of convenience methods to it.  It's intended to be
- * immutable; no state is stored in it, and calling JSON.stringify() on
- * it yields the same policy structure it was initialized with.
+ * immutable; no state is stored in it.
  */
 
 export default class Policy {
-  constructor(policy) {
-    Object.assign(this, policy);
+  constructor(initial) {
+    this.hasDocnode = initial.hasDocnode || initial.has_docnode || false;
+    this.id = initial.id || '';
+    this.ombPolicyId = initial.ombPolicyId || initial.omb_policy_id || '';
+    this.originalUrl = initial.originalUrl || initial.original_url || '';
+    this.relevantReqs = initial.relevantReqs || initial.relevant_reqs || 0;
+    this.titleWithNumber = initial.titleWithNumber || initial.title_with_number || '';
+    this.totalReqs = initial.totalReqs || initial.total_reqs || 0;
     Object.freeze(this);
   }
 
   hasDocument() {
-    return this.omb_policy_id && this.has_docnode;
+    return this.ombPolicyId && this.hasDocnode;
   }
 
   getDocumentLinkProps() {
     return {
       route: 'document',
       params: {
-        policyId: this.omb_policy_id,
+        policyId: this.ombPolicyId,
       },
     };
   }

--- a/ui/util/policy.js
+++ b/ui/util/policy.js
@@ -1,5 +1,3 @@
-import PropTypes from 'prop-types';
-
 /**
  * The Policy class wraps the policy structure returned by the API
  * and adds a number of convenience methods to it.  It's intended to be
@@ -31,12 +29,3 @@ export default class Policy {
     };
   }
 }
-
-Policy.shape = PropTypes.shape({
-  id: PropTypes.number,
-  title_with_number: PropTypes.string,
-  relevant_reqs: PropTypes.number,
-  total_reqs: PropTypes.number,
-  has_docnode: PropTypes.bool,
-  omb_policy_id: PropTypes.string,
-});


### PR DESCRIPTION
We had defined a `Policy` object for use on the policy search results page. This defines that object's fields a bit more closely and uses it on the homepage and in document metadata.

This came up while adding page titles.