### PR TITLE
Add script for scraping & loading memoranda.

### DIFF
--- a/api/ombpdf/management/commands/scrape_memoranda.py
+++ b/api/ombpdf/management/commands/scrape_memoranda.py
@@ -1,0 +1,83 @@
+import logging
+import re
+from io import BytesIO
+from os.path import basename
+from typing import Dict, NewType, Set, Tuple
+from urllib.parse import urljoin, urlparse
+
+import requests
+from django.core.management.base import BaseCommand
+from django.db.models import Exists, OuterRef
+from lxml import etree
+
+from document.models import DocNode
+from ombpdf.document import OMBDocument
+from ombpdf.semdb import to_db
+from reqs.models import Policy
+
+MemoId = NewType('MemoId', str)
+Url = NewType('Url', str)
+
+BASE_URL = 'https://www.whitehouse.gov/omb/memoranda/'
+M_REGEX = re.compile('^(?P<m_number>M-\d\d-\d\d), .*')
+logger = logging.getLogger(__name__)
+
+
+def scrape_urls(base_url=BASE_URL) -> Dict[MemoId, Url]:
+    """Hit OMB's listing of memoranda, pull out each memo and url pair, then
+    de-dupe."""
+    html = etree.HTML(requests.get(base_url).content)
+    url_by_num = {}
+    for link in html.findall('.//li/a[@href]'):
+        match = M_REGEX.match(link.text or '')
+        if match and link.attrib['href'].endswith('.pdf'):
+            url_by_num[match.group('m_number')] = urljoin(
+                base_url, link.attrib['href'])
+    return url_by_num
+
+
+def parse_pdf(policy: Policy, url: Url) -> bool:
+    """Fetch and attempt to parse a PDF. Return whether or not this was
+    successful."""
+    try:
+        content = requests.get(url).content
+        pdf = BytesIO(content)
+        pdf.name = basename(urlparse(url).path)     # this used by from_file
+        doc = OMBDocument.from_file(pdf)
+        cursor = to_db(doc, policy)
+        logger.info('Imported %s (%s nodes)', policy.omb_policy_id,
+                    cursor.subtree_size())
+        return True
+    except (DocNode.DoesNotExist, KeyError, ValueError):
+        logger.warning('Something went wrong when importing %s',
+                       policy.omb_policy_id)
+        return False
+
+
+def scrape_memoranda() -> Tuple[Set[MemoId], Set[MemoId]]:
+    """For all policies which haven't already been imported, try parsing the
+    pdf listed on OMB's site."""
+    successes, failures = set(), set()
+    url_by_num = scrape_urls()
+    has_docnodes = Exists(DocNode.objects.filter(policy=OuterRef('pk')))
+    query = Policy.objects \
+        .annotate(has_docnodes=has_docnodes) \
+        .filter(omb_policy_id__in=url_by_num.keys()) \
+        .filter(has_docnodes=False)     # not replacing data
+    for policy in query:
+        if parse_pdf(policy, url_by_num[policy.omb_policy_id]):
+            successes.add(policy.omb_policy_id)
+        else:
+            failures.add(policy.omb_policy_id)
+    return successes, failures
+
+
+class Command(BaseCommand):
+    help = scrape_memoranda.__doc__     # noqa
+
+    def handle(self, *args, **options):
+        successes, failures = scrape_memoranda()
+        num_success, num_failure = len(successes), len(failures)
+        logger.info('Imported %s new documents. Attempted %s, with %s '
+                    'failures: %s', num_success, num_success + num_failure,
+                    num_failure, list(sorted(failures)))

