### PR TITLE
Resolve a handful of pdf importing exceptions

### DIFF
--- a/api/ombpdf/document.py
+++ b/api/ombpdf/document.py
@@ -37,7 +37,11 @@ def calc_left_edge(lines):
 class OMBDocument:
     def __init__(self, ltpages, filename=None):
         stats = fontsize.get_font_size_stats(ltpages)
-        self.paragraph_fontsize = stats.most_common(1)[0][0]
+        if stats:
+            self.paragraph_fontsize = stats.most_common(1)[0][0]
+        else:
+            logger.warning('No text found. Image-only pdf?')
+            self.paragraph_fontsize = 0
         self.pages = [
             OMBPage(page, number)
             for page, number in zip(ltpages, range(1, len(ltpages) + 1))

--- a/api/ombpdf/document.py
+++ b/api/ombpdf/document.py
@@ -8,16 +8,26 @@ from . import fontsize, util
 from .annotators import AnnotatorTracker
 from .eqnamedtuple import eqnamedtuple
 
+# Minimum percentage of lines, out of all lines in the document, that
+# we should expect to be on the left edge of the page. This helps us
+# filter out outliers that might be left of the edge, but which might
+# represent e.g. decorative banner text.
+MIN_LEFT_EDGE_PERCENTAGE = 0.10
+
 logger = logging.getLogger(__name__)
 
 
-class OMBDocument:
-    # Minimum percentage of lines, out of all lines in the document, that
-    # we should expect to be on the left edge of the page. This helps us
-    # filter out outliers that might be left of the edge, but which might
-    # represent e.g. decorative banner text.
-    MIN_LEFT_EDGE_PERCENTAGE = 0.10
+def calc_left_edge(lines):
+    counter = Counter(line.left_edge for line in lines)
+    total_lines = sum(counter.values())
+    significant_edges = [
+        left_edge for (left_edge, count) in counter.items()
+        if count > total_lines * MIN_LEFT_EDGE_PERCENTAGE
+    ]
+    return min(significant_edges)
 
+
+class OMBDocument:
     def __init__(self, ltpages, filename=None):
         stats = fontsize.get_font_size_stats(ltpages)
         self.paragraph_fontsize = stats.most_common(1)[0][0]
@@ -26,7 +36,7 @@ class OMBDocument:
             for page, number in zip(ltpages, range(1, len(ltpages) + 1))
         ]
         self.filename = filename
-        self.left_edge = self._calc_left_edge()
+        self.left_edge = calc_left_edge(self.lines)
         self.annotators = AnnotatorTracker(self)
 
         self._realign_lines_left_of_left_edge()
@@ -36,18 +46,6 @@ class OMBDocument:
             lines = [line for line in page if line.left_edge < self.left_edge]
             for line in lines:
                 line.left_edge = self.left_edge
-
-    def _calc_left_edge(self):
-        counter = Counter()
-        total_lines = 0
-        for line in self.lines:
-            counter[line.left_edge] += 1
-            total_lines += 1
-        significant_edges = [
-            left_edge for (left_edge, count) in counter.items()
-            if count > total_lines * self.MIN_LEFT_EDGE_PERCENTAGE
-        ]
-        return min(significant_edges)
 
     @property
     def lines(self):

--- a/api/ombpdf/document.py
+++ b/api/ombpdf/document.py
@@ -24,7 +24,14 @@ def calc_left_edge(lines):
         left_edge for (left_edge, count) in counter.items()
         if count > total_lines * MIN_LEFT_EDGE_PERCENTAGE
     ]
-    return min(significant_edges)
+    if significant_edges:
+        return min(significant_edges)
+    elif counter:
+        logger.warning("Couldn't find a significant left edge")
+        return min(counter.keys())
+    else:
+        logger.warning("Couldn't find any left edge. Blank document?")
+        return 0
 
 
 class OMBDocument:

--- a/api/ombpdf/management/commands/scrape_memoranda.py
+++ b/api/ombpdf/management/commands/scrape_memoranda.py
@@ -20,6 +20,7 @@ Url = NewType('Url', str)
 
 BASE_URL = 'https://www.whitehouse.gov/omb/memoranda/'
 M_REGEX = re.compile('^(?P<m_number>M-\d\d-\d\d), .*')
