### PR TITLE
Add Jest support to API JS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,11 @@ jobs:
             COMPOSE_FILE: docker-compose-circle.yml
           command: docker-compose run --rm bandit -r ereqs_admin reqs omb_eregs -s B101   # skip asserts
       - run:
+          name: API JS tests
+          environment:
+            COMPOSE_FILE: docker-compose-circle.yml
+          command: docker-compose run --rm api-npm test
+      - run:
           name: API Build JS
           environment:
             COMPOSE_FILE: docker-compose-circle.yml

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ ui-dist
 ui/static/font/fontawesome-webfont*
 ui/static/font/KaTeX*
 ui/static/styles.css*
-jest*
+jest_*
 ui/lcov-report/
 ui/lcov.info
 .next

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ ui-dist
 ui/static/font/fontawesome-webfont*
 ui/static/font/KaTeX*
 ui/static/styles.css*
-jest_*
+jest_*/
 ui/lcov-report/
 ui/lcov.info
 .next

--- a/api/document/js/__tests__/example-doc.test.ts
+++ b/api/document/js/__tests__/example-doc.test.ts
@@ -1,0 +1,5 @@
+import exampleDoc from "../example-doc";
+
+test('example document conforms to schema', () => {
+  exampleDoc.check();
+});

--- a/api/document/js/example-doc.ts
+++ b/api/document/js/example-doc.ts
@@ -1,0 +1,18 @@
+import {Node} from "prosemirror-model";
+
+import schema from "./schema";
+
+const EXAMPLE_DOC = {
+  type: 'doc',
+  content: [{
+    type: 'paragraph',
+    content: [{
+      type: 'text',
+      text: 'Hello, I am a paragraph.',
+    }],
+  }],
+};
+
+const exampleDoc = Node.fromJSON(schema, EXAMPLE_DOC);
+
+export default exampleDoc;

--- a/api/document/js/keyboard.ts
+++ b/api/document/js/keyboard.ts
@@ -1,0 +1,11 @@
+import {baseKeymap} from "prosemirror-commands";
+import {undo, redo} from "prosemirror-history";
+import {keymap} from "prosemirror-keymap";
+
+const keyboard = keymap({
+  ...baseKeymap,
+  'Mod-z': undo,
+  'Shift-Mod-z': redo,
+});
+
+export default keyboard;

--- a/api/document/js/main.ts
+++ b/api/document/js/main.ts
@@ -1,10 +1,7 @@
-import {Schema, Node} from "prosemirror-model";
 import {EditorView} from "prosemirror-view";
-import {EditorState} from "prosemirror-state";
-import {menuBar, undoItem, redoItem, MenuItem} from "prosemirror-menu";
-import {history, undo, redo} from "prosemirror-history";
-import {keymap} from "prosemirror-keymap";
-import {baseKeymap} from "prosemirror-commands";
+
+import createEditorState from "./state";
+import exampleDoc from "./example-doc";
 
 // We need to load our CSS via require() rather than import;
 // using the latter raises errors about not being able to find
@@ -23,45 +20,6 @@ require("prosemirror-menu/style/menu.css");
 
 const EDITOR_ID = 'editor';
 
