### PR TITLE
Skip intermediary XML layer from pdf

### DIFF
--- a/api/.docker/watch_tests.sh
+++ b/api/.docker/watch_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-ptw document ereqs_admin omb_eregs reqs "$@"
+ptw document ereqs_admin omb_eregs ombpdf reqs "$@"

--- a/api/document/models.py
+++ b/api/document/models.py
@@ -8,9 +8,9 @@ from reqs.models import Policy, Requirement
 
 class DocNode(models.Model):
     policy = models.ForeignKey(Policy, on_delete=models.CASCADE)
-    # e.g. part_447__subpart_A__sect_1__par_b
+    # e.g. part_447__subpart_A__sec_1__para_b
     identifier = models.CharField(max_length=1024)
-    # e.g. par
+    # e.g. para
     node_type = models.CharField(max_length=64)
     # e.g. b
     type_emblem = models.CharField(max_length=16)

--- a/api/document/models.py
+++ b/api/document/models.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Iterator
+from typing import Iterator, List
 
 from django.db import models
 
@@ -36,6 +36,11 @@ class DocNode(models.Model):
         return queryset.filter(
             left__gt=self.left, right__lt=self.right, policy_id=self.policy_id
         ).order_by('left')
+
+    def ancestor_node_types(self) -> List[str]:
+        # reverse so we get the closest ancestor first
+        ancestry = reversed(self.identifier.split('__'))
+        return [ident.rsplit('_')[0] for ident in ancestry]
 
     def annotations(self) -> Iterator['Annotation']:
         """Query all of our annotation types."""

--- a/api/document/tests/serializers/doc_cursor_test.py
+++ b/api/document/tests/serializers/doc_cursor_test.py
@@ -17,11 +17,11 @@ def test_end_to_end():
         title='Some Title', uri='http://example.com/thing.pdf',
     )
     root = DocCursor.new_tree('root', '0', policy=policy, title='Policy A')