+known_exceptions = ()  # no known failure cases
 logger = logging.getLogger(__name__)
 
 
@@ -48,7 +49,7 @@ def parse_pdf(policy: Policy, url: Url) -> bool:
         logger.info('Imported %s (%s nodes)', policy.omb_policy_id,
                     cursor.subtree_size())
         return True
-    except (DocNode.DoesNotExist, KeyError, ValueError):
+    except known_exceptions:
         logger.warning('Something went wrong when importing %s',
                        policy.omb_policy_id)
         return False

--- a/api/ombpdf/semdb.py
+++ b/api/ombpdf/semdb.py
@@ -63,6 +63,12 @@ class DatabaseWriter(semtree.Writer):
 
     def end_document(self, doc):
         self.cursor_stack = self.cursor_stack[:1]
+        no_nodes = [key for key, value in self.footnote_citations.items()
+                    if not hasattr(value, 'footnote_node')]
+        if no_nodes:
+            logger.warning('Unresolved footnote citations exist: %s', no_nodes)
+            for no_node_cite in no_nodes:
+                del self.footnote_citations[no_node_cite]
 
     def begin_heading(self, heading):
         while heading.level <= self.sec_level:
@@ -118,12 +124,7 @@ class DatabaseWriter(semtree.Writer):
         self.cursor_stack = self.cursor_stack[:1]
 
     def end_footnote_list(self, fl):
-        no_nodes = [key for key, value in self.footnote_citations.items()
-                    if not hasattr(value, 'footnote_node')]
-        if no_nodes:
-            logger.warning('Unresolved footnote citations exist: %s', no_nodes)
-            for no_node_cite in no_nodes:
-                del self.footnote_citations[no_node_cite]
+        pass
 
     def begin_footnote(self, f):
         child_args = {

--- a/api/ombpdf/semdb.py
+++ b/api/ombpdf/semdb.py
@@ -119,7 +119,7 @@ class DatabaseWriter(semtree.Writer):
 
     def end_footnote_list(self, fl):
         no_nodes = [key for key, value in self.footnote_citations.items()
-                    if not value.footnote_node]
+                    if not hasattr(value, 'footnote_node')]
         if no_nodes:
             logger.warning('Unresolved footnote citations exist: %s', no_nodes)
             for no_node_cite in no_nodes:

--- a/api/ombpdf/tests/test_document.py
+++ b/api/ombpdf/tests/test_document.py
@@ -52,3 +52,12 @@ def test_no_left_edge(monkeypatch):
 
     assert document.calc_left_edge([]) == 0
     assert document.logger.warning.called
+
+
+def test_image_pdf(monkeypatch):
+    monkeypatch.setattr(document, 'logger', Mock())
+    mock_page = []
+
+    doc = document.OMBDocument([mock_page, mock_page, mock_page])
+    assert doc.paragraph_fontsize == 0
+    assert document.logger.warning.called

--- a/api/ombpdf/tests/test_document.py
+++ b/api/ombpdf/tests/test_document.py
@@ -1,3 +1,8 @@
+from unittest.mock import Mock
+
+from ombpdf import document
+
+
 def test_textline_repr_works(m_16_19_doc):
     assert repr(m_16_19_doc.pages[0][4]) == \
         '<OMBTextLine with text "August 1, 2016 ">'
@@ -17,3 +22,15 @@ def test_useful_lines_are_not_culled(m_11_29_doc):
     lastpage_text = '\n'.join([str(line) for line in m_11_29_doc.pages[-1]])
 
     assert 'opportunities to reduce duplication' in lastpage_text
+
+
+def test_calc_left_edge():
+    lines = [
+        Mock(left_edge=10),
+        Mock(left_edge=20),
+        Mock(left_edge=10),
+        Mock(left_edge=20),
+        Mock(left_edge=30),
+        Mock(left_edge=10),
+    ]
+    assert document.calc_left_edge(lines) == 10