--- a/api/ombpdf/tests/test_management_commands_scrape_memoranda.py
+++ b/api/ombpdf/tests/test_management_commands_scrape_memoranda.py
@@ -1,0 +1,97 @@
+from unittest.mock import Mock
+
+import pytest
+from model_mommy import mommy
+
+from document.models import DocNode
+from ombpdf.management.commands import scrape_memoranda
+from reqs.models import Policy
+
+
+def test_scrape_urls(monkeypatch):
+    monkeypatch.setattr(scrape_memoranda, 'requests', Mock())
+    scrape_memoranda.requests.get.return_value.content = b"""
+        <html>
+            <body>
+                <a href="/1.pdf">M-01-01, Not in an li</a>
+                <ul>
+                    <li>
+                        <a href="/2.pdf">M-02-02, Everything is right</a>
+                    </li>
+                    <li>
+                        <div>
+                            <a href="/3.pdf">M-03-03, Not in an li</a>
+                        </div>
+                    </li>
+                    <li>
+                        <a href="/4.pdf">Other link, won't work</a>
+                    </li>
+                    <li>
+                        <a href="/5.exe">M-05-05, Bad file extension</a>
+                    </li>
+                    <li>
+                        <a href="/6.pdf">M-06-06, Second success</a>
+                    </li>
+                </ul>
+            <body>
+        </html>
+    """
+
+    result = scrape_memoranda.scrape_urls('http://example.com/path/here')
+    assert result == {
+        'M-02-02': 'http://example.com/2.pdf',
+        'M-06-06': 'http://example.com/6.pdf',
+    }
+
+
+def test_parse_pdf_calls(monkeypatch):
+    """Lots of mocking here, just to confirm all the pieces are called."""
+    monkeypatch.setattr(scrape_memoranda, 'requests', Mock())
+    monkeypatch.setattr(scrape_memoranda, 'OMBDocument', Mock())
+    monkeypatch.setattr(scrape_memoranda, 'to_db', Mock())
+    scrape_memoranda.requests.get.return_value.content = b'some content'
+
+    assert scrape_memoranda.parse_pdf(
+        mommy.prepare(Policy), 'http://example.com/some/pdf/here.pdf')
+
+    assert scrape_memoranda.OMBDocument.from_file.called
+    pdf_bytes = scrape_memoranda.OMBDocument.from_file.call_args[0][0]
+    assert pdf_bytes.name == 'here.pdf'
+    assert pdf_bytes.read() == b'some content'
+
+    assert scrape_memoranda.to_db.called
+
+
+def test_parse_pdf_failure(monkeypatch):
+    """An exception should mark the parse as failed."""
+    monkeypatch.setattr(scrape_memoranda, 'requests', Mock())
+    monkeypatch.setattr(scrape_memoranda, 'OMBDocument', Mock())
+    monkeypatch.setattr(scrape_memoranda, 'to_db', Mock())
+    scrape_memoranda.requests.get.return_value.content = b''
+    scrape_memoranda.to_db.side_effect = ValueError()
+
+    assert not scrape_memoranda.parse_pdf(mommy.prepare(Policy), '')
+
+
+@pytest.mark.django_db
+def test_scrape_memoranda(monkeypatch):
+    monkeypatch.setattr(scrape_memoranda, 'scrape_urls', Mock())
+    monkeypatch.setattr(scrape_memoranda, 'parse_pdf', Mock())
+    scrape_memoranda.scrape_urls.return_value = {
+        f'M-0{i}-0{i}': f'http://example.com/path/{i}.pdf'
+        for i in range(1, 7)
+    }
+    # Successes for all but M-03-03
+    scrape_memoranda.parse_pdf.side_effect = \
+        lambda p, _: not p.omb_policy_id.endswith('3')
+
+    for i in range(1, 5):
+        policy = mommy.make(Policy, omb_policy_id=f'M-0{i}-0{i}')
+        if i == 1:     # Immitate a policy having "already" been processed
+            mommy.make(DocNode, policy=policy)
+
+    successes, failures = scrape_memoranda.scrape_memoranda()
+    # M-01-01 has a docnode, so is ignored
+    assert successes == {'M-02-02', 'M-04-04'}
+    assert failures == {'M-03-03'}
+    # M-05-05 and M-06-06 aren't in the database


### PR DESCRIPTION
OMB keeps a list of all their memoranda. Rather than manually downloading and
loading each PDF into the database, we can scrape that list and load them all
at once. This'll allow us to verify them much more quickly and make importing
them into an empty database much easier.

Using current db importer
* 92 imports
* 54 exceptions

Using the #799 importer
* 110 imports
* 36 exceptions