### PR TITLE
Add a BrowsableAkomaNtosoRenderer

### DIFF
--- a/api/document/renderers.py
+++ b/api/document/renderers.py
@@ -60,3 +60,10 @@ class AkomaNtosoRenderer(renderers.BaseRenderer):
     def render(self, data, media_type=None, renderer_context=None):
         as_xml = node_to_xml(data)
         return etree.tostring(as_xml, encoding=self.charset, pretty_print=True)
+
+
+class BrowsableAkomaNtosoRenderer(renderers.BrowsableAPIRenderer):
+    format = 'akn-api'  # noqa
+
+    def get_default_renderer(self, view):
+        return AkomaNtosoRenderer()

--- a/api/document/templates/rest_framework/api.html
+++ b/api/document/templates/rest_framework/api.html
@@ -1,0 +1,19 @@
+{% extends "rest_framework/base.html" %}
+
+{% load staticfiles %}
+
+{% block title %}{% if name %}{{ name }} – {% endif %}OMB Policy Library API (Beta){% endblock %}
+
+{% block branding %}
+  <a class="navbar-brand" href="/">OMB Policy Library API (Beta)</a>
+{% endblock %}
+
+{% block bootstrap_theme %}
+  <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap.min.css" %}"/>
+  <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap-tweaks.css" %}"/>
+  <style>
+  pre.prettyprint {
+    white-space: pre-wrap;
+  }
+  </style>
+{% endblock %}

--- a/api/document/tests/renderers_test.py
+++ b/api/document/tests/renderers_test.py
@@ -151,3 +151,10 @@ def test_renderer_pretty():
         b'  <content>Beginning <wrapper>stuff</wrapper></content>\n'
         b'</a_node>\n'
     )
+
+
+def test_browsable_akn_uses_akn_renderer():
+    assert isinstance(
+        renderers.BrowsableAkomaNtosoRenderer().get_default_renderer(None),
+        renderers.AkomaNtosoRenderer
+    )

--- a/api/document/views.py
+++ b/api/document/views.py
@@ -4,7 +4,7 @@ from rest_framework.generics import RetrieveAPIView
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 
 from document.models import DocNode, FootnoteCitation, InlineRequirement
-from document.renderers import AkomaNtosoRenderer
+from document.renderers import AkomaNtosoRenderer, BrowsableAkomaNtosoRenderer
 from document.serializers.doc_cursor import DocCursorSerializer
 from document.tree import DocCursor
 from reqs.views.policies import policy_or_404
@@ -30,7 +30,7 @@ def optimize(queryset):
 class TreeView(RetrieveAPIView):
     serializer_class = DocCursorSerializer
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer,
-                        AkomaNtosoRenderer)
+                        AkomaNtosoRenderer, BrowsableAkomaNtosoRenderer)
     queryset = DocNode.objects.none()   # Used to determine permissions
 
     def get_object(self):


### PR DESCRIPTION
This minorly builds on #795 by making the AKN renderer easy to browse, which I think could be helpful for debugging. Currently, clicking the "akn" format in the browsable API (under the "GET" button/popup) triggers a download, which one then has to find and open in their text editor, whereas this PR adds an "akn-api" format that [trivially customizes `BrowsableAPIRenderer`](http://www.django-rest-framework.org/api-guide/renderers/#customizing-browsableapirenderer) to present the XML response in a syntax-highlighted web view, similar to how the normal JSON responses are presented:

> ![screenshot-2017-12-20 tree omb policy library api beta](https://user-images.githubusercontent.com/124687/34234182-932ce1be-e5b7-11e7-9d32-bc6e461d64fd.png)

It also overrides `rest_framework/api.html`'s [`{% bootstrap_theme %}` block](http://www.django-rest-framework.org/topics/browsable-api/#overriding-the-default-theme) with a bit of well-targeted CSS to ensure that readers don't have to horizontally scroll to see all the content. While I was at it, I also changed the page's title and branding to reflect the OMB Policy API rather than Django Rest Framework.
