### PR TITLE
Display list item titles, if present.

### DIFF
--- a/ui/__tests__/components/node-renderers/list-item.test.js
+++ b/ui/__tests__/components/node-renderers/list-item.test.js
@@ -18,5 +18,16 @@ describe('<ListItem />', () => {
     const text = shallow(<ListItem docNode={docNode} />).text();
     expect(text).toMatch(/c\.!!!/);
   });
+  it('includes the title if present', () => {
+    const docNode = new DocumentNode({ title: 'Some title' });
+    const result = shallow(<ListItem docNode={docNode} />).find('.list-item-title');
+    expect(result).toHaveLength(1);
+    expect(result.text()).toBe('Some title');
+  });
+  it('does not include a title if not present', () => {
+    const docNode = new DocumentNode();
+    const result = shallow(<ListItem docNode={docNode} />).find('.list-item-title');
+    expect(result).toHaveLength(0);
+  });
 });
 

--- a/ui/components/node-renderers/list-item.js
+++ b/ui/components/node-renderers/list-item.js
@@ -5,10 +5,17 @@ import DocumentNode from '../../util/document-node';
 import renderNode from '../../util/render-node';
 
 export default function ListItem({ docNode }) {
+  let title = null;
+  if (docNode.title) {
+    title = <strong className="list-item-title">{ docNode.title }</strong>;
+  }
   return (
     <li className="node-list-item" id={docNode.identifier}>
       <span className="list-item-marker">{ docNode.marker }</span>
-      <div className="list-item-text">{ docNode.children.map(renderNode) }</div>
+      <div className="list-item-text">
+        { title }
+        { docNode.children.map(renderNode) }
+      </div>
     </li>
   );
 }

--- a/ui/css/module/_listitem.scss
+++ b/ui/css/module/_listitem.scss
@@ -11,4 +11,10 @@
   .list-item-text {
     @include paragraph-with-marker();
   }
+
+  .list-item-title {
+    @include font-serif-bold();
+    @include size-regular();
+    display: block;
+  }
 }

--- a/ui/util/document-node.js
+++ b/ui/util/document-node.js
@@ -43,6 +43,9 @@ export default class DocumentNode {
     // to access this as it doesn't deal with inline elements
     this.text = fieldValues.text || '';
 
+    // a string to describe this node and all its children
+    this.title = fieldValues.title || '';
+
     // text like "a)" or "Section 22"; not essential to understanding a list
     // item, footnote, etc. but essential to correct display
     this.marker = fieldValues.marker || '';


### PR DESCRIPTION
We've seen multiple policies where individual list items have an associated
title/heading. This modifies our renderers to display that, if present.

Looks like (after mocking out some data):
<img width="554" alt="screen shot 2017-12-29 at 4 09 12 pm" src="https://user-images.githubusercontent.com/326918/34447553-150d3312-ecb3-11e7-8d0d-ca823f65da82.png">
