### PR TITLE
Convert ombpdf JS to TypeScript

### DIFF
--- a/api/ombpdf/js/bbox.ts
+++ b/api/ombpdf/js/bbox.ts
@@ -1,5 +1,12 @@
 class Bbox {
-  constructor(page, x0, y0, x1, y1) {
+  page: number;
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+
+  constructor(page: number, x0: number, y0: number,
+              x1: number, y1: number) {
     this.page = page;
     this.x0 = x0;
     this.y0 = y0;
@@ -7,7 +14,7 @@ class Bbox {
     this.y1 = y1;
   }
 
-  toCss() {
+  toCss(): string {
     return [
       `bottom: ${this.y0 - 1}px`,
       `left: ${this.x0}px`,
@@ -16,11 +23,11 @@ class Bbox {
     ].join('; ')
   }
 
-  toQuerystring() {
+  toQuerystring(): string {
     return `?bbox=${this.page},${this.x0},${this.y0},${this.x1},${this.y1}`;
   }
 
-  static fromQuerystring(text) {
+  static fromQuerystring(text): Bbox {
     const match = text.match(/bbox=([0-9,.]+)/);
 
     if (!match) {
@@ -41,7 +48,7 @@ class Bbox {
   }
 }
 
-function showBbox(bbox) {
+function showBbox(bbox: Bbox): HTMLDivElement {
   const pageEl = document.querySelector(`.page[data-page="${bbox.page}"]`);
   const bboxEl = document.createElement('div');
 
@@ -53,9 +60,9 @@ function showBbox(bbox) {
   return bboxEl;
 }
 
-let currBboxEl = null;
+let currBboxEl: HTMLDivElement = null;
 
-function setCurrBbox(bbox) {
+function setCurrBbox(bbox: Bbox) {
   if (currBboxEl !== null) {
     currBboxEl.parentNode.removeChild(currBboxEl);
     currBboxEl = null;
@@ -65,7 +72,16 @@ function setCurrBbox(bbox) {
   }
 }
 
-function dragInfoToBbox(dragInfo) {
+interface DragInfo {
+  page: number;
+  pageCanvas: HTMLCanvasElement;
+  startX: number;
+  startY: number;
+  currX: number;
+  currY: number;
+}
+
+function dragInfoToBbox(dragInfo: DragInfo): Bbox {
   if (dragInfo.startX === dragInfo.currX ||
       dragInfo.startY === dragInfo.currY) {
     return null;
@@ -95,11 +111,13 @@ function dragInfoToBbox(dragInfo) {
   return new Bbox(dragInfo.page, x0, y0, x1, y1);
 }
 
-let currDragInfo = null;
+let currDragInfo: DragInfo = null;
 
 window.addEventListener('mousedown', e => {
   if (e.target instanceof HTMLCanvasElement) {
     const pageEl = e.target.parentNode;
+
+    if (!(pageEl instanceof Element)) return;
 
     currDragInfo = {
       page: parseInt(pageEl.getAttribute('data-page')),

--- a/api/ombpdf/js/in-viewport.ts
+++ b/api/ombpdf/js/in-viewport.ts
@@ -5,7 +5,7 @@
 
 var pages = document.querySelectorAll('.page');
 
-function isElPartlyInViewport (el) {
+function isElPartlyInViewport (el: Element) {
   var rect = el.getBoundingClientRect();
 
   return (
@@ -17,7 +17,7 @@ function isElPartlyInViewport (el) {
 }
 
 function setInViewport() {
-  pages.forEach(function(page, i) {
+  Array.from(pages).forEach(function(page, i) {
     page.classList.toggle('in-viewport', isElPartlyInViewport(page));
   });
 }

--- a/api/ombpdf/js/main.js
+++ b/api/ombpdf/js/main.js
@@ -1,4 +1,0 @@
-require('./render-pdf');
-require('./in-viewport');
-require('./tooltip');
-require('./bbox');

--- a/api/ombpdf/js/main.ts
+++ b/api/ombpdf/js/main.ts
@@ -1,0 +1,4 @@
+import './render-pdf';
+import './in-viewport';
+import './tooltip';
+import './bbox';

--- a/api/ombpdf/js/render-pdf.ts
+++ b/api/ombpdf/js/render-pdf.ts
@@ -1,4 +1,11 @@
-var pdfjsLib = require('pdfjs-dist');
+interface ScriptParams {
+  workerSrc: string;
+  pdfPath: string;
+}
+
+declare let SCRIPT_PARAMS: ScriptParams;
+
+import * as pdfjsLib from 'pdfjs-dist';
 
 // Setting worker path to worker bundle.
 pdfjsLib.PDFJS.workerSrc = SCRIPT_PARAMS.workerSrc;
@@ -7,9 +14,15 @@ pdfjsLib.PDFJS.workerSrc = SCRIPT_PARAMS.workerSrc;
 var loadingTask = pdfjsLib.getDocument(SCRIPT_PARAMS.pdfPath);
 
 loadingTask.promise.then(function (pdfDocument) {
-  document.querySelectorAll('.page').forEach(function(page, i) {
+  var pages = document.querySelectorAll('.page');
+  Array.from(pages).forEach(function(page, i) {
     var canvas = document.createElement('canvas');
-    page.prepend(canvas);
+
+    if (page.children.length > 0) {
+      page.insertBefore(canvas, page.children[0]);
+    } else {
+      page.appendChild(canvas);
+    }
 
     return pdfDocument.getPage(i + 1).then(function (pdfPage) {
       // Display page on the existing canvas with 100% scale.

--- a/api/ombpdf/js/tooltip.ts
+++ b/api/ombpdf/js/tooltip.ts
@@ -1,7 +1,14 @@
-var tooltip = document.getElementById('tooltip');
+const TOOLTIP_ID = 'tooltip';
+
+function getTooltip(): HTMLElement {
+  var el = document.getElementById(TOOLTIP_ID);
+  if (!el)
+    throw new Error(`element with id '${TOOLTIP_ID}' not found!`);
+  return el;
+}
 
 function hideTooltip() {
-  tooltip.style.display = 'none';
+  getTooltip().style.display = 'none';
 }
 
 function showTooltip(charEl: Element, x: number, y: number) {
@@ -12,6 +19,7 @@ function showTooltip(charEl: Element, x: number, y: number) {
   var lineno = lineEl.getAttribute('data-lineno');
   var lineAnno = lineEl.getAttribute('data-anno');
   var char = charEl.textContent;
+  var tooltip = getTooltip();
 
   tooltip.style.top = y + 'px';
   tooltip.style.left = x + 'px';

--- a/api/ombpdf/js/tooltip.ts
+++ b/api/ombpdf/js/tooltip.ts
@@ -4,8 +4,11 @@ function hideTooltip() {
   tooltip.style.display = 'none';
 }
 
-function showTooltip(charEl, x, y) {
+function showTooltip(charEl: Element, x: number, y: number) {
   var lineEl = charEl.parentNode;
+
+  if (!(lineEl instanceof Element)) return;
+
   var lineno = lineEl.getAttribute('data-lineno');
   var lineAnno = lineEl.getAttribute('data-anno');
   var char = charEl.textContent;
@@ -21,6 +24,8 @@ function showTooltip(charEl, x, y) {
 
 window.addEventListener('load', function() {
   document.body.addEventListener('mousemove', function(e) {
+    if (!(e.target instanceof Element)) return;
+
     if (e.target.classList.contains('char')) {
       showTooltip(e.target, e.pageX + 10, e.pageY + 10);
     } else {

--- a/api/ombpdf/package.json
+++ b/api/ombpdf/package.json
@@ -20,6 +20,8 @@
   },
   "homepage": "https://github.com/toolness/omb-pdfminer-fun#readme",
   "dependencies": {
+    "ts-loader": "^3.2.0",
+    "typescript": "^2.6.2",
     "pdfjs-dist": "^2.0.185",
     "webpack": "^3.10.0"
   }

--- a/api/ombpdf/tsconfig.json
+++ b/api/ombpdf/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "CommonJS",
+    "sourceMap": true
+  }
+}

--- a/api/ombpdf/tsconfig.json
+++ b/api/ombpdf/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES6",
     "module": "CommonJS",
     "strictNullChecks": true,
+    "alwaysStrict": true,
     "sourceMap": true
   }
 }

--- a/api/ombpdf/tsconfig.json
+++ b/api/ombpdf/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES6",
     "module": "CommonJS",
+    "strictNullChecks": true,
     "sourceMap": true
   }
 }

--- a/api/ombpdf/webpack.config.js
+++ b/api/ombpdf/webpack.config.js
@@ -4,9 +4,18 @@ var path = require('path');
 module.exports = {
   context: __dirname,
   watch: true,
+  devtool: 'inline-source-map',
   entry: {
-    'main': './js/main.js',
+    'main': './js/main.ts',
     'pdf.worker': 'pdfjs-dist/build/pdf.worker.entry'
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js'],
+  },
+  module: {
+    rules: [
+      { test: /\.tsx?$/, loader: 'ts-loader' },
+    ],
   },
   output: {
     path: path.join(__dirname, 'static/ombpdf/js/'),


### PR DESCRIPTION
This is really just meant to build a TypeScript foundation on the API-side, so that we can use TS to implement the productionalized version of the front-end from #798.

I figured I might as well convert my hackneyed JS devtool code for ombpdf into TypeScript as a way to refresh myself on how TypeScript works, so I did that. Note, though, that I didn't have to do a full conversion--I actually started by just converting one file to TS--because TypeScript plays nicely with regular 'ol JS.
