### PR TITLE
Add a page title for every page

### DIFF
--- a/api/document/serializers/meta.py
+++ b/api/document/serializers/meta.py
@@ -8,6 +8,8 @@ from reqs.models import Policy
 
 
 class PolicySerializer(serializers.ModelSerializer):
+    title_with_number = serializers.CharField(read_only=True)
+
     class Meta:
         model = Policy
         fields = (
@@ -15,6 +17,7 @@ class PolicySerializer(serializers.ModelSerializer):
             'omb_policy_id',
             'original_url',
             'title',
+            'title_with_number',
         )
 
 

--- a/api/document/tests/serializers/doc_cursor_test.py
+++ b/api/document/tests/serializers/doc_cursor_test.py
@@ -41,6 +41,7 @@ def test_end_to_end():
                 'omb_policy_id': 'M-18-18',
                 'original_url': 'http://example.com/thing.pdf',
                 'title': 'Some Title',
+                'title_with_number': 'M-18-18: Some Title',
             },
             'table_of_contents': {
                 'identifier': 'root_0',

--- a/ui/__tests__/pages/document.test.js
+++ b/ui/__tests__/pages/document.test.js
@@ -1,4 +1,5 @@
 import { shallow } from 'enzyme';
+import Head from 'next/head';
 import React from 'react';
 
 import { Document, getInitialProps } from '../../pages/document';
@@ -43,6 +44,13 @@ describe('<Document />', () => {
     expect(footnotes.prop('footnotes').map(f => f.identifier)).toEqual(
       ['footnote_1', 'footnote_2'],
     );
+  });
+  it('sets the page header', () => {
+    renderNode.mockImplementationOnce(() => null);
+    const docNode = { meta: { policy: { title_with_number: 'AAAA: Stuff' } } };
+    const head = shallow(<Document docNode={docNode} />).find(Head);
+    expect(head).toHaveLength(1);
+    expect(head.children().text()).toMatch(/AAAA: Stuff/);
   });
 });
 

