### PR TITLE
Run mypy on whitelisted files.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,11 @@ jobs:
             COMPOSE_FILE: docker-compose-circle.yml
           command: docker-compose run --rm flake8
       - run:
+          name: API Mypy
+          environment:
+            COMPOSE_FILE: docker-compose-circle.yml
+          command: docker-compose run --rm mypy
+      - run:
           name: API Bandit
           environment:
             COMPOSE_FILE: docker-compose-circle.yml

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,9 @@ instance/
 # Scrapy stuff:
 .scrapy
 
+# Mypy stuff:
+.mypy_cache/
+
 # Sphinx documentation
 docs/_build/
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ There are two types of entry points:
   * `manage.py`
   * `py.test`
   * `flake8`
+  * `mypy`
   * `pip-compile`
   * `npm`
   * `webpack`
@@ -219,6 +220,7 @@ We have unit tests for the API/admin (Python) and for the React-based frontend
 For Python unit tests, run:
 ```sh
 docker-compose run --rm flake8  # linting
+docker-compose run --rm mypy    # type checking
 docker-compose run --rm py.test # run tests once
 docker-compose run --rm ptw     # watch command to run tests whenever a file changes
 ```

--- a/api/mypy-files.txt
+++ b/api/mypy-files.txt
@@ -1,0 +1,1 @@
+document/xml_importer/importer.py

--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+
+incremental = True
+strict_optional = True
+check_untyped_defs = True
+warn_incomplete_stub = True
+warn_unused_ignores = True
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+follow_imports = silent
+ignore_missing_imports = True

--- a/api/requirements_dev.in
+++ b/api/requirements_dev.in
@@ -19,3 +19,4 @@ pytest-cov
 pytest-django
 pytest-watch
 tqdm
+mypy

--- a/api/requirements_dev.txt
+++ b/api/requirements_dev.txt
@@ -51,6 +51,7 @@ jmespath==0.9.3
 lxml==4.1.0
 mccabe==0.6.1             # via flake8
 model-mommy==1.3.2
+mypy==0.560
 networkx==2.0
 newrelic==2.90.0.75
 orderedmultidict==0.7.11
@@ -58,6 +59,7 @@ pathtools==0.1.2          # via watchdog
 pbr==3.1.1                # via stevedore
 pdfminer.six==20170720
 pep8-naming==0.4.1
+psutil==5.4.3             # via mypy
 psycopg2==2.7.3.1
 py==1.4.34                # via pytest
 pycodestyle==2.3.1        # via flake8
@@ -80,6 +82,7 @@ sqlparse==0.2.3           # via django-debug-toolbar
 stevedore==1.26.0         # via bandit
 testfixtures==5.2.0       # via flake8-isort
 tqdm==4.19.5
+typed-ast==1.1.0          # via mypy
 urllib3==1.22
 watchdog==0.8.3           # via pytest-watch
 whitenoise==3.3.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,12 @@ services:
       DEBUG: "true"
     entrypoint: .docker/activate_then flake8
 
+  mypy:
+    <<: *PYTHON
+    environment:
+      DEBUG: "true"
+    entrypoint: .docker/activate_then mypy @mypy-files.txt
+
   manage.py:
     <<: *DEV_API
     entrypoint: .docker/wait_for_db_then .docker/activate_then ./manage.py


### PR DESCRIPTION
This attempts to productionalize some experimentation I did in #798 by running [mypy](http://mypy.readthedocs.io/) on a whitelist of our source files (stored in `api/mypy-files.txt`).  This allows us to easily opt-in to type checking without slowing us down.

Currently the mypy settings are _very_ lax, which I've found is generally good for legacy codebases and code that uses third-party libraries that lack type annotations (like Django), since it makes it possible to ["sprinkle in" type checking in a targeted way](https://github.com/18F/calc/pull/1505#issuecomment-288855201), e.g. based on where it'd be most useful.

If this seems amenable, I can add documentation for it to `README.md` in which I also explain our approach, which could help with #410.