-const EXAMPLE_DOC = {
-  type: 'doc',
-  content: [{
-    type: 'paragraph',
-    content: [{
-      type: 'text',
-      text: 'Hello, I am a paragraph.',
-    }],
-  }],
-};
-
-const schema = new Schema({
-  nodes: {
-    doc: {
-      content: 'paragraph+',
-    },
-    paragraph: {
-      content: 'inline*',
-      toDOM() { return ['p', 0]; },
-    },
-    text: {
-      group: 'inline',
-    },
-  },
-  marks: {},
-});
-
-function getDocument(): Node {
-  const doc = Node.fromJSON(schema, EXAMPLE_DOC);
-
-  // This validates the document structure against our schema, which
-  // is useful as a sanity check. However, in production we may want
-  // to catch any exceptions and log an error, rather than crashing
-  // the whole front-end.
-  doc.check();
-
-  return doc;
-}
-
 function getEl(id: string): Element {
   const el = document.getElementById(id);
   if (!el)
@@ -71,30 +29,6 @@ function getEl(id: string): Element {
 
 window.addEventListener('load', () => {
   const view = new EditorView(getEl(EDITOR_ID), {
-    state: EditorState.create({
-      doc: getDocument(),
-      plugins: [
-        menuBar({
-          floating: true,
-          content: [
-            [
-              // This forcible type assertion is due to what appears to
-              // be a bug in the documentation/type annotations for
-              // prosemirror-menu. For more details, see:
-              //
-              // https://github.com/ProseMirror/prosemirror-menu/issues/12
-              undoItem as any as MenuItem,
-              redoItem as any as MenuItem,
-            ]
-          ],
-        }),
-        keymap({
-          ...baseKeymap,
-          'Mod-z': undo,
-          'Shift-Mod-z': redo,
-        }),
-        history(),
-      ],
-    })
+    state: createEditorState(exampleDoc),
   });
 });

--- a/api/document/js/menu.ts
+++ b/api/document/js/menu.ts
@@ -1,0 +1,18 @@
+import {menuBar, undoItem, redoItem, MenuItem} from "prosemirror-menu";
+
+const menu = menuBar({
+  floating: true,
+  content: [
+    [
+      // This forcible type assertion is due to what appears to
+      // be a bug in the documentation/type annotations for
+      // prosemirror-menu. For more details, see:
+      //
+      // https://github.com/ProseMirror/prosemirror-menu/issues/12
+      undoItem as any as MenuItem,
+      redoItem as any as MenuItem,
+    ]
+  ],
+});
+
+export default menu;

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -1,0 +1,19 @@
+import {Schema} from "prosemirror-model";
+
+const schema = new Schema({
+  nodes: {
+    doc: {
+      content: 'paragraph+',
+    },
+    paragraph: {
+      content: 'inline*',
+      toDOM() { return ['p', 0]; },
+    },
+    text: {
+      group: 'inline',
+    },
+  },
+  marks: {},
+});
+
+export default schema;

--- a/api/document/js/state.ts
+++ b/api/document/js/state.ts
@@ -1,0 +1,17 @@
+import {Node} from "prosemirror-model";
+import {EditorState} from "prosemirror-state";
+import {history} from "prosemirror-history";
+
+import menu from "./menu";
+import keyboard from "./keyboard";
+
+export default function createEditorState(doc: Node): EditorState {
+  return EditorState.create({
+    doc,
+    plugins: [
+      menu,
+      keyboard,
+      history(),
+    ],
+  });
+}

--- a/api/jest-ts-preprocessor.js
+++ b/api/jest-ts-preprocessor.js
@@ -1,0 +1,11 @@
+const tsc = require('typescript');
+const tsConfig = require('./tsconfig.json');
+
+module.exports = {
+  process(src, path) {
+    if (path.endsWith('.ts') || path.endsWith('.tsx')) {
+      return tsc.transpile(src, tsConfig.compilerOptions, path, []);
+    }
+    return src;
+  },
+};

--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pdfminer-fun",
+  "name": "omb-eregs-api",
   "version": "1.0.0",
   "description": "[![CircleCI](https://circleci.com/gh/18F/omb-pdf.svg?style=svg)](https://circleci.com/gh/18F/omb-pdf)",
   "main": "index.js",
@@ -7,7 +7,8 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "NODE_ENV=test jest --coverage",
+    "test:watch": "NODE_ENV=test jest --watch"
   },
   "repository": {
     "type": "git",
@@ -38,5 +39,22 @@
     "ts-loader": "^3.2.0",
     "typescript": "^2.6.2",
     "webpack": "^3.10.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^22.0.1",
+    "jest": "^22.0.4"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js"
+    ],
+    "transform": {
+      "^.+\\.(ts|tsx)$": "<rootDir>/jest-ts-preprocessor.js"
+    },
+    "testMatch": [
+      "**/__tests__/*.(ts|tsx|js)"
+    ]
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,6 +181,11 @@ services:
     ports: []
     depends_on: []
 
+  api-npm:
+    <<: *API_WEBPACK
+    entrypoint: .docker/deps_ok_then npm
+    command: ''
+
   api-webpack:
     <<: *API_WEBPACK
     entrypoint: .docker/deps_ok_then ./node_modules/.bin/webpack


### PR DESCRIPTION
~~**Note that this is currently a PR against #809, not `master`.**~~

This builds upon #809 by adding support for Jest, along with one simple test.

Unfortunately, in doing so, it refactors a bunch of #809 by splitting up `main.ts` into a bunch of files, which muddles things up a bit.  Sorry about that...

  