--- a/ui/__tests__/pages/policies.test.js
+++ b/ui/__tests__/pages/policies.test.js
@@ -9,7 +9,8 @@ describe('<PoliciesContainer />', () => {
     results: [{ id: 9 }, { id: 12 }],
     count: 2,
   };
-  const result = shallow(<PoliciesContainer pagedPolicies={pagedPolicies} />);
+  const result = shallow(<PoliciesContainer pagedPolicies={pagedPolicies} />)
+    .find('SearchFilterView');
 
   it('has a topics filter controls', () => {
     const controls = result.prop('filterControls');

--- a/ui/__tests__/pages/privacy.test.js
+++ b/ui/__tests__/pages/privacy.test.js
@@ -1,4 +1,5 @@
 import { shallow } from 'enzyme';
+import Head from 'next/head';
 import React from 'react';
 
 import { PrivacyView } from '../../pages/privacy';
@@ -13,5 +14,10 @@ describe('<PrivacyView />', () => {
     const result = shallow(<PrivacyView />);
     expect(result.find('h2')).toHaveLength(1);
     expect(result.find('h2').text()).toEqual('Privacy Policy');
+  });
+  it('sets the page title', () => {
+    const result = shallow(<PrivacyView />).find(Head);
+    expect(result).toHaveLength(1);
+    expect(result.children().text()).toMatch(/Privacy Policy/);
   });
 });

--- a/ui/__tests__/pages/requirements.test.js
+++ b/ui/__tests__/pages/requirements.test.js
@@ -8,7 +8,8 @@ describe('<RequirementsContainer />', () => {
     results: [{ thing: 1 }, { thing: 2 }],
     count: 2,
   };
-  const result = shallow(<RequirementsContainer pagedReqs={pagedReqs} />);
+  const result = shallow(<RequirementsContainer pagedReqs={pagedReqs} />)
+    .find('SearchFilterView');
 
   it('has a topics filter controls', () => {
     const controls = result.prop('filterControls');

--- a/ui/__tests__/util/page-title.test.js
+++ b/ui/__tests__/util/page-title.test.js
@@ -1,0 +1,18 @@
+import { shallow } from 'enzyme';
+
+import pageTitle from '../../util/page-title';
+
+describe('pageTitle', () => {
+  it('generates a "Head" component', () => {
+    const result = shallow(pageTitle());
+    expect(result.name()).toBe('Head');
+  });
+  it('has a default', () => {
+    const result = shallow(pageTitle());
+    expect(result.children().text()).toBe('OMB Policy Library (Beta)');
+  });
+  it('displays title first', () => {
+    const result = shallow(pageTitle('AAA BB'));
+    expect(result.children().text()).toBe('AAA BB | OMB Policy Library (Beta)');
+  });
+});

--- a/ui/components/header-footer.js
+++ b/ui/components/header-footer.js
@@ -83,7 +83,11 @@ export default function HeaderFooter({ children, showSearch, wrapperClassName })
         { faviconTags() }
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
-      { pageTitle() }
+      {
+        /* Set a default page title. This can be overridden if pageTitle()
+          is also called in child components */
+        pageTitle()
+      }
       <div className="page-header-wrapper">
         <Disclaimer key="disclaimer" />
         <Navbar key="navbar" showSearch={showSearch} />

--- a/ui/components/header-footer.js
+++ b/ui/components/header-footer.js
@@ -6,6 +6,8 @@ import Disclaimer from './disclaimer';
 import Navbar from './navbar';
 import Footer from './footer';
 
+import pageTitle from '../util/page-title';
+
 
 /* Generates the myriad tags needed to support favicons across a variety of
  * OSes, browsers, and display sizes. */
@@ -67,30 +69,30 @@ function faviconTags() {
 export default function HeaderFooter({ children, showSearch, wrapperClassName }) {
   const klasses = ['container', wrapperClassName].join(' ');
 
-  return [
-    <Head key="head">
-      <title>OMB Policy Library (Beta)</title>
-      <link rel="stylesheet" href="/static/styles.css" />
-      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-alpha1/katex.min.css" integrity="sha384-8QOKbPtTFvh/lMY0qPVbXj9hDh+v8US0pD//FcoYFst2lCIf0BmT58+Heqj0IGyx" crossOrigin="anonymous" />
-      <script
-        async
-        type="text/javascript"
-        id="_fed_an_ua_tag"
-        src="https://dap.digitalgov.gov/Universal­Federated­Analytics­Min.js?agency=EOP&subagency=OMB"
-      />
-      { faviconTags() }
-      <meta name="viewport" content="width=device-width, initial-scale=1" />
-    </Head>,
-    <div key="page-header-wrapper" className="page-header-wrapper">
-      <Disclaimer key="disclaimer" />
-      <Navbar key="navbar" showSearch={showSearch} />
-    </div>,
-    <div key="body" className={klasses}>
-      {children}
-    </div>,
-    <Footer key="footer" />,
-    <script key="footer-script" src="/static/ie.js" />,
-  ];
+  return (
+    <React.Fragment>
+      <Head>
+        <link rel="stylesheet" href="/static/styles.css" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-alpha1/katex.min.css" integrity="sha384-8QOKbPtTFvh/lMY0qPVbXj9hDh+v8US0pD//FcoYFst2lCIf0BmT58+Heqj0IGyx" crossOrigin="anonymous" />
+        <script
+          async
+          type="text/javascript"
+          id="_fed_an_ua_tag"
+          src="https://dap.digitalgov.gov/Universal­Federated­Analytics­Min.js?agency=EOP&subagency=OMB"
+        />
+        { faviconTags() }
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      { pageTitle() }
+      <div className="page-header-wrapper">
+        <Disclaimer key="disclaimer" />
+        <Navbar key="navbar" showSearch={showSearch} />
+      </div>
+      <div className={klasses}>{children}</div>
+      <Footer />
+      <script src="/static/ie.js" />
+    </React.Fragment>
+  );
 }
 
 HeaderFooter.propTypes = {

--- a/ui/components/startup-sticky.js
+++ b/ui/components/startup-sticky.js
@@ -1,5 +1,11 @@
 import Sticky from 'react-stickynode';
 
+/* react-stickynode has an annoying bug
+ * https://github.com/yahoo/react-stickynode/issues/61 around not loading
+ * correctly if linking to the middle of a page. This hacks around that by
+ * sending a mock scroll event (resizing won't get us into the "fixed" state)
+ * on mount to the DOM.
+ */
 export default class StartupSticky extends Sticky {
   componentDidMount() {
     super.componentDidMount();

--- a/ui/pages/document.js
+++ b/ui/pages/document.js
@@ -8,6 +8,7 @@ import SidebarNav from '../components/document/sidebar-nav';
 import { loadDocument } from '../store/actions';
 import { documentData, propagate404 } from '../util/api/queries';
 import DocumentNode from '../util/document-node';
+import pageTitle from '../util/page-title';
 import renderNode from '../util/render-node';
 
 const headerFooterParams = {
@@ -26,6 +27,7 @@ export function Document({ docNode }) {
   const footnotes = doc.meta.descendantFootnotes;
   return (
     <React.Fragment>
+      { pageTitle(doc.meta.policy.titleWithNumber) }
       <FloatingNav />
       <div className="document-container clearfix max-width-4">
         <SidebarNav bottomBoundary=".document-container" className="col col-3 mobile-hide" />

--- a/ui/pages/document.js
+++ b/ui/pages/document.js
@@ -15,13 +15,6 @@ const headerFooterParams = {
   showSearch: true,
 };
 
-/* react-stickynode has an annoying bug
- * https://github.com/yahoo/react-stickynode/issues/61 around not loading
- * correctly if linking to the middle of a page. This hacks around that by
- * sending a mock scroll event (resizing won't get us into the "fixed" state)
- * on mount to the DOM.
- */
-
 export function Document({ docNode }) {
   const doc = new DocumentNode(docNode);
   const footnotes = doc.meta.descendantFootnotes;

--- a/ui/pages/policies.js
+++ b/ui/pages/policies.js
@@ -8,6 +8,7 @@ import ExistingFilters from '../components/filters/existing-container';
 import FilterListView from '../components/filters/list-view';
 import SelectorContainer from '../components/filters/selector';
 import { policiesData } from '../util/api/queries';
+import pageTitle from '../util/page-title';
 import Policy from '../util/policy';
 
 const fieldNames = {
@@ -39,25 +40,28 @@ export function PoliciesContainer({
     />,
   ];
   return (
-    <SearchFilterView
-      filterControls={filterControls}
-      pageContent={
-        <PoliciesView
-          policies={pagedPolicies.results.map(p => new Policy(p))}
-          count={pagedPolicies.count}
-          topicsIds={existingTopics.map(t => t.id).join(',')}
-        />
-      }
-      selectedFilters={
-        <ExistingFilters
-          agencies={existingAgencies}
-          fieldNames={fieldNames}
-          policies={existingPolicies}
-          route="policies"
-          topics={existingTopics}
-        />
-      }
-    />
+    <React.Fragment>
+      { pageTitle('Policy Search Results') }
+      <SearchFilterView
+        filterControls={filterControls}
+        pageContent={
+          <PoliciesView
+            policies={pagedPolicies.results.map(p => new Policy(p))}
+            count={pagedPolicies.count}
+            topicsIds={existingTopics.map(t => t.id).join(',')}
+          />
+        }
+        selectedFilters={
+          <ExistingFilters
+            agencies={existingAgencies}
+            fieldNames={fieldNames}
+            policies={existingPolicies}
+            route="policies"
+            topics={existingTopics}
+          />
+        }
+      />
+    </React.Fragment>
   );
 }
 PoliciesContainer.propTypes = {

--- a/ui/pages/privacy.js
+++ b/ui/pages/privacy.js
@@ -3,10 +3,12 @@ import React from 'react';
 import wrapPage from '../components/app-wrapper';
 import { email, ContactEmail } from '../components/contact-email';
 import Link from '../components/link';
+import pageTitle from '../util/page-title';
 
 export function PrivacyView() {
   return (
     <div className="ml3">
+      { pageTitle('Privacy Policy') }
       <h2 className="h1">Privacy Policy</h2>
       <h3 className="caps">Protecting privacy and security</h3>
 

--- a/ui/pages/requirements.js
+++ b/ui/pages/requirements.js
@@ -10,6 +10,7 @@ import ExistingFilters from '../components/filters/existing-container';
 import FilterListView from '../components/filters/list-view';
 import SelectorContainer from '../components/filters/selector';
 import { requirementsData } from '../util/api/queries';
+import pageTitle from '../util/page-title';
 
 export function PoliciesTab({ router }) {
   const reqQuery = router.query;
@@ -69,20 +70,23 @@ export function RequirementsContainer({
     </div>
   );
   return (
-    <SearchFilterView
-      filterControls={filterControls}
-      pageContent={<RequirementsView requirements={pagedReqs.results} count={pagedReqs.count} />}
-      selectedFilters={
-        <ExistingFilters
-          agencies={existingAgencies}
-          fieldNames={fieldNames}
-          policies={existingPolicies}
-          route="requirements"
-          topics={existingTopics}
-        />
-      }
-      tabs={tabs}
-    />
+    <React.Fragment>
+      { pageTitle('Requirement Search Results') }
+      <SearchFilterView
+        filterControls={filterControls}
+        pageContent={<RequirementsView requirements={pagedReqs.results} count={pagedReqs.count} />}
+        selectedFilters={
+          <ExistingFilters
+            agencies={existingAgencies}
+            fieldNames={fieldNames}
+            policies={existingPolicies}
+            route="requirements"
+            topics={existingTopics}
+          />
+        }
+        tabs={tabs}
+      />
+    </React.Fragment>
   );
 }
 RequirementsContainer.propTypes = {

--- a/ui/pages/search-redirect.js
+++ b/ui/pages/search-redirect.js
@@ -6,6 +6,7 @@ import Link from '../components/link';
 import PagersContainer from '../components/pagers';
 import { apiNameField } from '../lookup-search';
 import { cleanSearchParamTypes, redirectQuery, searchRedirectData } from '../util/api/queries';
+import pageTitle from '../util/page-title';
 
 function Entry({ entry, userParams }) {
   const name = entry[apiNameField[userParams.lookup]];
@@ -32,6 +33,7 @@ export function SearchRedirect({ pagedEntries, userParams }) {
 
   return (
     <div className="max-width-4 mx-auto my3">
+      { pageTitle('Search Results') }
       <div>
         <Link route={userParams.redirect.route} params={userParams.redirect.query}>
           Return to view requirements

--- a/ui/util/page-title.js
+++ b/ui/util/page-title.js
@@ -1,0 +1,10 @@
+import Head from 'next/head';
+import React from 'react';
+
+export default function pageTitle(prefix) {
+  let title = 'OMB Policy Library (Beta)';
+  if (prefix) {
+    title = `${prefix} | ${title}`;
+  }
+  return <Head><title key="title">{ title }</title></Head>;
+}


### PR DESCRIPTION
Building off #775 ([diff](https://github.com/18F/omb-eregs/compare/699-policy-object...699-page-titles)), this ensures every page sets a title. The only interesting bit here is that the "document" page sets its title to the policy's title-with-number.