--- a/api/ombpdf/tests/test_document.py
+++ b/api/ombpdf/tests/test_document.py
@@ -24,7 +24,9 @@ def test_useful_lines_are_not_culled(m_11_29_doc):
     assert 'opportunities to reduce duplication' in lastpage_text
 
 
-def test_calc_left_edge():
+def test_calc_left_edge(monkeypatch):
+    monkeypatch.setattr(document, 'logger', Mock())
+
     lines = [
         Mock(left_edge=10),
         Mock(left_edge=20),
@@ -34,3 +36,19 @@ def test_calc_left_edge():
         Mock(left_edge=10),
     ]
     assert document.calc_left_edge(lines) == 10
+    assert not document.logger.warning.called
+
+
+def test_no_significant_left_edge(monkeypatch):
+    monkeypatch.setattr(document, 'logger', Mock())
+
+    lines = [Mock(left_edge=i*10) for i in range(1, 20)]
+    assert document.calc_left_edge(lines) == 10
+    assert document.logger.warning.called
+
+
+def test_no_left_edge(monkeypatch):
+    monkeypatch.setattr(document, 'logger', Mock())
+
+    assert document.calc_left_edge([]) == 0
+    assert document.logger.warning.called

--- a/api/ombpdf/tests/test_management_commands_scrape_memoranda.py
+++ b/api/ombpdf/tests/test_management_commands_scrape_memoranda.py
@@ -67,6 +67,7 @@ def test_parse_pdf_failure(monkeypatch):
     monkeypatch.setattr(scrape_memoranda, 'requests', Mock())
     monkeypatch.setattr(scrape_memoranda, 'OMBDocument', Mock())
     monkeypatch.setattr(scrape_memoranda, 'to_db', Mock())
+    monkeypatch.setattr(scrape_memoranda, 'known_exceptions', (ValueError,))
     scrape_memoranda.requests.get.return_value.content = b''
     scrape_memoranda.to_db.side_effect = ValueError()
 

--- a/api/ombpdf/tests/test_semdb.py
+++ b/api/ombpdf/tests/test_semdb.py
@@ -1,4 +1,5 @@
 from datetime import date
+from unittest.mock import Mock
 
 import pytest
 from model_mommy import mommy
@@ -128,3 +129,21 @@ def test_footnotes():
     assert writer.footnote_citations[1].start == len('Some stuff')
     assert writer.footnote_citations[1].end == len('Some stuff1')
     assert 2 not in writer.footnote_citations
+
+
+def test_footnotes_citation_without_footnote(monkeypatch):
+    monkeypatch.setattr(semdb, 'logger', Mock())
+
+    writer = semdb.DatabaseWriter(mommy.prepare(Policy))
+    para = semtree.Paragraph()
+    footnote_list = semtree.FootnoteList()
+
+    writer.begin_paragraph(para)
+    writer.create_text('This has a citation')
+    writer.create_footnote_citation(semtree.FootnoteCitation(1))
+    writer.create_text(' but no footnote')
+    writer.end_paragraph(para)
+    writer.begin_footnote_list(footnote_list)
+    assert 1 in writer.footnote_citations
+    writer.end_footnote_list(footnote_list)
+    assert semdb.logger.warning.called

--- a/api/ombpdf/tests/test_semdb.py
+++ b/api/ombpdf/tests/test_semdb.py
@@ -136,14 +136,12 @@ def test_footnotes_citation_without_footnote(monkeypatch):
 
     writer = semdb.DatabaseWriter(mommy.prepare(Policy))
     para = semtree.Paragraph()
-    footnote_list = semtree.FootnoteList()
 
     writer.begin_paragraph(para)
     writer.create_text('This has a citation')
     writer.create_footnote_citation(semtree.FootnoteCitation(1))
     writer.create_text(' but no footnote')
     writer.end_paragraph(para)
-    writer.begin_footnote_list(footnote_list)
     assert 1 in writer.footnote_citations
-    writer.end_footnote_list(footnote_list)
+    writer.end_document(semtree.Document(''))
     assert semdb.logger.warning.called


### PR DESCRIPTION
These prevent explosions when importing docs that:
* Don't have a clear left margin
* Have footnote citations, but no footnote list
* Have no text (i.e. image-only)