### PR TITLE
Visual tweaks to document

### DIFF
--- a/ui/css/base/_spacing.scss
+++ b/ui/css/base/_spacing.scss
@@ -1,0 +1,5 @@
+$space: 1rem;
+$space-xs: .5 * $space;
+$space-sm: .75 * $space;
+$space-lg: 1.5 * $space;
+$space-xl: 2 * $space;

--- a/ui/css/base/_type-size.scss
+++ b/ui/css/base/_type-size.scss
@@ -1,0 +1,4 @@
+@mixin size-regular() {
+  font-size: 1rem;
+  line-height: 1.6875rem;
+}

--- a/ui/css/layout/_layout.scss
+++ b/ui/css/layout/_layout.scss
@@ -5,30 +5,30 @@ body {
 @media (max-width: 52em) {
   .main {
     border: 0;
-    padding: .5rem 1rem;
+    padding: $space-xs $space;
     width: 100%;
   }
 }
 
 .document-container {
   margin: 0 auto;
-  padding-top: 2em;
+  padding-top: $space-xl;
   padding-bottom: 4em;
-  padding-left: 1em;
-  padding-right: 1em;
+  padding-left: $space;
+  padding-right: $space;
 }
 
 @media #{$breakpoint-sm} {
   .document-container {
-    padding-left: 1.5em;
-    padding-right: 1.5em;
+    padding-left: $space-lg;
+    padding-right: $space-lg;
   }
 }
 
 @media #{$breakpoint-lg} {
   .document-container {
-    padding-left: 2em;
-    padding-right: 2em;
+    padding-left: $space-xl;
+    padding-right: $space-xl;
   }
 }
 

--- a/ui/css/layout/_typography.scss
+++ b/ui/css/layout/_typography.scss
@@ -114,8 +114,7 @@ h6,
 
 p {
   @include font-serif();
-  font-size: 1rem;
-  line-height: 1.69rem;
+  @include size-regular();
 }
 
 @media #{$on-desktop} {

--- a/ui/css/layout/_typography.scss
+++ b/ui/css/layout/_typography.scss
@@ -94,20 +94,11 @@ h3,
   line-height: 1.5rem;
 }
 
-.document-container {
-  h4,
-  .h4 {
-    color: $color-ochre;
-  }
-}
-
 h4,
 .h4 {
   font-size: 1rem;
   line-height: 1.5rem;
 }
