### PR TITLE
Support (eventual) inline rich text markup in footnotes

### DIFF
--- a/api/ombpdf/document.py
+++ b/api/ombpdf/document.py
@@ -75,7 +75,7 @@ class OMBPage(list):
 OMBFootnoteCitation = eqnamedtuple('OMBFootnoteCitation', ['number',
                                                            'preceding_text'])
 
-OMBFootnote = eqnamedtuple('OMBFootnote', ['number', 'text'])
+OMBFootnote = eqnamedtuple('OMBFootnote', ['number'])
 
 OMBFootnoteMarker = eqnamedtuple('OMBFootnoteMarker', ['number'])
 

--- a/api/ombpdf/document.py
+++ b/api/ombpdf/document.py
@@ -77,6 +77,8 @@ OMBFootnoteCitation = eqnamedtuple('OMBFootnoteCitation', ['number',
 
 OMBFootnote = eqnamedtuple('OMBFootnote', ['number', 'text'])
 
+OMBFootnoteMarker = eqnamedtuple('OMBFootnoteMarker', ['number'])
+
 OMBPageNumber = eqnamedtuple('OMBPageNumber', ['number'])
 
 OMBParagraph = eqnamedtuple('OMBParagraph', ['id'])

--- a/api/ombpdf/footnotes.py
+++ b/api/ombpdf/footnotes.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from textwrap import TextWrapper
 
 from . import util
-from .document import OMBFootnote, OMBFootnoteCitation
+from .document import OMBFootnote, OMBFootnoteCitation, OMBFootnoteMarker
 from .horizlines import get_horizontal_lines
 
 NUMBER_RE = re.compile(r'[0-9]')
@@ -107,6 +107,8 @@ def annotate_footnotes(doc):
                 if match:
                     finish_footnote()
                     footnote, desc = match.groups()
+                    for char in line[:len(footnote) + 1]:
+                        char.set_annotation(OMBFootnoteMarker(int(footnote)))
                     curr_footnote = [int(footnote), desc, [line]]
                 elif curr_footnote:
                     curr_footnote[1] += chars

--- a/api/ombpdf/footnotes.py
+++ b/api/ombpdf/footnotes.py
@@ -8,7 +8,7 @@ from .horizlines import get_horizontal_lines
 
 NUMBER_RE = re.compile(r'[0-9]')
 
-FOOTNOTE_RE = re.compile(r'([0-9]+) (.+)')
+FOOTNOTE_RE = re.compile(r'([0-9]+ )(.+)')
 
 # Maximum distance the horizontal line separating a page's footnote section
 # can be from the top of the first footnote.
@@ -106,10 +106,11 @@ def annotate_footnotes(doc):
                 match = FOOTNOTE_RE.match(chars)
                 if match:
                     finish_footnote()
-                    footnote, desc = match.groups()
-                    for char in line[:len(footnote) + 1]:
-                        char.set_annotation(OMBFootnoteMarker(int(footnote)))
-                    curr_footnote = [int(footnote), desc, [line]]
+                    marker, rest = match.groups()
+                    number = int(marker.strip())
+                    for char in line[:len(marker)]:
+                        char.set_annotation(OMBFootnoteMarker(number))
+                    curr_footnote = [number, rest, [line]]
                 elif curr_footnote:
                     curr_footnote[1] += chars
                     curr_footnote[2].append(line)

--- a/api/ombpdf/footnotes.py
+++ b/api/ombpdf/footnotes.py
@@ -85,8 +85,8 @@ def annotate_footnotes(doc):
             # We want to track the OMBFootnote for the purpose of setting
             # annotations, but track the OMBFootnote and the line in the
             # rolling footnotes list, which is where we put footnote_plus.
-            footnote = OMBFootnote(number, text)
-            footnote_plus = (OMBFootnote(number, text), lines)
+            footnote = OMBFootnote(number)
+            footnote_plus = (footnote, text, lines)
             for line in lines:
                 line.set_annotation(footnote)
             footnotes.append(footnote_plus)
@@ -118,19 +118,14 @@ def annotate_footnotes(doc):
                     if found_horiz_line:
                         # Here we pull out the previous footnote and continue
                         # adding to it.
-                        curr_ft = footnotes.pop()
-                        curr_obj = curr_ft[0]
-                        curr_num = curr_obj[0]
-                        curr_txt = curr_obj[1]
-                        curr_lines = curr_ft[1]
+                        (curr_num,), curr_txt, curr_lines = footnotes.pop()
                         curr_footnote = [curr_num, curr_txt + chars, curr_lines
                                          + [line]]
             else:
                 finish_footnote()
     finish_footnote()
-    # Return the OMBFootnote list after applying strip() to the text:
-    footnote_objs = [OMBFootnote(f[0][0], f[0][1].strip()) for f in footnotes]
-    return footnote_objs
+
+    return [(footnote, text.strip()) for footnote, text, _ in footnotes]
 
 
 def main(doc):
@@ -143,7 +138,7 @@ def main(doc):
     wrapper = TextWrapper(initial_indent=indent, subsequent_indent=indent)
 
     print("\nFootnotes:")
-    for f in annotate_footnotes(doc):
+    for f, text in annotate_footnotes(doc):
         print(f"  #{f.number}:")
-        print('\n'.join(wrapper.wrap(f.text)))
+        print('\n'.join(wrapper.wrap(text)))
         print()

--- a/api/ombpdf/html.py
+++ b/api/ombpdf/html.py
@@ -1,7 +1,7 @@
 from html import escape
 
-from .document import (OMBFootnote, OMBFootnoteCitation, OMBListItemMarker,
-                       OMBPageNumber, OMBParagraph)
+from .document import (OMBFootnote, OMBFootnoteCitation, OMBFootnoteMarker,
+                       OMBListItemMarker, OMBPageNumber, OMBParagraph)
 
 
 HTML_INTRO = """\
@@ -38,7 +38,7 @@ html {
     color: lightgray;
 }
 
-.list-item-marker {
+.list-item-marker, .footnote-marker {
     color: darkgray;
 }
 
@@ -113,6 +113,8 @@ def to_html(doc):
                 elif isinstance(first_char.annotation, OMBListItemMarker):
                     classes.append('list-item-marker')
                     attrs.append(f'title="{first_char.annotation}"')
+                elif isinstance(first_char.annotation, OMBFootnoteMarker):
+                    classes.append('footnote-marker')
                 elif first_char.annotation is not None:
                     raise Exception(
                         f'Unknown annotation: {first_char.annotation}')

--- a/api/ombpdf/semdom.py
+++ b/api/ombpdf/semdom.py
@@ -150,10 +150,9 @@ class DOMWriter(semtree.Writer):
             )
         self.muted = False
 
-    def create_footnote(self, f):
+    def begin_footnote(self, f):
         citation = self.footnote_citations.get(f.number)
         if citation is not None:
-            del self.footnote_citations[f.number]
             parent = citation.parentNode
             if parent.nodeName == 'content':
                 parent = parent.parentNode
@@ -162,11 +161,19 @@ class DOMWriter(semtree.Writer):
                 'emblem': str(f.number),
                 'marker': str(f.number),
             })
-            self._add_text(f.text)
+            self.muted = False
+        else:
+            self._add_comment(f'Begin uncited footnote #{f.number}')
+
+    def end_footnote(self, f):
+        citation = self.footnote_citations.get(f.number)
+        if citation is not None:
+            del self.footnote_citations[f.number]
             self._pop_child('footnote')
             self._pop_cursor()
         else:
-            self._add_comment(f'Uncited footnote #{f.number}: {f.text}')
+            self._add_comment(f'End uncited footnote #{f.number}')
+        self.muted = True
 
     def create_text(self, text):
         text = text.replace('\n', ' ')

--- a/api/ombpdf/semhtml.py
+++ b/api/ombpdf/semhtml.py
@@ -71,10 +71,12 @@ class HTMLWriter(semtree.Writer):
     def end_footnote_list(self, fl):
         self.chunks.append('</dl>\n')
 
-    def create_footnote(self, f):
+    def begin_footnote(self, f):
         self.chunks.append(f'<dt id="{self.id_for_footnote(f.number)}">'
                            f'{f.number}</dt>\n')
-        self.chunks.append(f'<dd>{f.text}')
+        self.chunks.append(f'<dd>')
+
+    def end_footnote(self, f):
         cit_id = self.footnote_citations.get(f.number)
         if cit_id:
             self.chunks.append(

--- a/api/ombpdf/semtree.py
+++ b/api/ombpdf/semtree.py
@@ -49,11 +49,8 @@ class FootnoteList(Element):
 
 
 class Footnote(Element):
-    is_void = True
-
-    def __init__(self, number, text):
+    def __init__(self, number):
         self.number = number
-        self.text = text
 
 
 class Writer:
@@ -194,7 +191,8 @@ class SemanticTreeBuilder:
         for char, text in line.iter_char_chunks():
             anno = char.annotation
 
-            if isinstance(anno, document.OMBListItemMarker):
+            if isinstance(anno, (document.OMBListItemMarker,
+                                 document.OMBFootnoteMarker)):
                 # Don't display this content at all.
                 pass
             elif isinstance(anno, document.OMBFootnoteCitation):
@@ -212,8 +210,10 @@ class SemanticTreeBuilder:
                 anno = line.annotation
                 if anno != curr_footnote:
                     curr_footnote = anno
-                    self.writer.create_element(Footnote(anno.number,
-                                                        anno.text))
+                    self.close_all_blocks()
+                    self.open_new_block(Footnote(anno.number), anno)
+                self.process_line(line)
+            self.close_all_blocks()
 
     def process_document(self):
         for line in self.doc.lines:

--- a/api/ombpdf/tests/test_footnotes.py
+++ b/api/ombpdf/tests/test_footnotes.py
@@ -5,6 +5,11 @@ def tuplify(iterable):
     return [tuple(x) for x in iterable]
 
 
+def simplified_footnotes(doc):
+    return [(footnote.number, text) for (footnote, text)
+            in footnotes.annotate_footnotes(doc)]
+
+
 def test_annotate_citations_works(m_16_19_doc):
     citations = tuplify(footnotes.annotate_citations(m_16_19_doc))
     assert citations[:3] == [
@@ -18,7 +23,7 @@ def test_annotate_citations_works(m_16_19_doc):
 def test_annotate_footnotes_works(m_16_19_doc):
     # Page numbers and footnotes can clash; handle page numbers first.
     pagenumbers.annotate_page_numbers(m_16_19_doc)
-    notes = tuplify(footnotes.annotate_footnotes(m_16_19_doc))
+    notes = simplified_footnotes(m_16_19_doc)
     assert notes[:1] == [
         (1, 'The FDCCI was first established by OMB “Memo for CIOs: '
             'Federal Data Center Consolidation Initiative,” issued '
@@ -42,7 +47,7 @@ def test_main_15_17(m_15_17_doc):
 def test_annotate_footnotes_m_15_17(m_15_17_doc):
     # Page numbers and footnotes can clash; handle page numbers first.
     pagenumbers.annotate_page_numbers(m_15_17_doc)
-    notes = tuplify(footnotes.annotate_footnotes(m_15_17_doc))
+    notes = simplified_footnotes(m_15_17_doc)
     # Run this to check that there isn't a clash over lists:
     lists.annotate_lists(m_15_17_doc)
 
@@ -119,7 +124,7 @@ def test_annotate_footnotes_m_15_17(m_15_17_doc):
 def test_annotate_footnotes_m_17_11_0(m_17_11_0_doc):
     # Page numbers and footnotes can clash; handle page numbers first.
     pagenumbers.annotate_page_numbers(m_17_11_0_doc)
-    notes = tuplify(footnotes.annotate_footnotes(m_17_11_0_doc))
+    notes = simplified_footnotes(m_17_11_0_doc)
     citations = tuplify(footnotes.annotate_citations(m_17_11_0_doc))
     # Run this to check that there isn't a clash over lists:
     lists.annotate_lists(m_17_11_0_doc)

--- a/api/ombpdf/tests/test_html.snapshot.html
+++ b/api/ombpdf/tests/test_html.snapshot.html
@@ -31,7 +31,7 @@ html {
     color: lightgray;
 }
 
-.list-item-marker {
+.list-item-marker, .footnote-marker {
     color: darkgray;
 }
 
@@ -90,11 +90,11 @@ html {
 </span></div><div ><span style="font-size: 16.2pt"> 
 </span></div><div ><span style="font-size: 67.0pt"> 
 </span></div><div ><span style="font-size: 67.0pt">                                                        
-</span></div><div title="Footnote 1" id="footnote-1" class="footnote"><span style="font-size: 8.7pt">1</span><span style="font-size: 13.4pt"> The FDCCI was first established by OMB “Memo for CIOs: Federal Data Center Consolidation Initiative,” issued 
+</span></div><div title="Footnote 1" id="footnote-1" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">1</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">The FDCCI was first established by OMB “Memo for CIOs: Federal Data Center Consolidation Initiative,” issued 
 </span></div><div title="Footnote 1" class="footnote"><span style="font-size: 13.4pt">on February 26, 2010, and modified by subsequent memoranda. 
-</span></div><div title="Footnote 2" id="footnote-2" class="footnote"><span style="font-size: 8.7pt">2</span><span style="font-size: 13.4pt"> Title VIII, Subtitle D of the National Defense Authorization Act (NDAA) for Fiscal Year 2015, Pub. L. No. 113-
+</span></div><div title="Footnote 2" id="footnote-2" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">2</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Title VIII, Subtitle D of the National Defense Authorization Act (NDAA) for Fiscal Year 2015, Pub. L. No. 113-
 </span></div><div title="Footnote 2" class="footnote"><span style="font-size: 13.4pt">291. 
-</span></div><div title="Footnote 3" id="footnote-3" class="footnote"><span style="font-size: 8.7pt">3</span><span style="font-size: 13.4pt"> This office was established in accordance with Section 101 of the E-government Act of 2002, codified at 44 U.S.C. 
+</span></div><div title="Footnote 3" id="footnote-3" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">3</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">This office was established in accordance with Section 101 of the E-government Act of 2002, codified at 44 U.S.C. 
 </span></div><div title="Footnote 3" class="footnote"><span style="font-size: 13.4pt">§ 3602, and is headed by the Federal government Chief Information Officer.  This office will also be referred to as 
 </span></div><div title="Footnote 3" class="footnote"><span style="font-size: 13.4pt">OMB’s Office of the Federal Chief Information Officer (OFCIO).   
 </span></div><div class="page-number"><span style="font-size: 67.0pt">1 
@@ -134,19 +134,19 @@ html {
 </span></div><div data-id="9" class="paragraph"><span style="font-size: 16.2pt">Beginning 180 days after issuance of this memorandum, agencies may not budget any funds or 
 </span></div><div data-id="9" class="paragraph"><span style="font-size: 16.2pt">resources toward initiating a new data center or significantly expanding</span><a style="font-size: 10.8pt" href="#footnote-9" class="footnote-citation">9</a><span style="font-size: 16.2pt"> an existing data center 
 </span></div><div ><span style="font-size: 67.0pt">                                                        
-</span></div><div title="Footnote 4" id="footnote-4" class="footnote"><span style="font-size: 8.7pt">4</span><span style="font-size: 13.4pt"> Federal Information Technology Shared Services Strategy, May 2, 2012, 
+</span></div><div title="Footnote 4" id="footnote-4" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">4</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Federal Information Technology Shared Services Strategy, May 2, 2012, 
 </span></div><div title="Footnote 4" class="footnote"><span style="font-size: 13.4pt" class="underline">https://www.whitehouse.gov/sites/default/files/omb/assets/egov_docs/shared_services_strategy.pdf</span><span style="font-size: 13.4pt">. 
-</span></div><div title="Footnote 5" id="footnote-5" class="footnote"><span style="font-size: 8.7pt">5</span><span style="font-size: 13.4pt"> See Chief Financial Officers Act of 1990, Pub. L. No. 101–576. 
-</span></div><div title="Footnote 6" id="footnote-6" class="footnote"><span style="font-size: 8.7pt">6</span><span style="font-size: 13.4pt"> Per Sec. 834(b)(1)(C) of the FY2015 NDAA, the Department of Defense may submit to OMB, in lieu of the 
+</span></div><div title="Footnote 5" id="footnote-5" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">5</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">See Chief Financial Officers Act of 1990, Pub. L. No. 101–576. 
+</span></div><div title="Footnote 6" id="footnote-6" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">6</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Per Sec. 834(b)(1)(C) of the FY2015 NDAA, the Department of Defense may submit to OMB, in lieu of the 
 </span></div><div title="Footnote 6" class="footnote"><span style="font-size: 13.4pt">Strategic Plan described in this memorandum, the defense-wide plan and cost savings report required under sections 
 </span></div><div title="Footnote 6" class="footnote"><span style="font-size: 13.4pt">2867(b)(2) and 2867(d), respectively, of the FY2012 NDAA.  If submitting such plans and reports in lieu of the 
 </span></div><div title="Footnote 6" class="footnote"><span style="font-size: 13.4pt">Strategic Plan, DOD shall ensure all information required by the Strategic Plan is included in the submitted plans 
 </span></div><div title="Footnote 6" class="footnote"><span style="font-size: 13.4pt">and reports. 
-</span></div><div title="Footnote 7" id="footnote-7" class="footnote"><span style="font-size: 8.7pt">7</span><span style="font-size: 13.4pt"> Title VIII, Subtitle D of the National Defense Authorization Act (NDAA) for Fiscal Year 2015, Pub. L. No. 113-
+</span></div><div title="Footnote 7" id="footnote-7" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">7</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Title VIII, Subtitle D of the National Defense Authorization Act (NDAA) for Fiscal Year 2015, Pub. L. No. 113-
 </span></div><div title="Footnote 7" class="footnote"><span style="font-size: 13.4pt">291.  
-</span></div><div title="Footnote 8" id="footnote-8" class="footnote"><span style="font-size: 8.7pt">8</span><span style="font-size: 13.4pt"> OMB Memorandum M-15-14, “Management and Oversight of Federal Information Technology,” June 10, 2015, 
+</span></div><div title="Footnote 8" id="footnote-8" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">8</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">OMB Memorandum M-15-14, “Management and Oversight of Federal Information Technology,” June 10, 2015, 
 </span></div><div title="Footnote 8" class="footnote"><span style="font-size: 13.4pt" class="underline">https://www.whitehouse.gov/sites/default/files/omb/memoranda/2015/m-15-14.pdf</span><span style="font-size: 13.4pt">. 
-</span></div><div title="Footnote 9" id="footnote-9" class="footnote"><span style="font-size: 8.7pt">9</span><span style="font-size: 13.4pt"> The General Services Administration (GSA) Office of Government-wide Policy (OGP) will coordinate with OMB 
+</span></div><div title="Footnote 9" id="footnote-9" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">9</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">The General Services Administration (GSA) Office of Government-wide Policy (OGP) will coordinate with OMB 
 </span></div><div title="Footnote 9" class="footnote"><span style="font-size: 13.4pt">to define thresholds for what constitutes “significant” expansion within 60 days of publication of this memorandum. 
 </span></div><div ><span style="font-size: 67.0pt"> 
 </span></div><div class="page-number"><span style="font-size: 67.0pt">2 
@@ -191,13 +191,13 @@ html {
 </span></div><div data-id="12" class="paragraph"><span style="font-size: 16.2pt">To support the shared services efforts described by this memorandum, the General Services 
 </span></div><div data-id="12" class="paragraph"><span style="font-size: 16.2pt">Administration (GSA) Office of Government-wide Policy (OGP) shall serve as the managing 
 </span></div><div ><span style="font-size: 67.0pt">                                                        
-</span></div><div title="Footnote 10" id="footnote-10" class="footnote"><span style="font-size: 8.7pt">10</span><span style="font-size: 13.4pt"> Data centers certified by GSA OGP as Inter-agency Shared Service Provider data centers are excluded from this 
+</span></div><div title="Footnote 10" id="footnote-10" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">10</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Data centers certified by GSA OGP as Inter-agency Shared Service Provider data centers are excluded from this 
 </span></div><div title="Footnote 10" class="footnote"><span style="font-size: 13.4pt">development freeze. 
-</span></div><div title="Footnote 11" id="footnote-11" class="footnote"><span style="font-size: 8.7pt">11</span><span style="font-size: 13.4pt"> This requirement does not apply to GSA OGP designated inter-agency shared services data centers. 
-</span></div><div title="Footnote 12" id="footnote-12" class="footnote"><span style="font-size: 8.7pt">12</span><span style="font-size: 13.4pt"> Federal Cloud Computing Strategy, February 8, 2011, 
+</span></div><div title="Footnote 11" id="footnote-11" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">11</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">This requirement does not apply to GSA OGP designated inter-agency shared services data centers. 
+</span></div><div title="Footnote 12" id="footnote-12" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">12</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Federal Cloud Computing Strategy, February 8, 2011, 
 </span></div><div title="Footnote 12" class="footnote"><span style="font-size: 13.4pt" class="underline">https://www.whitehouse.gov/sites/default/files/omb/assets/egov_docs/federal-cloud-computing-strategy.pdf</span><span style="font-size: 13.4pt">. 
-</span></div><div title="Footnote 13" id="footnote-13" class="footnote"><span style="font-size: 8.7pt">13</span><span style="font-size: 13.4pt"> Ibid. 
-</span></div><div title="Footnote 14" id="footnote-14" class="footnote"><span style="font-size: 8.7pt">14</span><span style="font-size: 13.4pt"> See FY2015 NDAA Sec. 834(3)(c). 
+</span></div><div title="Footnote 13" id="footnote-13" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">13</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Ibid. 
+</span></div><div title="Footnote 14" id="footnote-14" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">14</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">See FY2015 NDAA Sec. 834(3)(c). 
 </span></div><div ><span style="font-size: 67.0pt"> 
 </span></div><div class="page-number"><span style="font-size: 67.0pt">3 
 </span></div><!-- 
@@ -243,7 +243,7 @@ html {
 </span></div><div data-id="15" class="paragraph"><span style="font-size: 16.2pt">(whether in a production, test, staging, development, or any other environment) are considered 
 </span></div><div data-id="15" class="paragraph"><span style="font-size: 16.2pt">data centers. However, rooms containing only print servers, routing equipment, switches, 
 </span></div><div data-id="15" class="paragraph"><span style="font-size: 16.2pt">security devices (such as firewalls), or other telecommunications components shall not be 
-</span></div><div title="Footnote 15" id="footnote-15" class="footnote"><span style="font-size: 8.7pt">15</span><span style="font-size: 13.4pt"> Formed in 2004, lines of business (LOB) are cross-agency initiatives to define, design, implement and monitor a 
+</span></div><div title="Footnote 15" id="footnote-15" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">15</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Formed in 2004, lines of business (LOB) are cross-agency initiatives to define, design, implement and monitor a 
 </span></div><div title="Footnote 15" class="footnote"><span style="font-size: 13.4pt">set of common solutions for government-wide business functions, processes, or desires capabilities. Each LOB is 
 </span></div><div title="Footnote 15" class="footnote"><span style="font-size: 13.4pt">governed by a Managing Partner which is designated as the lead organization responsible for managing the business 
 </span></div><div title="Footnote 15" class="footnote"><span style="font-size: 13.4pt">requirements of their community. 
@@ -285,16 +285,16 @@ html {
 </span></div><div data-id="20" class="paragraph"><span style="font-size: 16.2pt">Instructions), energy metering tools shall enable the active tracking of PUE for the data center 
 </span></div><div data-id="20" class="paragraph"><span style="font-size: 16.2pt">and shall be installed in all tiered Federal data centers by September 30, 2018.</span><a style="font-size: 10.8pt" href="#footnote-20" class="footnote-citation">20</a><span style="font-size: 16.2pt"> The E.O. 
 </span></div><div ><span style="font-size: 67.0pt">                                                        
-</span></div><div title="Footnote 16" id="footnote-16" class="footnote"><span style="font-size: 8.7pt">16</span><span style="font-size: 13.4pt"> Data centers containing only print servers that were previously reported as “closed” shall remain classified as 
+</span></div><div title="Footnote 16" id="footnote-16" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">16</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Data centers containing only print servers that were previously reported as “closed” shall remain classified as 
 </span></div><div title="Footnote 16" class="footnote"><span style="font-size: 13.4pt">closed data centers in agencies’ data center reporting. 
-</span></div><div title="Footnote 17" id="footnote-17" class="footnote"><span style="font-size: 8.7pt">17</span><span style="font-size: 13.4pt"> The term “tiered” and the definitions that follow are derived from the Uptime Institute’s Tier Classification 
+</span></div><div title="Footnote 17" id="footnote-17" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">17</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">The term “tiered” and the definitions that follow are derived from the Uptime Institute’s Tier Classification 
 </span></div><div title="Footnote 17" class="footnote"><span style="font-size: 13.4pt">System; however, this shall not be construed as requiring any certification in order for a data center to be considered 
 </span></div><div title="Footnote 17" class="footnote"><span style="font-size: 13.4pt">tiered by OMB. 
-</span></div><div title="Footnote 18" id="footnote-18" class="footnote"><span style="font-size: 8.7pt">18</span><span style="font-size: 13.4pt"> Data centers previously classified as tiered in past inventories will automatically be classified as tiered under the 
+</span></div><div title="Footnote 18" id="footnote-18" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">18</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Data centers previously classified as tiered in past inventories will automatically be classified as tiered under the 
 </span></div><div title="Footnote 18" class="footnote"><span style="font-size: 13.4pt">DCOI. 
-</span></div><div title="Footnote 19" id="footnote-19" class="footnote"><span style="font-size: 8.7pt">19</span><span style="font-size: 13.4pt"> Executive Order, “Planning for Federal Sustainability in the Next Decade” </span><span style="font-size: 13.4pt" class="underline">https://www.whitehouse.gov/the-press-
+</span></div><div title="Footnote 19" id="footnote-19" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">19</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Executive Order, “Planning for Federal Sustainability in the Next Decade” </span><span style="font-size: 13.4pt" class="underline">https://www.whitehouse.gov/the-press-
 </span></div><div title="Footnote 19" class="footnote"><span style="font-size: 13.4pt" class="underline">office/2015/03/19/executive-order-planning-federal-sustainability-next-decade</span><span style="font-size: 13.4pt">.   
-</span></div><div title="Footnote 20" id="footnote-20" class="footnote"><span style="font-size: 8.7pt">20</span><span style="font-size: 13.4pt"> While Executive Order 13693 requires advanced energy metering in all data centers, OMB will monitor PUE for 
+</span></div><div title="Footnote 20" id="footnote-20" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">20</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">While Executive Order 13693 requires advanced energy metering in all data centers, OMB will monitor PUE for 
 </span></div><div title="Footnote 20" class="footnote"><span style="font-size: 13.4pt">tiered data centers only. 
 </span></div><div ><span style="font-size: 67.0pt"> 
 </span></div><div class="page-number"><span style="font-size: 67.0pt">5 
@@ -340,12 +340,12 @@ html {
 </span></div><div data-id="26" class="paragraph"><span style="font-size: 16.2pt">strongly encouraged to implement automated monitoring and management tools throughout their 
 </span></div><div data-id="26" class="paragraph"><span style="font-size: 16.2pt">data centers immediately.  
 </span></div><div ><span style="font-size: 16.2pt"> </span><span style="font-size: 67.0pt">                                                        
-</span></div><div title="Footnote 21" id="footnote-21" class="footnote"><span style="font-size: 8.7pt">21</span><span style="font-size: 13.4pt"> See “Implementing Instructions for Executive Order 13693, ‘Planning for Federal Sustainability in the Next 
+</span></div><div title="Footnote 21" id="footnote-21" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">21</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">See “Implementing Instructions for Executive Order 13693, ‘Planning for Federal Sustainability in the Next 
 </span></div><div title="Footnote 21" class="footnote"><span style="font-size: 13.4pt">Decade’” 
 </span></div><div title="Footnote 21" class="footnote"><span style="font-size: 13.4pt" class="underline">https://www.whitehouse.gov/sites/default/files/docs/eo_13693_implementing_instructions_june_10_2015.pdf</span><span style="font-size: 13.4pt">.  
-</span></div><div title="Footnote 22" id="footnote-22" class="footnote"><span style="font-size: 8.7pt">22</span><span style="font-size: 13.4pt"> This can be PUE for the facility as a whole in cases where the agency only contracts for a portion of a larger 
+</span></div><div title="Footnote 22" id="footnote-22" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">22</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">This can be PUE for the facility as a whole in cases where the agency only contracts for a portion of a larger 
 </span></div><div title="Footnote 22" class="footnote"><span style="font-size: 13.4pt">facility; however, if PUE metrics are available specific to the agency’s use, that is preferred. 
-</span></div><div title="Footnote 23" id="footnote-23" class="footnote"><span style="font-size: 8.7pt">23</span><span style="font-size: 13.4pt"> For non-tiered data centers, only automated monitoring of server utilization is required. 
+</span></div><div title="Footnote 23" id="footnote-23" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">23</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">For non-tiered data centers, only automated monitoring of server utilization is required. 
 </span></div><div ><span style="font-size: 67.0pt"> 
 </span></div><div class="page-number"><span style="font-size: 67.0pt">6 
 </span></div><!-- 
@@ -413,12 +413,12 @@ html {
 </span></div><div ><span style="font-size: 16.2pt">IT equipment. 
 </span></div><div ><span style="font-size: 67.0pt">                                                        
 </span></div><div ><span style="font-size: 67.0pt"> 
-</span></div><div title="Footnote 24" id="footnote-24" class="footnote"><span style="font-size: 8.7pt">24</span><span style="font-size: 13.4pt"> While agencies should strive to achieve each applicable optimization target for each data center, only PUE targets 
+</span></div><div title="Footnote 24" id="footnote-24" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">24</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">While agencies should strive to achieve each applicable optimization target for each data center, only PUE targets 
 </span></div><div title="Footnote 24" class="footnote"><span style="font-size: 13.4pt">will be calculated on a per-data center basis. All other targets will be calculated at the agency inventory-level. 
-</span></div><div title="Footnote 25" id="footnote-25" class="footnote"><span style="font-size: 8.7pt">25</span><span style="font-size: 13.4pt"> “Total gross floor area” is defined as total square footage available for IT equipment and includes all associated 
+</span></div><div title="Footnote 25" id="footnote-25" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">25</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">“Total gross floor area” is defined as total square footage available for IT equipment and includes all associated 
 </span></div><div title="Footnote 25" class="footnote"><span style="font-size: 13.4pt">corridors, walkways, and air circulation requirements. This does not include office space, mechanical rooms, or 
 </span></div><div title="Footnote 25" class="footnote"><span style="font-size: 13.4pt">storage areas. 
-</span></div><div title="Footnote 26" id="footnote-26" class="footnote"><span style="font-size: 8.7pt">26</span><span style="font-size: 13.4pt"> PUE shall be calculated by OMB based on quarterly average IT and facility electricity usage data.  
+</span></div><div title="Footnote 26" id="footnote-26" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">26</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">PUE shall be calculated by OMB based on quarterly average IT and facility electricity usage data.  
 </span></div><div class="page-number"><span style="font-size: 67.0pt">7 
 </span></div><!-- 
 
@@ -492,11 +492,11 @@ html {
 </span></div><div data-id="32" class="paragraph"><span style="font-size: 16.2pt">years 2016, 2017, and 2018: 
 </span></div><div ><span style="font-size: 16.2pt"> 
 </span></div><div ><span style="font-size: 67.0pt">                                                        
-</span></div><div title="Footnote 27" id="footnote-27" class="footnote"><span style="font-size: 8.7pt">27</span><span style="font-size: 13.4pt"> Server utilization shall be collected continuously and reported as a quarterly average. 
-</span></div><div title="Footnote 28" id="footnote-28" class="footnote"><span style="font-size: 8.7pt">28</span><span style="font-size: 13.4pt"> “Active” racks are those that have IT equipment consuming electricity. 
-</span></div><div title="Footnote 29" id="footnote-29" class="footnote"><span style="font-size: 8.7pt">29</span><span style="font-size: 13.4pt"> Benchmarked against the sum of all non-cloud data center costs (including data center labor, software, hardware, 
+</span></div><div title="Footnote 27" id="footnote-27" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">27</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Server utilization shall be collected continuously and reported as a quarterly average. 
+</span></div><div title="Footnote 28" id="footnote-28" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">28</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">“Active” racks are those that have IT equipment consuming electricity. 
+</span></div><div title="Footnote 29" id="footnote-29" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">29</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Benchmarked against the sum of all non-cloud data center costs (including data center labor, software, hardware, 
 </span></div><div title="Footnote 29" class="footnote"><span style="font-size: 13.4pt">electricity, and facility) found in physical data center fields of the IT Inventory Summary Table of the IT Dashboard. 
-</span></div><div title="Footnote 30" id="footnote-30" class="footnote"><span style="font-size: 8.7pt">30</span><span style="font-size: 13.4pt"> Consistent with OMB Circular A-131, the term “cost savings” refers to “a reduction in actual expenditures below 
+</span></div><div title="Footnote 30" id="footnote-30" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">30</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Consistent with OMB Circular A-131, the term “cost savings” refers to “a reduction in actual expenditures below 
 </span></div><div title="Footnote 30" class="footnote"><span style="font-size: 13.4pt">the projected level of costs to achieve a specific objective,” and the term “cost avoidance” refers to “an action taken 
 </span></div><div title="Footnote 30" class="footnote"><span style="font-size: 13.4pt">in the immediate time frame that will decrease costs in the future.” 
 </span></div><div class="page-number"><span style="font-size: 67.0pt">8 
@@ -550,10 +550,10 @@ html {
 </span></div><div data-id="38" class="paragraph"><span style="font-size: 16.2pt">centers that are physically inseparable from non-IT hardware (e.g. simulation and modeling 
 </span></div><div data-id="38" class="paragraph"><span style="font-size: 16.2pt">devices, sensors, etc.) and that perform a specific, non-standard set of tasks (e.g. do not provide 
 </span></div><div data-id="38" class="paragraph"><span style="font-size: 16.2pt">general purpose computing or storage services to Federal facilities). 
-</span></div><div title="Footnote 31" id="footnote-31" class="footnote"><span style="font-size: 8.7pt">31</span><span style="font-size: 13.4pt"> Excludes print servers. 
-</span></div><div title="Footnote 32" id="footnote-32" class="footnote"><span style="font-size: 8.7pt">32</span><span style="font-size: 13.4pt"> The baseline number of data centers is based on the agencies’ August 31, 2015, data center inventory submissions, 
+</span></div><div title="Footnote 31" id="footnote-31" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">31</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Excludes print servers. 
+</span></div><div title="Footnote 32" id="footnote-32" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">32</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">The baseline number of data centers is based on the agencies’ August 31, 2015, data center inventory submissions, 
 </span></div><div title="Footnote 32" class="footnote"><span style="font-size: 13.4pt">as collected by OMB OFCIO through the Integrated Data Collection. 
-</span></div><div title="Footnote 33" id="footnote-33" class="footnote"><span style="font-size: 8.7pt">33</span><span style="font-size: 13.4pt"> Estimated reduction in gross floor area of data centers is approximate and has been based on the average size, in 
+</span></div><div title="Footnote 33" id="footnote-33" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">33</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Estimated reduction in gross floor area of data centers is approximate and has been based on the average size, in 
 </span></div><div title="Footnote 33" class="footnote"><span style="font-size: 13.4pt">square feet, of the data centers of each type to be closed. 
 </span></div><div ><span style="font-size: 67.0pt">                                                        
 </span></div><div ><span style="font-size: 67.0pt"> 
@@ -605,9 +605,9 @@ html {
 </span></div><div ><span style="font-size: 16.2pt"> 
 </span></div><div ><span style="font-size: 67.0pt">                                                        
 </span></div><div ><span style="font-size: 67.0pt"> 
-</span></div><div title="Footnote 34" id="footnote-34" class="footnote"><span style="font-size: 8.7pt">34</span><span style="font-size: 13.4pt"> Note: Agencies participating as a tenant in an inter-agency shared services provider data center are not required to 
+</span></div><div title="Footnote 34" id="footnote-34" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">34</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">Note: Agencies participating as a tenant in an inter-agency shared services provider data center are not required to 
 </span></div><div title="Footnote 34" class="footnote"><span style="font-size: 13.4pt">report metric values to OMB. The provider will report this data to OMB. 
-</span></div><div title="Footnote 35" id="footnote-35" class="footnote"><span style="font-size: 8.7pt">35</span><span style="font-size: 13.4pt"> See FITARA Section 834(b)(1)(A)-(E). 
+</span></div><div title="Footnote 35" id="footnote-35" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">35</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">See FITARA Section 834(b)(1)(A)-(E). 
 </span></div><div class="page-number"><span style="font-size: 67.0pt">10 
 </span></div><!-- 
 
@@ -650,7 +650,7 @@ html {
 </span></div><div data-id="46" class="paragraph"><span style="font-size: 16.2pt">In addition to addressing questions and comments via the Data Centers listserv, 
 </span></div><div data-id="46" class="paragraph"><span style="font-size: 16.2pt" class="underline">https://management.cio.gov</span><span style="font-size: 16.2pt"> will be updated with best practices and other resources as they 
 </span></div><div data-id="46" class="paragraph"><span style="font-size: 16.2pt">become available. 
-</span></div><div title="Footnote 36" id="footnote-36" class="footnote"><span style="font-size: 8.7pt">36</span><span style="font-size: 13.4pt"> See 2015 NDAA Section 834(b)(2)(C). 
+</span></div><div title="Footnote 36" id="footnote-36" class="footnote"><span style="font-size: 8.7pt" class="footnote-marker">36</span><span style="font-size: 13.4pt" class="footnote-marker"> </span><span style="font-size: 13.4pt">See 2015 NDAA Section 834(b)(2)(C). 
 </span></div><div ><span style="font-size: 67.0pt">                                                        
 </span></div><div ><span style="font-size: 67.0pt"> 
 </span></div><div class="page-number"><span style="font-size: 67.0pt">11 

--- a/api/ombpdf/tests/test_semdom.snapshot.m_16_19_1.xml
+++ b/api/ombpdf/tests/test_semdom.snapshot.m_16_19_1.xml
@@ -38,7 +38,10 @@
           
           
       </content>
-      <footnote emblem="1" marker="1">The FDCCI was first established by OMB “Memo for CIOs: Federal Data Center Consolidation Initiative,” issued on February 26, 2010, and modified by subsequent memoranda. </footnote>
+      <footnote emblem="1" marker="1">
+        The FDCCI was first established by OMB “Memo for CIOs: Federal Data Center Consolidation Initiative,” issued  
+        on February 26, 2010, and modified by subsequent memoranda.  
+      </footnote>
     </para>
     <para>
       <content>
@@ -52,7 +55,10 @@
         investment and cost savings.  
           
       </content>
-      <footnote emblem="2" marker="2">Title VIII, Subtitle D of the National Defense Authorization Act (NDAA) for Fiscal Year 2015, Pub. L. No. 113-291. </footnote>
+      <footnote emblem="2" marker="2">
+        Title VIII, Subtitle D of the National Defense Authorization Act (NDAA) for Fiscal Year 2015, Pub. L. No. 113- 
+        291.  
+      </footnote>
     </para>
     <para>
       <content>
@@ -67,7 +73,11 @@
           
                                                                  
       </content>
-      <footnote emblem="3" marker="3">This office was established in accordance with Section 101 of the E-government Act of 2002, codified at 44 U.S.C. § 3602, and is headed by the Federal government Chief Information Officer.  This office will also be referred to as OMB’s Office of the Federal Chief Information Officer (OFCIO).   </footnote>
+      <footnote emblem="3" marker="3">
+        This office was established in accordance with Section 101 of the E-government Act of 2002, codified at 44 U.S.C.  
+        § 3602, and is headed by the Federal government Chief Information Officer.  This office will also be referred to as  
+        OMB’s Office of the Federal Chief Information Officer (OFCIO).    
+      </footnote>
     </para>
     <para>
       <content>
@@ -101,7 +111,11 @@
           
           
       </content>
-      <footnote emblem="4" marker="4">Federal Information Technology Shared Services Strategy, May 2, 2012, https://www.whitehouse.gov/sites/default/files/omb/assets/egov_docs/shared_services_strategy.pdf. </footnote>
+      <footnote emblem="4" marker="4">
+        Federal Information Technology Shared Services Strategy, May 2, 2012,  
+        https://www.whitehouse.gov/sites/default/files/omb/assets/egov_docs/shared_services_strategy.pdf
+        .  
+      </footnote>
     </para>
     <para>
       <content>
@@ -113,8 +127,14 @@
           
           
       </content>
-      <footnote emblem="5" marker="5">See Chief Financial Officers Act of 1990, Pub. L. No. 101–576. </footnote>
-      <footnote emblem="6" marker="6">Per Sec. 834(b)(1)(C) of the FY2015 NDAA, the Department of Defense may submit to OMB, in lieu of the Strategic Plan described in this memorandum, the defense-wide plan and cost savings report required under sections 2867(b)(2) and 2867(d), respectively, of the FY2012 NDAA.  If submitting such plans and reports in lieu of the Strategic Plan, DOD shall ensure all information required by the Strategic Plan is included in the submitted plans and reports. </footnote>
+      <footnote emblem="5" marker="5">See Chief Financial Officers Act of 1990, Pub. L. No. 101–576.  </footnote>
+      <footnote emblem="6" marker="6">
+        Per Sec. 834(b)(1)(C) of the FY2015 NDAA, the Department of Defense may submit to OMB, in lieu of the  
+        Strategic Plan described in this memorandum, the defense-wide plan and cost savings report required under sections  
+        2867(b)(2) and 2867(d), respectively, of the FY2012 NDAA.  If submitting such plans and reports in lieu of the  
+        Strategic Plan, DOD shall ensure all information required by the Strategic Plan is included in the submitted plans  
+        and reports.  
+      </footnote>
     </para>
     <sec title="Leadership and Responsibilities    ">
       <heading>
@@ -135,8 +155,15 @@
           toward meeting the goals set forth in this memorandum.  
             
         </content>
-        <footnote emblem="7" marker="7">Title VIII, Subtitle D of the National Defense Authorization Act (NDAA) for Fiscal Year 2015, Pub. L. No. 113-291.  </footnote>
-        <footnote emblem="8" marker="8">OMB Memorandum M-15-14, “Management and Oversight of Federal Information Technology,” June 10, 2015, https://www.whitehouse.gov/sites/default/files/omb/memoranda/2015/m-15-14.pdf. </footnote>
+        <footnote emblem="7" marker="7">
+          Title VIII, Subtitle D of the National Defense Authorization Act (NDAA) for Fiscal Year 2015, Pub. L. No. 113- 
+          291.   
+        </footnote>
+        <footnote emblem="8" marker="8">
+          OMB Memorandum M-15-14, “Management and Oversight of Federal Information Technology,” June 10, 2015,  
+          https://www.whitehouse.gov/sites/default/files/omb/memoranda/2015/m-15-14.pdf
+          .  
+        </footnote>
       </para>
     </sec>
     <sec title="Transition to Cloud and Data Center Shared Services    ">
@@ -167,8 +194,14 @@
             (such as through consolidation of multiple existing data centers into a single new data center).  
               
           </content>
-          <footnote emblem="9" marker="9">The General Services Administration (GSA) Office of Government-wide Policy (OGP) will coordinate with OMB to define thresholds for what constitutes “significant” expansion within 60 days of publication of this memorandum. </footnote>
-          <footnote emblem="10" marker="10">Data centers certified by GSA OGP as Inter-agency Shared Service Provider data centers are excluded from this development freeze. </footnote>
+          <footnote emblem="9" marker="9">
+            The General Services Administration (GSA) Office of Government-wide Policy (OGP) will coordinate with OMB  
+            to define thresholds for what constitutes “significant” expansion within 60 days of publication of this memorandum.  
+          </footnote>
+          <footnote emblem="10" marker="10">
+            Data centers certified by GSA OGP as Inter-agency Shared Service Provider data centers are excluded from this  
+            development freeze.  
+          </footnote>
         </para>
       </sec>
       <sec title="Consolidation and Closure of Existing Data Centers    ">
@@ -187,7 +220,7 @@
              by (in order of priority):  
               
           </content>
-          <footnote emblem="11" marker="11">This requirement does not apply to GSA OGP designated inter-agency shared services data centers. </footnote>
+          <footnote emblem="11" marker="11">This requirement does not apply to GSA OGP designated inter-agency shared services data centers.  </footnote>
         </para>
         <list>
           <listitem emblem="1" marker="1.">
@@ -200,7 +233,11 @@
                 <footnote_citation>12</footnote_citation>
                   
               </content>
-              <footnote emblem="12" marker="12">Federal Cloud Computing Strategy, February 8, 2011, https://www.whitehouse.gov/sites/default/files/omb/assets/egov_docs/federal-cloud-computing-strategy.pdf. </footnote>
+              <footnote emblem="12" marker="12">
+                Federal Cloud Computing Strategy, February 8, 2011,  
+                https://www.whitehouse.gov/sites/default/files/omb/assets/egov_docs/federal-cloud-computing-strategy.pdf
+                .  
+              </footnote>
             </para>
           </listitem>
           <listitem emblem="2" marker="2.">
@@ -239,8 +276,8 @@
               
               
           </content>
-          <footnote emblem="13" marker="13">Ibid. </footnote>
-          <footnote emblem="14" marker="14">See FY2015 NDAA Sec. 834(3)(c). </footnote>
+          <footnote emblem="13" marker="13">Ibid.  </footnote>
+          <footnote emblem="14" marker="14">See FY2015 NDAA Sec. 834(3)(c).  </footnote>
         </para>
       </sec>
       <sec title="Shared Services Managing Partner    ">
@@ -262,7 +299,12 @@
             for inter-agency consumption by:  
               
           </content>
-          <footnote emblem="15" marker="15">Formed in 2004, lines of business (LOB) are cross-agency initiatives to define, design, implement and monitor a set of common solutions for government-wide business functions, processes, or desires capabilities. Each LOB is governed by a Managing Partner which is designated as the lead organization responsible for managing the business requirements of their community. </footnote>
+          <footnote emblem="15" marker="15">
+            Formed in 2004, lines of business (LOB) are cross-agency initiatives to define, design, implement and monitor a  
+            set of common solutions for government-wide business functions, processes, or desires capabilities. Each LOB is  
+            governed by a Managing Partner which is designated as the lead organization responsible for managing the business  
+            requirements of their community.  
+          </footnote>
         </para>
         <list>
           <listitem marker="•">
@@ -367,7 +409,10 @@
               
               
           </content>
-          <footnote emblem="16" marker="16">Data centers containing only print servers that were previously reported as “closed” shall remain classified as closed data centers in agencies’ data center reporting. </footnote>
+          <footnote emblem="16" marker="16">
+            Data centers containing only print servers that were previously reported as “closed” shall remain classified as  
+            closed data centers in agencies’ data center reporting.  
+          </footnote>
         </para>
         <para>
           <content>
@@ -384,8 +429,15 @@
             included in agencies’ quarterly inventory data submissions to OMB.  
               
           </content>
-          <footnote emblem="17" marker="17">The term “tiered” and the definitions that follow are derived from the Uptime Institute’s Tier Classification System; however, this shall not be construed as requiring any certification in order for a data center to be considered tiered by OMB. </footnote>
-          <footnote emblem="18" marker="18">Data centers previously classified as tiered in past inventories will automatically be classified as tiered under the DCOI. </footnote>
+          <footnote emblem="17" marker="17">
+            The term “tiered” and the definitions that follow are derived from the Uptime Institute’s Tier Classification  
+            System; however, this shall not be construed as requiring any certification in order for a data center to be considered  
+            tiered by OMB.  
+          </footnote>
+          <footnote emblem="18" marker="18">
+            Data centers previously classified as tiered in past inventories will automatically be classified as tiered under the  
+            DCOI.  
+          </footnote>
         </para>
         <para>
           <content>
@@ -420,7 +472,12 @@
               
               
           </content>
-          <footnote emblem="19" marker="19">Executive Order, “Planning for Federal Sustainability in the Next Decade” https://www.whitehouse.gov/the-press-office/2015/03/19/executive-order-planning-federal-sustainability-next-decade.   </footnote>
+          <footnote emblem="19" marker="19">
+            Executive Order, “Planning for Federal Sustainability in the Next Decade” 
+            https://www.whitehouse.gov/the-press- 
+            office/2015/03/19/executive-order-planning-federal-sustainability-next-decade
+            .    
+          </footnote>
         </para>
         <para>
           <content>
@@ -432,7 +489,10 @@
                                                                      
               
           </content>
-          <footnote emblem="20" marker="20">While Executive Order 13693 requires advanced energy metering in all data centers, OMB will monitor PUE for tiered data centers only. </footnote>
+          <footnote emblem="20" marker="20">
+            While Executive Order 13693 requires advanced energy metering in all data centers, OMB will monitor PUE for  
+            tiered data centers only.  
+          </footnote>
         </para>
         <para>
           <content>
@@ -442,7 +502,12 @@
                
               
           </content>
-          <footnote emblem="21" marker="21">See “Implementing Instructions for Executive Order 13693, ‘Planning for Federal Sustainability in the Next Decade’” https://www.whitehouse.gov/sites/default/files/docs/eo_13693_implementing_instructions_june_10_2015.pdf.  </footnote>
+          <footnote emblem="21" marker="21">
+            See “Implementing Instructions for Executive Order 13693, ‘Planning for Federal Sustainability in the Next  
+            Decade’”  
+            https://www.whitehouse.gov/sites/default/files/docs/eo_13693_implementing_instructions_june_10_2015.pdf
+            .   
+          </footnote>
         </para>
         <para>
           <content>
@@ -478,7 +543,10 @@
             existing vehicles.  PUE reporting is not required for cloud services.  
               
           </content>
-          <footnote emblem="22" marker="22">This can be PUE for the facility as a whole in cases where the agency only contracts for a portion of a larger facility; however, if PUE metrics are available specific to the agency’s use, that is preferred. </footnote>
+          <footnote emblem="22" marker="22">
+            This can be PUE for the facility as a whole in cases where the agency only contracts for a portion of a larger  
+            facility; however, if PUE metrics are available specific to the agency’s use, that is preferred.  
+          </footnote>
         </para>
       </sec>
       <sec title="Automated Infrastructure Management    ">
@@ -497,7 +565,7 @@
               
               
           </content>
-          <footnote emblem="23" marker="23">For non-tiered data centers, only automated monitoring of server utilization is required. </footnote>
+          <footnote emblem="23" marker="23">For non-tiered data centers, only automated monitoring of server utilization is required.  </footnote>
         </para>
         <para>
           <content>
@@ -695,10 +763,17 @@
              
               
           </content>
-          <footnote emblem="24" marker="24">While agencies should strive to achieve each applicable optimization target for each data center, only PUE targets will be calculated on a per-data center basis. All other targets will be calculated at the agency inventory-level. </footnote>
-          <footnote emblem="25" marker="25">“Total gross floor area” is defined as total square footage available for IT equipment and includes all associated corridors, walkways, and air circulation requirements. This does not include office space, mechanical rooms, or storage areas. </footnote>
-          <footnote emblem="26" marker="26">PUE shall be calculated by OMB based on quarterly average IT and facility electricity usage data.  </footnote>
-          <footnote emblem="27" marker="27">Server utilization shall be collected continuously and reported as a quarterly average. </footnote>
+          <footnote emblem="24" marker="24">
+            While agencies should strive to achieve each applicable optimization target for each data center, only PUE targets  
+            will be calculated on a per-data center basis. All other targets will be calculated at the agency inventory-level.  
+          </footnote>
+          <footnote emblem="25" marker="25">
+            “Total gross floor area” is defined as total square footage available for IT equipment and includes all associated  
+            corridors, walkways, and air circulation requirements. This does not include office space, mechanical rooms, or  
+            storage areas.  
+          </footnote>
+          <footnote emblem="26" marker="26">PUE shall be calculated by OMB based on quarterly average IT and facility electricity usage data.   </footnote>
+          <footnote emblem="27" marker="27">Server utilization shall be collected continuously and reported as a quarterly average.  </footnote>
         </para>
         <para>
           <content>
@@ -741,8 +816,15 @@
             9  
               
           </content>
-          <footnote emblem="29" marker="29">Benchmarked against the sum of all non-cloud data center costs (including data center labor, software, hardware, electricity, and facility) found in physical data center fields of the IT Inventory Summary Table of the IT Dashboard. </footnote>
-          <footnote emblem="30" marker="30">Consistent with OMB Circular A-131, the term “cost savings” refers to “a reduction in actual expenditures below the projected level of costs to achieve a specific objective,” and the term “cost avoidance” refers to “an action taken in the immediate time frame that will decrease costs in the future.” </footnote>
+          <footnote emblem="29" marker="29">
+            Benchmarked against the sum of all non-cloud data center costs (including data center labor, software, hardware,  
+            electricity, and facility) found in physical data center fields of the IT Inventory Summary Table of the IT Dashboard.  
+          </footnote>
+          <footnote emblem="30" marker="30">
+            Consistent with OMB Circular A-131, the term “cost savings” refers to “a reduction in actual expenditures below  
+            the projected level of costs to achieve a specific objective,” and the term “cost avoidance” refers to “an action taken  
+            in the immediate time frame that will decrease costs in the future.”  
+          </footnote>
         </para>
         <para>
           <content>
@@ -766,7 +848,7 @@
               
               
           </content>
-          <footnote emblem="31" marker="31">Excludes print servers. </footnote>
+          <footnote emblem="31" marker="31">Excludes print servers.  </footnote>
         </para>
         <para>
           <content>
@@ -793,8 +875,14 @@
             age.   
               
           </content>
-          <footnote emblem="32" marker="32">The baseline number of data centers is based on the agencies’ August 31, 2015, data center inventory submissions, as collected by OMB OFCIO through the Integrated Data Collection. </footnote>
-          <footnote emblem="33" marker="33">Estimated reduction in gross floor area of data centers is approximate and has been based on the average size, in square feet, of the data centers of each type to be closed. </footnote>
+          <footnote emblem="32" marker="32">
+            The baseline number of data centers is based on the agencies’ August 31, 2015, data center inventory submissions,  
+            as collected by OMB OFCIO through the Integrated Data Collection.  
+          </footnote>
+          <footnote emblem="33" marker="33">
+            Estimated reduction in gross floor area of data centers is approximate and has been based on the average size, in  
+            square feet, of the data centers of each type to be closed.  
+          </footnote>
         </para>
         <para>
           <content>
@@ -855,7 +943,10 @@
                 <footnote_citation>34</footnote_citation>
                   
               </content>
-              <footnote emblem="34" marker="34">Note: Agencies participating as a tenant in an inter-agency shared services provider data center are not required to report metric values to OMB. The provider will report this data to OMB. </footnote>
+              <footnote emblem="34" marker="34">
+                Note: Agencies participating as a tenant in an inter-agency shared services provider data center are not required to  
+                report metric values to OMB. The provider will report this data to OMB.  
+              </footnote>
             </para>
           </listitem>
           <listitem emblem="3" marker="3.">
@@ -886,7 +977,7 @@
             replace existing FDCCI requirements for consolidation plans.   
               
           </content>
-          <footnote emblem="35" marker="35">See FITARA Section 834(b)(1)(A)-(E). </footnote>
+          <footnote emblem="35" marker="35">See FITARA Section 834(b)(1)(A)-(E).  </footnote>
         </para>
         <para>
           <content>
@@ -998,7 +1089,7 @@
           established herein and relative to agencies’ Strategic Plans.   
             
         </content>
-        <footnote emblem="36" marker="36">See 2015 NDAA Section 834(b)(2)(C). </footnote>
+        <footnote emblem="36" marker="36">See 2015 NDAA Section 834(b)(2)(C).  </footnote>
       </para>
       <para>
         <content>
@@ -1062,7 +1153,9 @@
             
         </content>
       </para>
-      <!--Uncited footnote #28: “Active” racks are those that have IT equipment consuming electricity. -->
+      <!--Begin uncited footnote #28-->
+      <!--“Active” racks are those that have IT equipment consuming electricity.  -->
+      <!--End uncited footnote #28-->
     </sec>
   </sec>
 </policy>

--- a/api/ombpdf/tests/test_semhtml.snapshot.html
+++ b/api/ombpdf/tests/test_semhtml.snapshot.html
@@ -586,75 +586,146 @@ become available.
 <h2>Footnotes</h2>
 <dl>
 <dt id="footnote-1">1</dt>
-<dd>The FDCCI was first established by OMB “Memo for CIOs: Federal Data Center Consolidation Initiative,” issued on February 26, 2010, and modified by subsequent memoranda.  <a href="#footnote-citation-1">Back to citation</a></dd>
+<dd>The FDCCI was first established by OMB “Memo for CIOs: Federal Data Center Consolidation Initiative,” issued 
+on February 26, 2010, and modified by subsequent memoranda. 
+ <a href="#footnote-citation-1">Back to citation</a></dd>
 <dt id="footnote-2">2</dt>
-<dd>Title VIII, Subtitle D of the National Defense Authorization Act (NDAA) for Fiscal Year 2015, Pub. L. No. 113-291.  <a href="#footnote-citation-2">Back to citation</a></dd>
+<dd>Title VIII, Subtitle D of the National Defense Authorization Act (NDAA) for Fiscal Year 2015, Pub. L. No. 113-
+291. 
+ <a href="#footnote-citation-2">Back to citation</a></dd>
 <dt id="footnote-3">3</dt>
-<dd>This office was established in accordance with Section 101 of the E-government Act of 2002, codified at 44 U.S.C. § 3602, and is headed by the Federal government Chief Information Officer.  This office will also be referred to as OMB’s Office of the Federal Chief Information Officer (OFCIO).    <a href="#footnote-citation-3">Back to citation</a></dd>
+<dd>This office was established in accordance with Section 101 of the E-government Act of 2002, codified at 44 U.S.C. 
+§ 3602, and is headed by the Federal government Chief Information Officer.  This office will also be referred to as 
+OMB’s Office of the Federal Chief Information Officer (OFCIO).   
+ <a href="#footnote-citation-3">Back to citation</a></dd>
 <dt id="footnote-4">4</dt>
-<dd>Federal Information Technology Shared Services Strategy, May 2, 2012, https://www.whitehouse.gov/sites/default/files/omb/assets/egov_docs/shared_services_strategy.pdf.  <a href="#footnote-citation-4">Back to citation</a></dd>
+<dd>Federal Information Technology Shared Services Strategy, May 2, 2012, 
+https://www.whitehouse.gov/sites/default/files/omb/assets/egov_docs/shared_services_strategy.pdf. 
+ <a href="#footnote-citation-4">Back to citation</a></dd>
 <dt id="footnote-5">5</dt>
-<dd>See Chief Financial Officers Act of 1990, Pub. L. No. 101–576.  <a href="#footnote-citation-5">Back to citation</a></dd>
+<dd>See Chief Financial Officers Act of 1990, Pub. L. No. 101–576. 
+ <a href="#footnote-citation-5">Back to citation</a></dd>
 <dt id="footnote-6">6</dt>
-<dd>Per Sec. 834(b)(1)(C) of the FY2015 NDAA, the Department of Defense may submit to OMB, in lieu of the Strategic Plan described in this memorandum, the defense-wide plan and cost savings report required under sections 2867(b)(2) and 2867(d), respectively, of the FY2012 NDAA.  If submitting such plans and reports in lieu of the Strategic Plan, DOD shall ensure all information required by the Strategic Plan is included in the submitted plans and reports.  <a href="#footnote-citation-6">Back to citation</a></dd>
+<dd>Per Sec. 834(b)(1)(C) of the FY2015 NDAA, the Department of Defense may submit to OMB, in lieu of the 
+Strategic Plan described in this memorandum, the defense-wide plan and cost savings report required under sections 
+2867(b)(2) and 2867(d), respectively, of the FY2012 NDAA.  If submitting such plans and reports in lieu of the 
+Strategic Plan, DOD shall ensure all information required by the Strategic Plan is included in the submitted plans 
+and reports. 
+ <a href="#footnote-citation-6">Back to citation</a></dd>
 <dt id="footnote-7">7</dt>
-<dd>Title VIII, Subtitle D of the National Defense Authorization Act (NDAA) for Fiscal Year 2015, Pub. L. No. 113-291.   <a href="#footnote-citation-7">Back to citation</a></dd>
+<dd>Title VIII, Subtitle D of the National Defense Authorization Act (NDAA) for Fiscal Year 2015, Pub. L. No. 113-
+291.  
+ <a href="#footnote-citation-7">Back to citation</a></dd>
 <dt id="footnote-8">8</dt>
-<dd>OMB Memorandum M-15-14, “Management and Oversight of Federal Information Technology,” June 10, 2015, https://www.whitehouse.gov/sites/default/files/omb/memoranda/2015/m-15-14.pdf.  <a href="#footnote-citation-8">Back to citation</a></dd>
+<dd>OMB Memorandum M-15-14, “Management and Oversight of Federal Information Technology,” June 10, 2015, 
+https://www.whitehouse.gov/sites/default/files/omb/memoranda/2015/m-15-14.pdf. 
+ <a href="#footnote-citation-8">Back to citation</a></dd>
 <dt id="footnote-9">9</dt>
-<dd>The General Services Administration (GSA) Office of Government-wide Policy (OGP) will coordinate with OMB to define thresholds for what constitutes “significant” expansion within 60 days of publication of this memorandum.  <a href="#footnote-citation-9">Back to citation</a></dd>
+<dd>The General Services Administration (GSA) Office of Government-wide Policy (OGP) will coordinate with OMB 
+to define thresholds for what constitutes “significant” expansion within 60 days of publication of this memorandum. 
+ <a href="#footnote-citation-9">Back to citation</a></dd>
 <dt id="footnote-10">10</dt>
-<dd>Data centers certified by GSA OGP as Inter-agency Shared Service Provider data centers are excluded from this development freeze.  <a href="#footnote-citation-10">Back to citation</a></dd>
+<dd>Data centers certified by GSA OGP as Inter-agency Shared Service Provider data centers are excluded from this 
+development freeze. 
+ <a href="#footnote-citation-10">Back to citation</a></dd>
 <dt id="footnote-11">11</dt>
-<dd>This requirement does not apply to GSA OGP designated inter-agency shared services data centers.  <a href="#footnote-citation-11">Back to citation</a></dd>
+<dd>This requirement does not apply to GSA OGP designated inter-agency shared services data centers. 
+ <a href="#footnote-citation-11">Back to citation</a></dd>
 <dt id="footnote-12">12</dt>
-<dd>Federal Cloud Computing Strategy, February 8, 2011, https://www.whitehouse.gov/sites/default/files/omb/assets/egov_docs/federal-cloud-computing-strategy.pdf.  <a href="#footnote-citation-12">Back to citation</a></dd>
+<dd>Federal Cloud Computing Strategy, February 8, 2011, 
+https://www.whitehouse.gov/sites/default/files/omb/assets/egov_docs/federal-cloud-computing-strategy.pdf. 
+ <a href="#footnote-citation-12">Back to citation</a></dd>
 <dt id="footnote-13">13</dt>
-<dd>Ibid.  <a href="#footnote-citation-13">Back to citation</a></dd>
+<dd>Ibid. 
+ <a href="#footnote-citation-13">Back to citation</a></dd>
 <dt id="footnote-14">14</dt>
-<dd>See FY2015 NDAA Sec. 834(3)(c).  <a href="#footnote-citation-14">Back to citation</a></dd>
+<dd>See FY2015 NDAA Sec. 834(3)(c). 
+ <a href="#footnote-citation-14">Back to citation</a></dd>
 <dt id="footnote-15">15</dt>
-<dd>Formed in 2004, lines of business (LOB) are cross-agency initiatives to define, design, implement and monitor a set of common solutions for government-wide business functions, processes, or desires capabilities. Each LOB is governed by a Managing Partner which is designated as the lead organization responsible for managing the business requirements of their community.  <a href="#footnote-citation-15">Back to citation</a></dd>
+<dd>Formed in 2004, lines of business (LOB) are cross-agency initiatives to define, design, implement and monitor a 
+set of common solutions for government-wide business functions, processes, or desires capabilities. Each LOB is 
+governed by a Managing Partner which is designated as the lead organization responsible for managing the business 
+requirements of their community. 
+ <a href="#footnote-citation-15">Back to citation</a></dd>
 <dt id="footnote-16">16</dt>
-<dd>Data centers containing only print servers that were previously reported as “closed” shall remain classified as closed data centers in agencies’ data center reporting.  <a href="#footnote-citation-16">Back to citation</a></dd>
+<dd>Data centers containing only print servers that were previously reported as “closed” shall remain classified as 
+closed data centers in agencies’ data center reporting. 
+ <a href="#footnote-citation-16">Back to citation</a></dd>
 <dt id="footnote-17">17</dt>
-<dd>The term “tiered” and the definitions that follow are derived from the Uptime Institute’s Tier Classification System; however, this shall not be construed as requiring any certification in order for a data center to be considered tiered by OMB.  <a href="#footnote-citation-17">Back to citation</a></dd>
+<dd>The term “tiered” and the definitions that follow are derived from the Uptime Institute’s Tier Classification 
+System; however, this shall not be construed as requiring any certification in order for a data center to be considered 
+tiered by OMB. 
+ <a href="#footnote-citation-17">Back to citation</a></dd>
 <dt id="footnote-18">18</dt>
-<dd>Data centers previously classified as tiered in past inventories will automatically be classified as tiered under the DCOI.  <a href="#footnote-citation-18">Back to citation</a></dd>
+<dd>Data centers previously classified as tiered in past inventories will automatically be classified as tiered under the 
+DCOI. 
+ <a href="#footnote-citation-18">Back to citation</a></dd>
 <dt id="footnote-19">19</dt>
-<dd>Executive Order, “Planning for Federal Sustainability in the Next Decade” https://www.whitehouse.gov/the-press-office/2015/03/19/executive-order-planning-federal-sustainability-next-decade.    <a href="#footnote-citation-19">Back to citation</a></dd>
+<dd>Executive Order, “Planning for Federal Sustainability in the Next Decade” https://www.whitehouse.gov/the-press-
+office/2015/03/19/executive-order-planning-federal-sustainability-next-decade.   
+ <a href="#footnote-citation-19">Back to citation</a></dd>
 <dt id="footnote-20">20</dt>
-<dd>While Executive Order 13693 requires advanced energy metering in all data centers, OMB will monitor PUE for tiered data centers only.  <a href="#footnote-citation-20">Back to citation</a></dd>
+<dd>While Executive Order 13693 requires advanced energy metering in all data centers, OMB will monitor PUE for 
+tiered data centers only. 
+ <a href="#footnote-citation-20">Back to citation</a></dd>
 <dt id="footnote-21">21</dt>
-<dd>See “Implementing Instructions for Executive Order 13693, ‘Planning for Federal Sustainability in the Next Decade’” https://www.whitehouse.gov/sites/default/files/docs/eo_13693_implementing_instructions_june_10_2015.pdf.   <a href="#footnote-citation-21">Back to citation</a></dd>
+<dd>See “Implementing Instructions for Executive Order 13693, ‘Planning for Federal Sustainability in the Next 
+Decade’” 
+https://www.whitehouse.gov/sites/default/files/docs/eo_13693_implementing_instructions_june_10_2015.pdf.  
+ <a href="#footnote-citation-21">Back to citation</a></dd>
 <dt id="footnote-22">22</dt>
-<dd>This can be PUE for the facility as a whole in cases where the agency only contracts for a portion of a larger facility; however, if PUE metrics are available specific to the agency’s use, that is preferred.  <a href="#footnote-citation-22">Back to citation</a></dd>
+<dd>This can be PUE for the facility as a whole in cases where the agency only contracts for a portion of a larger 
+facility; however, if PUE metrics are available specific to the agency’s use, that is preferred. 
+ <a href="#footnote-citation-22">Back to citation</a></dd>
 <dt id="footnote-23">23</dt>
-<dd>For non-tiered data centers, only automated monitoring of server utilization is required.  <a href="#footnote-citation-23">Back to citation</a></dd>
+<dd>For non-tiered data centers, only automated monitoring of server utilization is required. 
+ <a href="#footnote-citation-23">Back to citation</a></dd>
 <dt id="footnote-24">24</dt>
-<dd>While agencies should strive to achieve each applicable optimization target for each data center, only PUE targets will be calculated on a per-data center basis. All other targets will be calculated at the agency inventory-level.  <a href="#footnote-citation-24">Back to citation</a></dd>
+<dd>While agencies should strive to achieve each applicable optimization target for each data center, only PUE targets 
+will be calculated on a per-data center basis. All other targets will be calculated at the agency inventory-level. 
+ <a href="#footnote-citation-24">Back to citation</a></dd>
 <dt id="footnote-25">25</dt>
-<dd>“Total gross floor area” is defined as total square footage available for IT equipment and includes all associated corridors, walkways, and air circulation requirements. This does not include office space, mechanical rooms, or storage areas.  <a href="#footnote-citation-25">Back to citation</a></dd>
+<dd>“Total gross floor area” is defined as total square footage available for IT equipment and includes all associated 
+corridors, walkways, and air circulation requirements. This does not include office space, mechanical rooms, or 
+storage areas. 
+ <a href="#footnote-citation-25">Back to citation</a></dd>
 <dt id="footnote-26">26</dt>
-<dd>PUE shall be calculated by OMB based on quarterly average IT and facility electricity usage data.   <a href="#footnote-citation-26">Back to citation</a></dd>
+<dd>PUE shall be calculated by OMB based on quarterly average IT and facility electricity usage data.  
+ <a href="#footnote-citation-26">Back to citation</a></dd>
 <dt id="footnote-27">27</dt>
-<dd>Server utilization shall be collected continuously and reported as a quarterly average.  <a href="#footnote-citation-27">Back to citation</a></dd>
+<dd>Server utilization shall be collected continuously and reported as a quarterly average. 
+ <a href="#footnote-citation-27">Back to citation</a></dd>
 <dt id="footnote-28">28</dt>
-<dd>“Active” racks are those that have IT equipment consuming electricity. </dd>
+<dd>“Active” racks are those that have IT equipment consuming electricity. 
+</dd>
 <dt id="footnote-29">29</dt>
-<dd>Benchmarked against the sum of all non-cloud data center costs (including data center labor, software, hardware, electricity, and facility) found in physical data center fields of the IT Inventory Summary Table of the IT Dashboard.  <a href="#footnote-citation-29">Back to citation</a></dd>
+<dd>Benchmarked against the sum of all non-cloud data center costs (including data center labor, software, hardware, 
+electricity, and facility) found in physical data center fields of the IT Inventory Summary Table of the IT Dashboard. 
+ <a href="#footnote-citation-29">Back to citation</a></dd>
 <dt id="footnote-30">30</dt>
-<dd>Consistent with OMB Circular A-131, the term “cost savings” refers to “a reduction in actual expenditures below the projected level of costs to achieve a specific objective,” and the term “cost avoidance” refers to “an action taken in the immediate time frame that will decrease costs in the future.”  <a href="#footnote-citation-30">Back to citation</a></dd>
+<dd>Consistent with OMB Circular A-131, the term “cost savings” refers to “a reduction in actual expenditures below 
+the projected level of costs to achieve a specific objective,” and the term “cost avoidance” refers to “an action taken 
+in the immediate time frame that will decrease costs in the future.” 
+ <a href="#footnote-citation-30">Back to citation</a></dd>
 <dt id="footnote-31">31</dt>
-<dd>Excludes print servers.  <a href="#footnote-citation-31">Back to citation</a></dd>
+<dd>Excludes print servers. 
+ <a href="#footnote-citation-31">Back to citation</a></dd>
 <dt id="footnote-32">32</dt>
-<dd>The baseline number of data centers is based on the agencies’ August 31, 2015, data center inventory submissions, as collected by OMB OFCIO through the Integrated Data Collection.  <a href="#footnote-citation-32">Back to citation</a></dd>
+<dd>The baseline number of data centers is based on the agencies’ August 31, 2015, data center inventory submissions, 
+as collected by OMB OFCIO through the Integrated Data Collection. 
+ <a href="#footnote-citation-32">Back to citation</a></dd>
 <dt id="footnote-33">33</dt>
-<dd>Estimated reduction in gross floor area of data centers is approximate and has been based on the average size, in square feet, of the data centers of each type to be closed.  <a href="#footnote-citation-33">Back to citation</a></dd>
+<dd>Estimated reduction in gross floor area of data centers is approximate and has been based on the average size, in 
+square feet, of the data centers of each type to be closed. 
+ <a href="#footnote-citation-33">Back to citation</a></dd>
 <dt id="footnote-34">34</dt>
-<dd>Note: Agencies participating as a tenant in an inter-agency shared services provider data center are not required to report metric values to OMB. The provider will report this data to OMB.  <a href="#footnote-citation-34">Back to citation</a></dd>
+<dd>Note: Agencies participating as a tenant in an inter-agency shared services provider data center are not required to 
+report metric values to OMB. The provider will report this data to OMB. 
+ <a href="#footnote-citation-34">Back to citation</a></dd>
 <dt id="footnote-35">35</dt>
-<dd>See FITARA Section 834(b)(1)(A)-(E).  <a href="#footnote-citation-35">Back to citation</a></dd>
+<dd>See FITARA Section 834(b)(1)(A)-(E). 
+ <a href="#footnote-citation-35">Back to citation</a></dd>
 <dt id="footnote-36">36</dt>
-<dd>See 2015 NDAA Section 834(b)(2)(C).  <a href="#footnote-citation-36">Back to citation</a></dd>
+<dd>See 2015 NDAA Section 834(b)(2)(C). 
+ <a href="#footnote-citation-36">Back to citation</a></dd>
 </dl>


### PR DESCRIPTION
~~This fixes the core problem presented by #782, though it doesn't actually resolve that issue itself, because it still keeps the full text of a footnote as part of the `OMBFootnote` annotation. Actually fixing the latter will take some effort because the footnote tests rely on it so much, but it's not that high a priority.~~

This fixes #782.

Note that we don't actually _have_ any inline rich text markup in `semtree.py`, so this doesn't actually do a whole lot, but eventually we will support inline rich text markup, so it's nice to know it'll automatically work okay when it's in footnotes.

The changes in the snapshot files are due to us delegating the content of footnotes to the same logic we use for any block content, like paragraph text.  Because this logic is slightly different from the logic for calculating the text of footnotes--largely involving the handling of whitespace--the snapshots are different.
