### PR TITLE
Enable ombpdf in production.

### DIFF
--- a/api/omb_eregs/settings.py
+++ b/api/omb_eregs/settings.py
@@ -37,9 +37,10 @@ ALLOWED_HOSTS = env.uris
 
 INSTALLED_APPS = (
     'document',
+    'ombpdf',
     'reqs.apps.ReqsConfig',
     'django.contrib.contenttypes',
-    # must be after taggit and contenttypes, but before auth
+    # must be after contenttypes, but before auth
     'ereqs_admin.apps.EreqsAdminConfig',
     'corsheaders',
     'django_filters',
@@ -58,7 +59,7 @@ INSTALLED_APPS = (
     'django.contrib.postgres',
 )
 if DEBUG:
-    INSTALLED_APPS += ('ombpdf', 'debug_toolbar',)
+    INSTALLED_APPS += ('debug_toolbar',)
 
 MIDDLEWARE = (
     'django.middleware.cache.UpdateCacheMiddleware',


### PR DESCRIPTION
This'll allow us to run the PDF scraping scripts. The associated views are
still hidden behind a DEBUG flag.