-
-
 
 h5,
 .h5 {

--- a/ui/css/main.scss
+++ b/ui/css/main.scss
@@ -40,6 +40,7 @@ $fa-font-path: '~font-awesome/fonts';
 @import 'module/listitem';
 @import 'module/tables';
 @import 'module/external-link';
+@import 'module/node-heading';
 
 @import 'state/print';
 @import 'state/ie';

--- a/ui/css/main.scss
+++ b/ui/css/main.scss
@@ -15,6 +15,7 @@ $fa-font-path: '~font-awesome/fonts';
 @import 'base/base';
 @import 'base/fonts';
 @import 'base/media-queries';
+@import 'base/spacing';
 @import 'base/type-size';
 @import 'base/util';
 

--- a/ui/css/main.scss
+++ b/ui/css/main.scss
@@ -15,6 +15,7 @@ $fa-font-path: '~font-awesome/fonts';
 @import 'base/base';
 @import 'base/fonts';
 @import 'base/media-queries';
+@import 'base/type-size';
 @import 'base/util';
 
 @import 'layout/typography';

--- a/ui/css/module/_document.scss
+++ b/ui/css/module/_document.scss
@@ -1,5 +1,5 @@
 .node-paragraph {
-  margin-bottom: 16px;
+  margin-bottom: $space;
 }
 
 .document-header {
@@ -7,15 +7,15 @@
 }
 
 .document-heading {
-  margin-top: 8px;
+  margin-top: $space-xs;
 
   .original-link {
-    margin-bottom: 8px;
+    margin-bottom: $space-xs;
   }
 }
 
 .original-link-container {
-  margin-bottom: 8px;
+  margin-bottom: $space-xs;
 }
 
 .document-nav-heading {
@@ -29,8 +29,8 @@
 }
 
 .document-sidebar-nav {
-  $spacing: 1rem;
-  $active-width: 0.5rem;
+  $spacing: $space;
+  $active-width: $space-xs;
 
   .document-nav-container {
     padding: $spacing;
@@ -49,7 +49,7 @@
   }
 
   .sub-sections {
-    padding-left: 1rem;
+    padding-left: $space;
   }
 }
 
@@ -64,10 +64,10 @@
     color: $color-blue;
     font-size: 1rem;
     line-height: 1.3rem;
-    padding-bottom: .75rem;
+    padding-bottom: $space-sm;
     padding-left: 0;
     padding-right: 0;
-    padding-top: .75rem;
+    padding-top: $space-sm;
 
     &.active {
       background-color: $color-blue;
@@ -88,26 +88,26 @@
   }
 
   .document-nav-container {
-    padding-bottom: 1rem;
-    padding-top: 1rem;
+    padding-bottom: $space;
+    padding-top: $space;
     border-bottom: 1px solid $color-navy;
   }
 
   .sub-sections .document-nav-container {
-    margin-left: 1rem;
+    margin-left: $space;
   }
 
   .document-nav-heading {
     color: $color-white;
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-left: $space;
+    padding-right: $space;
   }
 
   .document-nav-heading:hover,
   .document-nav-heading.active {
     background-color: $color-navy;
     border-left: 0.25rem solid $color-white;
-    padding-left: 0.75rem;
+    padding-left: $space-sm;
   }
 }
 

--- a/ui/css/module/_footnotes.scss
+++ b/ui/css/module/_footnotes.scss
@@ -56,8 +56,8 @@ $footnote-vertical-margin: 24px;
     border-top: $footnote-border;
     border-bottom: $footnote-border;
     margin-top: $footnote-vertical-margin;
-    margin-bottom: 2rem;
-    padding-top: 1rem;
+    margin-bottom: $space-xl;
+    padding-top: $space;
     padding-bottom: 0.2em;
   }
 
@@ -80,7 +80,7 @@ $footnote-vertical-margin: 24px;
     font-size: .9rem;
     line-height: 1.5rem;
     text-align: right;
-    padding-right: .5em;
+    padding-right: $space-xs;
   }
 
   .footnote-text {
@@ -99,7 +99,7 @@ $footnote-vertical-margin: 24px;
     font-style: normal;
     font-size: .8em;
     display: block;
-    margin-top: 0.5rem;
+    margin-top: $space-xs;
     cursor: pointer;
 
     &::before {
@@ -111,12 +111,12 @@ $footnote-vertical-margin: 24px;
 }
 
 .bottom-footnotes {
-  margin-top: 2rem;
+  margin-top: $space-xl;
 
   .bottom-footnotes-border {
     border: none;
     border-bottom: 1px solid $color-blue;
-    margin-bottom: .75rem;
+    margin-bottom: $space-sm;
   }
 
   .node-footnote {

--- a/ui/css/module/_header.scss
+++ b/ui/css/module/_header.scss
@@ -3,7 +3,7 @@
   background-color: $color-white;
   color: $color-gray;
   font-size: 0.75rem;
-  padding: 0.25rem 1rem;
+  padding: 0.25rem $space;
   line-height: 0.9375rem;
   align-items: center;
 }
@@ -59,20 +59,20 @@
   .header-search {
     padding-top: 0;
     padding-right: 0;
-    padding-bottom: 1rem;
-    padding-left: 1rem;
+    padding-bottom: $space;
+    padding-left: $space;
   }
 
   .header-search-form {
-    padding-bottom: 1rem;
+    padding-bottom: $space;
   }
 }
 
 .header-search-form {
   @extend .no-print;
   position: absolute;
-  padding-left: 1rem;
-  padding-right: 1rem;
+  padding-left: $space;
+  padding-right: $space;
   right: 0;
 
   form {

--- a/ui/css/module/_homepage.scss
+++ b/ui/css/module/_homepage.scss
@@ -3,8 +3,8 @@
     background-color: $color-blue;
     border-top: 1px solid $color-white;
     color: $color-white;
-    padding-left: .75rem;
-    padding-right: .75rem;
+    padding-left: $space-sm;
+    padding-right: $space-sm;
   }
 
   h2,
@@ -22,7 +22,7 @@
 
     .search-input {
       width: 100%;
-      margin-bottom: 1rem;
+      margin-bottom: $space;
     }
   }
 
@@ -36,9 +36,9 @@
     width: 55%;
     min-width: 260px;
     max-width: 350px;
-    padding: 0.5rem;
-    margin-right: 0.5rem;
-    margin-bottom: 1rem;
+    padding: $space-xs;
+    margin-right: $space-xs;
+    margin-bottom: $space;
   }
 
   .search-submit {
@@ -61,7 +61,7 @@
     }
 
     .new-policies {
-      padding: 2rem 1rem;
+      padding: $space-xl $space;
     }
   }
 }

