### PR TITLE
Resolve 500 error when search 404ed.

### DIFF
--- a/ui/__tests__/util/api/queries.test.js
+++ b/ui/__tests__/util/api/queries.test.js
@@ -6,6 +6,7 @@ import {
   policiesData,
   redirectQuery,
   requirementsData,
+  searchRedirectData,
 } from '../../../util/api/queries';
 import endpoints from '../../../util/api/endpoints';
 
@@ -153,6 +154,23 @@ describe('requirementsData()', () => {
     });
 
     const result = await requirementsData({ query: { page: 99999 } });
+    expect(result).toEqual({ statusCode: 404 });
+  });
+});
+
+describe('searchRedirect()', () => {
+  it('passes up 404s', async () => {
+    endpoints.topics.fetch.mockImplementationOnce(() => {
+      throw error404;
+    });
+    const query = {
+      insertParam: 'goesHere',
+      lookup: 'topics',
+      page: '9999',
+      redirectRoute: 'requirements',
+    };
+
+    const result = await searchRedirectData({ query });
     expect(result).toEqual({ statusCode: 404 });
   });
 });

--- a/ui/util/api/endpoints.js
+++ b/ui/util/api/endpoints.js
@@ -2,9 +2,10 @@ import axios from 'axios';
 import buildURL from 'axios/lib/helpers/buildURL';
 import LRU from 'lru-cache';
 
-const CACHE_MAX_AGE = process.env.NODE_ENV === 'production'
-  ? 1000 * 60 * 60 // 1 hour
-  : 1;
+const CACHE_MAX_AGE = (
+  process.env.NODE_ENV === 'production' ||
+  process.env.NODE_ENV === 'test'
+) ? 1000 * 60 * 60 /* 1 hour */ : 1;
 
 const CACHE_CONFIG = {
   max: 32,

--- a/ui/util/api/queries.js
+++ b/ui/util/api/queries.js
@@ -134,10 +134,12 @@ export const cleanSearchParamTypes = PropTypes.shape({
   }).isRequired,
 });
 
-export async function searchRedirectData({ query }) {
-  const userParams = cleanSearchParams(query);
-  const pagedEntries = await search(userParams.lookup, userParams.q, userParams.page);
-  return { pagedEntries, userParams };
+export function searchRedirectData({ query }) {
+  return propagate404(async () => {
+    const userParams = cleanSearchParams(query);
+    const pagedEntries = await search(userParams.lookup, userParams.q, userParams.page);
+    return { pagedEntries, userParams };
+  });
 }
 
 /*


### PR DESCRIPTION
When a user doesn't have JS, the topic search falls back to a text field which
is passed around via POSTs. If the backend API returned a 404 (as is the case
with bad page numbers), we weren't passing that to the user.

To see it in action, visit: 
```
/search-redirect/topics/?insertParam=requirements__topics__id__in&redirectRoute=policies&q=security&redirectQuery__requirements__req_text__search=&page=44
```