### PR TITLE
Remove CDN'd version of KaTeX css.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules
 reqs/static/js/bundle.js
 ui-dist
 ui/static/font/fontawesome-webfont*
+ui/static/font/KaTeX*
 ui/static/styles.css*
 jest*
 ui/lcov-report/

--- a/ui/components/header-footer.js
+++ b/ui/components/header-footer.js
@@ -73,7 +73,6 @@ export default function HeaderFooter({ children, showSearch, wrapperClassName })
     <React.Fragment>
       <Head>
         <link rel="stylesheet" href="/static/styles.css" />
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-alpha1/katex.min.css" integrity="sha384-8QOKbPtTFvh/lMY0qPVbXj9hDh+v8US0pD//FcoYFst2lCIf0BmT58+Heqj0IGyx" crossOrigin="anonymous" />
         <script
           async
           type="text/javascript"

--- a/ui/css/main.scss
+++ b/ui/css/main.scss
@@ -8,6 +8,7 @@ $fa-font-path: '~font-awesome/fonts';
 @import '~font-awesome/scss/font-awesome';
 @import '~basscss-sass/scss/basscss';
 @import '~nprogress/nprogress.css';
+@import '~katex/dist/katex.css';
 
 // App-wide
 @import 'base/colors';


### PR DESCRIPTION
We can embed the CSS directly from our local node package, which ensures the
CSS and JS stay in sync.