-    root.add_child('sect', text='Section 1', title='First Section')
-    sect2 = root.add_child('sect', title='Section 2')
-    pa = sect2.add_child('par', 'a', marker='(a)')
-    pa.add_child('par', '1', text='Paragraph (a)(1)', marker='(1)')
-    sect2.add_child('par', 'b', marker='b.')
+    root.add_child('sec', text='Section 1', title='First Section')
+    sec2 = root.add_child('sec', title='Section 2')
+    pa = sec2.add_child('para', 'a', marker='(a)')
+    pa.add_child('para', '1', text='Paragraph (a)(1)', marker='(1)')
+    sec2.add_child('para', 'b', marker='b.')
     root.nested_set_renumber()
 
     result = doc_cursor.DocCursorSerializer(
@@ -50,11 +50,11 @@ def test_end_to_end():
                 'children': [
                     {
                         'children': [],
-                        'identifier': 'root_0__sect_1',
+                        'identifier': 'root_0__sec_1',
                         'title': 'First Section',
                     }, {
                         'children': [],
-                        'identifier': 'root_0__sect_2',
+                        'identifier': 'root_0__sec_2',
                         'title': 'Section 2',
                     },
                 ],
@@ -62,8 +62,8 @@ def test_end_to_end():
         },
         'children': [
             {
-                'identifier': 'root_0__sect_1',
-                'node_type': 'sect',
+                'identifier': 'root_0__sec_1',
+                'node_type': 'sec',
                 'type_emblem': '1',
                 'text': 'Section 1',
                 'title': 'First Section',
@@ -78,8 +78,8 @@ def test_end_to_end():
                 'children': [],
             },
             {
-                'identifier': 'root_0__sect_2',
-                'node_type': 'sect',
+                'identifier': 'root_0__sec_2',
+                'node_type': 'sec',
                 'type_emblem': '2',
                 'text': '',
                 'title': 'Section 2',
@@ -89,8 +89,8 @@ def test_end_to_end():
                 'content': [],
                 'children': [
                     {
-                        'identifier': 'root_0__sect_2__par_a',
-                        'node_type': 'par',
+                        'identifier': 'root_0__sec_2__para_a',
+                        'node_type': 'para',
                         'type_emblem': 'a',
                         'text': '',
                         'title': '',
@@ -100,8 +100,8 @@ def test_end_to_end():
                         'content': [],
                         'children': [
                             {
-                                'identifier': 'root_0__sect_2__par_a__par_1',
-                                'node_type': 'par',
+                                'identifier': 'root_0__sec_2__para_a__para_1',
+                                'node_type': 'para',
                                 'type_emblem': '1',
                                 'text': 'Paragraph (a)(1)',
                                 'title': '',
@@ -118,8 +118,8 @@ def test_end_to_end():
                         ],
                     },
                     {
-                        'identifier': 'root_0__sect_2__par_b',
-                        'node_type': 'par',
+                        'identifier': 'root_0__sec_2__para_b',
+                        'node_type': 'para',
                         'type_emblem': 'b',
                         'text': '',
                         'title': '',

--- a/api/document/tests/tree_test.py
+++ b/api/document/tests/tree_test.py
@@ -17,28 +17,28 @@ def test_new_tree():
 
 def test_item_access():
     root = tree.DocCursor.new_tree('root', '0')
-    sec1 = root.add_child('sect', '1', text='section 1')
-    root.add_child('sect', '2', text='section 2')
-    sec1.add_child('par', 'a', text='paragraph a')
-    sec1.add_child('par', 'b')
+    sec1 = root.add_child('sec', '1', text='section 1')
+    root.add_child('sec', '2', text='section 2')
+    sec1.add_child('para', 'a', text='paragraph a')
+    sec1.add_child('para', 'b')
 
-    assert root['sect_1'].text == 'section 1'
-    assert root['sect_2'].text == 'section 2'
-    assert root['sect_1']['par_a'].text == 'paragraph a'
+    assert root['sec_1'].text == 'section 1'
+    assert root['sec_2'].text == 'section 2'
+    assert root['sec_1']['para_a'].text == 'paragraph a'
 
 
 def test_depths():
     root = tree.DocCursor.new_tree('root', '0')
-    sec1 = root.add_child('sect')
-    root.add_child('sect')
-    sec1.add_child('par', 'a')
-    sec1.add_child('par', 'b')
+    sec1 = root.add_child('sec')
+    root.add_child('sec')
+    sec1.add_child('para', 'a')
+    sec1.add_child('para', 'b')
 
     assert root.depth == 0
-    assert root['sect_1'].depth == 1
-    assert root['sect_2'].depth == 1
-    assert root['sect_1']['par_a'].depth == 2
-    assert root['sect_1']['par_b'].depth == 2
+    assert root['sec_1'].depth == 1
+    assert root['sec_2'].depth == 1
+    assert root['sec_1']['para_a'].depth == 2
+    assert root['sec_1']['para_b'].depth == 2
 
 
 def test_children_are_sorted():
@@ -54,42 +54,42 @@ def test_children_are_sorted():
 
 def test_next_emblem():
     root = tree.DocCursor.new_tree('root', '0')
-    root.add_child('sect')
-    root.add_child('sect')
-    root.add_child('sect')
+    root.add_child('sec')
+    root.add_child('sec')
+    root.add_child('sec')
     root.add_child('appendix')
     root.add_child('appendix')
 
-    assert root.next_emblem('sect') == '4'
+    assert root.next_emblem('sec') == '4'
     assert root.next_emblem('appendix') == '3'
     assert set(root.tree.nodes()) == {
-        'root_0', 'root_0__sect_1', 'root_0__sect_2', 'root_0__sect_3',
+        'root_0', 'root_0__sec_1', 'root_0__sec_2', 'root_0__sec_3',
         'root_0__appendix_1', 'root_0__appendix_2',
     }
 
 
 def test_walk():
     root = tree.DocCursor.new_tree('root', '0')
-    sect1 = root.add_child('sect')
-    sect2 = root.add_child('sect')
-    sect1.add_child('par', 'a')
-    sect1.add_child('par', 'b')
-    sect2.add_child('par', '1')
+    sec1 = root.add_child('sec')
+    sec2 = root.add_child('sec')
+    sec1.add_child('para', 'a')
+    sec1.add_child('para', 'b')
+    sec2.add_child('para', '1')
 
     idents = [n.identifier for n in root.walk()]
     assert idents == [
-        'root_0', 'root_0__sect_1', 'root_0__sect_1__par_a',
-        'root_0__sect_1__par_b', 'root_0__sect_2', 'root_0__sect_2__par_1',
+        'root_0', 'root_0__sec_1', 'root_0__sec_1__para_a',
+        'root_0__sec_1__para_b', 'root_0__sec_2', 'root_0__sec_2__para_1',
     ]
 
 
 def test_nested_sets():
     root = tree.DocCursor.new_tree('root', '0')
-    sect1 = root.add_child('sect')
-    sect2 = root.add_child('sect')
-    sect1.add_child('par', 'a')
-    sect1.add_child('par', 'b')
-    sect2.add_child('par', '1')
+    sec1 = root.add_child('sec')
+    sec2 = root.add_child('sec')
+    sec1.add_child('para', 'a')
+    sec1.add_child('para', 'b')
+    sec2.add_child('para', '1')
 
     assert root.subtree_size() == 6
     assert root.left is None
@@ -98,65 +98,65 @@ def test_nested_sets():
     root.nested_set_renumber(bulk_create=False)
 
     assert root.left == 1
-    assert root['sect_1'].left == 2
-    assert root['sect_1']['par_a'].left == 3
-    assert root['sect_1']['par_a'].right == 4
-    assert root['sect_1']['par_b'].left == 5
-    assert root['sect_1']['par_b'].right == 6
-    assert root['sect_1'].right == 7
-    assert root['sect_2'].left == 8
-    assert root['sect_2']['par_1'].left == 9
-    assert root['sect_2']['par_1'].right == 10
-    assert root['sect_2'].right == 11
+    assert root['sec_1'].left == 2
+    assert root['sec_1']['para_a'].left == 3
+    assert root['sec_1']['para_a'].right == 4
+    assert root['sec_1']['para_b'].left == 5
+    assert root['sec_1']['para_b'].right == 6
+    assert root['sec_1'].right == 7
+    assert root['sec_2'].left == 8
+    assert root['sec_2']['para_1'].left == 9
+    assert root['sec_2']['para_1'].right == 10
+    assert root['sec_2'].right == 11
     assert root.right == 12
 
 
 def test_parent():
     root = tree.DocCursor.new_tree('root', '0')
-    root.add_child('sect')
-    sect2 = root.add_child('sect')
-    pa = sect2.add_child('par', 'a')
-    pa.add_child('par', '1')
-    sect2.add_child('par', 'b')
+    root.add_child('sec')
+    sec2 = root.add_child('sec')
+    pa = sec2.add_child('para', 'a')
+    pa.add_child('para', '1')
+    sec2.add_child('para', 'b')
 
     assert root.parent() is None
-    assert root['sect_1'].parent().identifier == 'root_0'
-    assert root['sect_2'].parent().identifier == 'root_0'
-    assert root['sect_2']['par_a'].parent().identifier == 'root_0__sect_2'
-    assert root['sect_2']['par_b'].parent().identifier == 'root_0__sect_2'
-    assert root['sect_2']['par_a']['par_1'].parent().identifier \
-        == 'root_0__sect_2__par_a'
+    assert root['sec_1'].parent().identifier == 'root_0'
+    assert root['sec_2'].parent().identifier == 'root_0'
+    assert root['sec_2']['para_a'].parent().identifier == 'root_0__sec_2'
+    assert root['sec_2']['para_b'].parent().identifier == 'root_0__sec_2'
+    assert root['sec_2']['para_a']['para_1'].parent().identifier \
+        == 'root_0__sec_2__para_a'
 
 
 def test_ancestors():
     root = tree.DocCursor.new_tree('root', '0')
-    root.add_child('sect')
-    sect2 = root.add_child('sect')
-    pa = sect2.add_child('par', 'a')
-    pa1 = pa.add_child('par', '1')
-    pa1.add_child('par', 'i')
-    sect2.add_child('par', 'b')
+    root.add_child('sec')
+    sec2 = root.add_child('sec')
+    pa = sec2.add_child('para', 'a')
+    pa1 = pa.add_child('para', '1')
+    pa1.add_child('para', 'i')
+    sec2.add_child('para', 'b')
 
     assert [n.identifier for n in root.ancestors()] == []
     result = [n.identifier
-              for n in root['sect_2']['par_a']['par_1'].ancestors()]
+              for n in root['sec_2']['para_a']['para_1'].ancestors()]
     assert result == [
-        'root_0__sect_2__par_a',
-        'root_0__sect_2',
+        'root_0__sec_2__para_a',
+        'root_0__sec_2',
         'root_0',
     ]
     result = [
         n.identifier
-        for n in root['sect_2']['par_a']['par_1']['par_i'].ancestors(
-            lambda n: n.node_type == 'par')
+        for n in root['sec_2']['para_a']['para_1']['para_i'].ancestors(
+            lambda n: n.node_type == 'para')
     ]
-    assert result == ['root_0__sect_2__par_a__par_1', 'root_0__sect_2__par_a']
+    assert result == ['root_0__sec_2__para_a__para_1', 'root_0__sec_2__para_a']
     result = [
         n.identifier
-        for n in root['sect_2']['par_a']['par_1']['par_i'].ancestors(
-            lambda n: n.node_type == 'sect')
+        for n in root['sec_2']['para_a']['para_1']['para_i'].ancestors(
+            lambda n: n.node_type == 'sec')
     ]
-    assert result == ['root_0__sect_2']
+    assert result == ['root_0__sec_2']
 
 
 @pytest.mark.django_db
@@ -165,10 +165,10 @@ def test_create_save_load():
     data from the database."""
     policy = mommy.make(Policy)
     root = tree.DocCursor.new_tree('root', '0', text='Root', policy=policy)
-    sect1 = root.add_child('sect', text='First Section')
-    sect1.add_child('par', 'a')
-    sect1.add_child('par', 'b', text='Paragraph b')
-    root.add_child('sect')
+    sec1 = root.add_child('sec', text='First Section')
+    sec1.add_child('para', 'a')
+    sec1.add_child('para', 'b', text='Paragraph b')
+    root.add_child('sec')
     app1 = root.add_child('appendix')
     app1.add_child('apppar', 'i', text='Appendix par i')
 
@@ -180,8 +180,8 @@ def test_create_save_load():
 
     assert new_root.subtree_size() == 7
     assert new_root.text == 'Root'
-    assert new_root['sect_1'].text == 'First Section'
-    assert new_root['sect_1']['par_b'].text == 'Paragraph b'
+    assert new_root['sec_1'].text == 'First Section'
+    assert new_root['sec_1']['para_b'].text == 'Paragraph b'
     assert new_root['appendix_1']['apppar_i'].text == 'Appendix par i'
 
 

--- a/api/document/tests/views_test.py
+++ b/api/document/tests/views_test.py
@@ -16,15 +16,15 @@ from reqs.models import Policy, Requirement
 def test_404s(client):
     policy = mommy.make(Policy)
     root = DocCursor.new_tree('root', '0', policy=policy)
-    root.add_child('sect')
+    root.add_child('sec')
     root.nested_set_renumber()
 
     assert client.get("/987654321").status_code == 404
     assert client.get(f"/{policy.pk}").status_code == 200
     assert client.get(f"/{policy.pk}/root_0").status_code == 200
     assert client.get(f"/{policy.pk}/root_1").status_code == 404
-    assert client.get(f"/{policy.pk}/root_0__sect_1").status_code == 200
-    assert client.get(f"/{policy.pk}/root_0__sect_2").status_code == 404
+    assert client.get(f"/{policy.pk}/root_0__sec_1").status_code == 200
+    assert client.get(f"/{policy.pk}/root_0__sec_2").status_code == 404
 
 
 @pytest.mark.django_db
@@ -32,9 +32,9 @@ def test_404s(client):
 def test_correct_data(client):
     policy = mommy.make(Policy)
     root = DocCursor.new_tree('root', '0', policy=policy)
-    sect1 = root.add_child('sect')
-    root.add_child('sect')
-    sect1.add_child('par', 'a')
+    sec1 = root.add_child('sec')
+    root.add_child('sec')
+    sec1.add_child('para', 'a')
     root.nested_set_renumber()
 
     def result(url):
@@ -45,10 +45,10 @@ def test_correct_data(client):
 
     assert result(f"/{policy.pk}") == serialize(root)
     assert result(f"/{policy.pk}/root_0") == serialize(root)
-    assert result(f"/{policy.pk}/root_0__sect_1") == serialize(root['sect_1'])
-    assert result(f"/{policy.pk}/root_0__sect_2") == serialize(root['sect_2'])
-    assert result(f"/{policy.pk}/root_0__sect_1__par_a") \
-        == serialize(root['sect_1']['par_a'])
+    assert result(f"/{policy.pk}/root_0__sec_1") == serialize(root['sec_1'])
+    assert result(f"/{policy.pk}/root_0__sec_2") == serialize(root['sec_2'])
+    assert result(f"/{policy.pk}/root_0__sec_1__para_a") \
+        == serialize(root['sec_1']['para_a'])
 
 
 @pytest.mark.django_db

--- a/api/document/tests/xml_importer/annotations_test.py
+++ b/api/document/tests/xml_importer/annotations_test.py
@@ -15,7 +15,7 @@ from reqs.models import Policy
 def test_footnote_annotations():
     policy = mommy.make(Policy)
     xml_span = etree.fromstring("<footnote_citation> 1  </footnote_citation>")
-    root = DocCursor.new_tree('sect', '2', policy=policy)
+    root = DocCursor.new_tree('sec', '2', policy=policy)
     for _ in range(8):
         root.add_child('para')
     root['para_2'].add_child('footnote', '3')  # not 1
@@ -33,7 +33,7 @@ def test_footnote_annotations():
 def test_footnote_annotations_missing(monkeypatch):
     monkeypatch.setattr(annotations.logger, 'warning', Mock())
     xml_span = etree.fromstring("<footnote_citation> 1  </footnote_citation>")
-    root = DocCursor.new_tree('sect', '2')
+    root = DocCursor.new_tree('sec', '2')
     for _ in range(8):
         root.add_child('para')
     root['para_2'].add_child('footnote', '3')  # not 1

--- a/api/ombpdf/semdb.py
+++ b/api/ombpdf/semdb.py
@@ -26,12 +26,13 @@ def to_db(doc, policy):
     builder.build()
 
     writer.cursor.nested_set_renumber()
-    # Account for a Django bug which prevents us from saving these
-    # directly due to saving the DocNodes in a bulk_insert
+    # Work around for a Django bug (arguably) that will insert nulls in place
+    # of foreign key ids
+    # See https://code.djangoproject.com/ticket/23449
     for footnote_citation in writer.footnote_citations.values():
         footnote_citation.doc_node = footnote_citation.doc_node
         footnote_citation.footnote_node = footnote_citation.footnote_node
-        footnote_citation.save()
+    FootnoteCitation.objects.bulk_create(writer.footnote_citations.values())
 
     return writer.cursor
 

--- a/api/ombpdf/semdb.py
+++ b/api/ombpdf/semdb.py
@@ -48,7 +48,7 @@ class DatabaseWriter(semtree.Writer):
 
     @property
     def sec_level(self):
-        return self.cursor.identifier.split('_').count('sec')
+        return self.cursor.ancestor_node_types().count('sec')
 
     def end_element(self, el):
         self.cursor.model.text = self.cursor.text.rstrip()

--- a/api/ombpdf/semdb.py
+++ b/api/ombpdf/semdb.py
@@ -1,12 +1,153 @@
-from lxml import etree
+import logging
 
-from document.xml_importer.importer import import_xml_doc
+from document.models import DocNode, FootnoteCitation
+from document.tree import DocCursor
 
-from . import semdom
+from . import semtree
+
+logger = logging.getLogger(__name__)
+
+
+class PDFAwareCursor(DocCursor):
+    """Extension of DocCursor which also tracks the PDF element which created
+    each node."""
+    @property
+    def pdf_node(self):
+        return self.tree.node[self.identifier].get('pdf_node')
+
+    @pdf_node.setter
+    def pdf_node(self, value):
+        self.tree.node[self.identifier]['pdf_node'] = value
 
 
 def to_db(doc, policy):
-    dom = semdom.to_dom(doc)
-    xml = etree.fromstring(dom.toxml())
-    root = import_xml_doc(policy, xml, ignore_preamble=True)
-    return root
+    writer = DatabaseWriter(policy)
+    builder = semtree.SemanticTreeBuilder(doc, writer)
+    builder.build()
+
+    writer.cursor.nested_set_renumber()
+    # Account for a Django bug which prevents us from saving these
+    # directly due to saving the DocNodes in a bulk_insert
+    for footnote_citation in writer.footnote_citations.values():
+        footnote_citation.doc_node = footnote_citation.doc_node
+        footnote_citation.footnote_node = footnote_citation.footnote_node
+        footnote_citation.save()
+
+    return writer.cursor
+
+
+class DatabaseWriter(semtree.Writer):
+    def __init__(self, policy):
+        self.cursor_stack = [PDFAwareCursor.new_tree('policy', policy=policy)]
+        self.footnote_citations = {}
+
+    @property
+    def cursor(self):
+        return self.cursor_stack[-1]
+
+    @property
+    def sec_level(self):
+        return self.cursor.identifier.split('_').count('sec')
+
+    def end_element(self, el):
+        self.cursor.model.text = self.cursor.text.rstrip()
+        super().end_element(el)
+
+    def begin_document(self, doc):
+        pass
+
+    def end_document(self, doc):
+        self.cursor_stack = self.cursor_stack[:1]
+
+    def begin_heading(self, heading):
+        while heading.level <= self.sec_level:
+            self.cursor_stack.pop()
+        while heading.level > self.sec_level:
+            self.cursor_stack.append(self.cursor.add_child('sec'))
+        self.cursor_stack.append(self.cursor.add_child('heading'))
+        self.cursor.pdf_node = heading
+
+    def end_heading(self, heading):
+        text = self.cursor.text.strip()
+        self.cursor_stack.pop()
+        max_length = DocNode._meta.get_field('title').max_length
+        if len(text) > max_length:
+            logger.warning('Heading too long. Misparse? %s', text)
+        self.cursor.model.title = text[:max_length]
+
+    def begin_paragraph(self, p):
+        self.cursor_stack.append(self.cursor.add_child('para'))
+        self.cursor.pdf_node = p
+
+    def end_paragraph(self, p):
+        self.cursor_stack.pop()
+
+    def begin_list(self, li):
+        self.cursor_stack.append(self.cursor.add_child('list'))
+        self.cursor.pdf_node = li
+
+    def end_list(self, li):
+        self.cursor_stack.pop()
+
+    def begin_list_item(self, p):
+        li = self.cursor.add_child('listitem')
+        self.cursor_stack.append(li.add_child('para'))
+        self.cursor.pdf_node = p
+
+        parent_list = next(
+            self.cursor.ancestors(lambda n: n.node_type == 'list'),
+            None,
+        )
+        if not parent_list:
+            logger.warning('Adding list item, but no list parent')
+            li.model.marker = '?'
+        elif parent_list.pdf_node.is_ordered:
+            li.model.marker = f'{li.model.type_emblem}.'
+        else:
+            li.model.marker = '\u2022'
+
+    def end_list_item(self, p):
+        self.cursor_stack.pop()
+
+    def begin_footnote_list(self, fl):
+        self.cursor_stack = self.cursor_stack[:1]
+
+    def end_footnote_list(self, fl):
+        no_nodes = [key for key, value in self.footnote_citations.items()
+                    if not value.footnote_node]
+        if no_nodes:
+            logger.warning('Unresolved footnote citations exist: %s', no_nodes)
+            for no_node_cite in no_nodes:
+                del self.footnote_citations[no_node_cite]
+
+    def begin_footnote(self, f):
+        child_args = {
+            'node_type': 'footnote',
+            'marker': str(f.number),
+            'type_emblem': str(f.number),
+        }
+        citation = self.footnote_citations.get(f.number)
+        if citation:
+            parent = self.cursor.jump_to(citation.doc_node.identifier)
+            self.cursor_stack.append(parent.add_child(**child_args))
+            citation.footnote_node = self.cursor.model
+        else:
+            logger.warning('Uncited footnote %s', f.number)
+            self.cursor_stack.append(self.cursor.add_child(**child_args))
+
+    def end_footnote(self, f):
+        self.cursor_stack.pop()
+
+    def create_footnote_citation(self, cit):
+        start = len(self.cursor.text)
+        cite_text = str(cit.number)
+        self.footnote_citations[cit.number] = FootnoteCitation(
+            doc_node=self.cursor.model, start=start, end=start + len(cite_text)
+        )
+        self.cursor.model.text += cite_text
+
+    def create_text(self, text):
+        if not self.cursor.text:
+            self.cursor.model.text = text.replace('\n', ' ').lstrip()
+        else:
+            self.cursor.model.text += text.replace('\n', ' ')

--- a/api/ombpdf/tests/test_semdb.py
+++ b/api/ombpdf/tests/test_semdb.py
@@ -3,7 +3,7 @@ from datetime import date
 import pytest
 from model_mommy import mommy
 
-from ombpdf import semdb
+from ombpdf import semdb, semtree
 from reqs.models import Policy
 
 
@@ -21,3 +21,110 @@ def test_m_14_10_import(m_14_10_doc):
     assert list(root.filter(
         lambda n: n.text.startswith(start) and n.text.endswith(end)
     ))
+
+
+def test_heading():
+    writer = semdb.DatabaseWriter(mommy.prepare(Policy))
+    elements = [
+        semtree.Heading(1),
+        semtree.Heading(3),     # skips a level
+        semtree.Heading(1),
+        semtree.Heading(2),
+    ]
+    for element in elements:
+        writer.begin_element(element)
+        writer.end_element(element)
+    writer.end_document(semtree.Document(''))
+    result = [n.identifier for n in writer.cursor.walk()]
+    assert result == [
+        'policy_1',
+        'policy_1__sec_1',
+        'policy_1__sec_1__heading_1',
+        'policy_1__sec_1__sec_1',
+        'policy_1__sec_1__sec_1__sec_1',
+        'policy_1__sec_1__sec_1__sec_1__heading_1',
+        'policy_1__sec_2',
+        'policy_1__sec_2__heading_1',
+        'policy_1__sec_2__sec_1',
+        'policy_1__sec_2__sec_1__heading_1',
+    ]
+
+
+def test_lists():
+    writer = semdb.DatabaseWriter(mommy.prepare(Policy))
+    outer = semtree.List(is_ordered=True)
+    inner = semtree.List(is_ordered=False)
+    item1, item2, item3 = (semtree.ListItem() for _ in range(3))
+    bullet1, bullet2 = (semtree.ListItem() for _ in range(2))
+
+    writer.begin_list(outer)
+    writer.begin_list_item(item1)
+    writer.end_list_item(item1)
+    writer.begin_list_item(item2)
+    writer.end_list_item(item2)
+    writer.begin_list(inner)
+    writer.begin_list_item(bullet1)
+    writer.end_list_item(bullet1)
+    writer.begin_list_item(bullet2)
+    writer.end_list_item(bullet2)
+    writer.end_list(inner)
+    writer.begin_list_item(item3)
+    writer.end_list_item(item3)
+    writer.end_document(semtree.Document(''))
+
+    result = [n.identifier for n in writer.cursor.walk()]
+    assert result == [
+        'policy_1',
+        'policy_1__list_1',
+        'policy_1__list_1__listitem_1',
+        'policy_1__list_1__listitem_1__para_1',
+        'policy_1__list_1__listitem_2',
+        'policy_1__list_1__listitem_2__para_1',
+        'policy_1__list_1__list_1',
+        'policy_1__list_1__list_1__listitem_1',
+        'policy_1__list_1__list_1__listitem_1__para_1',
+        'policy_1__list_1__list_1__listitem_2',
+        'policy_1__list_1__list_1__listitem_2__para_1',
+        'policy_1__list_1__listitem_3',
+        'policy_1__list_1__listitem_3__para_1',
+    ]
+
+    assert writer.cursor['list_1']['listitem_1'].marker == '1.'
+    assert writer.cursor['list_1']['list_1']['listitem_1'].marker == '\u2022'
+
+
+def test_footnotes():
+    writer = semdb.DatabaseWriter(mommy.prepare(Policy))
+    paras = [semtree.Paragraph() for _ in range(2)]
+    footnote_list = semtree.FootnoteList()
+    footnotes = [semtree.Footnote(i + 1) for i in range(3)]
+
+    writer.begin_paragraph(paras[0])
+    writer.create_text('Some stuff')
+    writer.create_footnote_citation(semtree.FootnoteCitation(1))
+    writer.create_text(' then2 more stuff')     # misparsed the second citation
+    writer.create_footnote_citation(semtree.FootnoteCitation(3))
+    writer.end_paragraph(paras[0])
+    writer.begin_paragraph(paras[1])
+    writer.end_paragraph(paras[1])
+    writer.begin_footnote_list(footnote_list)
+    for footnote in footnotes:
+        writer.begin_footnote(footnote)
+        writer.end_footnote(footnote)
+    writer.end_footnote_list(footnote_list)
+    writer.end_document(semtree.Document(''))
+
+    result = [n.identifier for n in writer.cursor.walk()]
+    assert result == [
+        'policy_1',
+        'policy_1__para_1',
+        'policy_1__para_1__footnote_1',
+        'policy_1__para_1__footnote_3',
+        'policy_1__para_2',
+        'policy_1__footnote_2',
+    ]
+
+    assert writer.cursor['para_1'].text == 'Some stuff1 then2 more stuff3'
+    assert writer.footnote_citations[1].start == len('Some stuff')
+    assert writer.footnote_citations[1].end == len('Some stuff1')
+    assert 2 not in writer.footnote_citations

--- a/api/setup.cfg
+++ b/api/setup.cfg
@@ -1,7 +1,7 @@
 [tool:pytest]
 python_files=test*.py *test.py *tests.py
 DJANGO_SETTINGS_MODULE=omb_eregs.settings
-testpaths=document/tests ereqs_admin/tests reqs/tests
+testpaths=document/tests ereqs_admin/tests ombpdf/tests reqs/tests
 
 [flake8]
 exclude = 


### PR DESCRIPTION
Rather than writing to XML then importing from that, this has the pdf import write directly to the database. Along the way, it also enables ombpdf tests from the py.test and ptw docker commands.