--- a/ui/css/module/_listitem.scss
+++ b/ui/css/module/_listitem.scss
@@ -3,8 +3,9 @@
   margin-bottom: 8px;
 
   .list-item-marker {
-    @include font-san-serif-bold();
+    @include font-serif-bold();
     @include paragraph-marker();
+    @include size-regular();
   }
 
   .list-item-text {

--- a/ui/css/module/_listitem.scss
+++ b/ui/css/module/_listitem.scss
@@ -1,6 +1,6 @@
 .node-list-item {
   @extend .clearfix;
-  margin-bottom: 8px;
+  margin-bottom: $space-xs;
 
   .list-item-marker {
     @include font-serif-bold();

--- a/ui/css/module/_node-heading.scss
+++ b/ui/css/module/_node-heading.scss
@@ -1,0 +1,10 @@
+.node-heading {
+  margin-bottom: $space-xs;
+  margin-top: $space-xl;
+}
+
+// Spacing between headings is different than other elements
+.node-heading + .node-heading,
+.node-heading + .node-section > .node-heading:first-child {
+  margin-top: $space-xs;
+}

--- a/ui/css/module/_policies.scss
+++ b/ui/css/module/_policies.scss
@@ -15,7 +15,7 @@
     height: 1.2rem;
     float: left;
     line-height: 1.2rem;
-    margin-top: -.5rem;
+    margin-top: -$space-xs;
     margin-right: .2rem;
 
     a {

--- a/ui/css/module/_tables.scss
+++ b/ui/css/module/_tables.scss
@@ -13,7 +13,7 @@ tfoot {
 }
 
 .basic-table {
-  margin-top: 2rem;
+  margin-top: $space-xl;
   font-size: .9rem;
   margin-bottom: 3rem;
 
@@ -79,5 +79,5 @@ table {
 .basic-table td,
 tfoot td,
 .table-footer {
-  padding: 1em;
+  padding: $space;
 }


### PR DESCRIPTION
Per #718, this:
* Removes gold from h4 headings
* Uses the same font size/line height for numbered lists
* Adjusts spacing between headings

It also adds some variables/mixins to start the process of standardizing our font sizes and spacing, per discussion last sprint with @rememberlenny and @rtwell 

Looks like

<img width="527" alt="screen shot 2017-12-19 at 10 42 43 am" src="https://user-images.githubusercontent.com/326918/34165224-af2a75f2-e4a9-11e7-80d9-c1d398beb682.png">
<img width="559" alt="screen shot 2017-12-19 at 10 42 29 am" src="https://user-images.githubusercontent.com/326918/34165233-b323a052-e4a9-11e7-9ef8-79fffefb37de.png">
<img width="555" alt="screen shot 2017-12-19 at 10 43 03 am" src="https://user-images.githubusercontent.com/326918/34165247-ba307ab4-e4a9-11e7-9e86-c7ae8df385c8.png">
