### PR TITLE
Foothold for custom styles in Django admin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
             COMPOSE_FILE: docker-compose-circle.yml
           command: docker-compose run --rm api-npm test
       - run:
-          name: API Build JS
+          name: API Build JS & CSS
           environment:
             COMPOSE_FILE: docker-compose-circle.yml
           command: |

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ docker-compose run --rm manage.py migrate  # set up database
 docker-compose run --rm manage.py createsuperuser
 # [fill out information]
 docker-compose up dev-api
-# Ctrl-c to kill
+# [Wait while it sets up]
+# Starting development server at http://0.0.0.0:8001/
+# Quit the server with CONTROL-C.
 ```
 
 Then navigate to http://localhost:8001/admin/ and log in.
@@ -103,19 +105,34 @@ There are two types of entry points:
     for UI, 8001 for API).
   * `prod` - Run the UI and API apps in "production" mode (port 9002 for UI,
     9001 for API). Note that this requires the JS be compiled already.
-1. One use commands which run until complete. These are ran via
+1. One-use commands which run until complete. These are ran via
   `docker-compose run --rm` (the `--rm` just deletes the images after running;
   it's not strictly required)
-  * `manage.py`
-  * `py.test`
+  * `api-npm`
+  * `api-webpack`
+  * `bandit`
   * `flake8`
+  * `manage.py`
   * `mypy`
-  * `pip-compile`
   * `npm`
-  * `webpack`
+  * `pip-compile`
   * `psql`
+  * `ptw`
+  * `py.test`
+  * `webpack`
 
 ### Resolving common container issues
+
+#### Restarting
+
+If the app is throwing an unexpected exception, it might be due to needing new
+libraries or needing to run a database migration. As a first debugging step,
+try bouncing the system:
+
+```sh
+docker-compose down
+docker-compose up dev
+```
 
 #### Bundles aren't being rebuilt when I change them
 

--- a/api/.docker/wait_for_db_then
+++ b/api/.docker/wait_for_db_then
@@ -1,8 +1,15 @@
 #!/bin/bash
 
+FIRST_RUN=true
+
 until (echo 2>/dev/null > /dev/tcp/persistent_db/5432)
 do
-  echo "Startup: Waiting for Postgres"
+  echo "Startup: Waiting for Postgres..."
+  if $FIRST_RUN; then
+    echo "\tTo track progress, run:"
+    echo "\tdocker-compose logs -f persistent_db"
+    FIRST_RUN=false
+  fi
   sleep 1
 done
 

--- a/api/.docker/wait_for_webpack_then
+++ b/api/.docker/wait_for_webpack_then
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+FIRST_RUN=true
+
+until (ls webpack-static 2> /dev/null)
+do
+  echo "Startup: Waiting for webpack..."
+  if $FIRST_RUN; then
+    echo "\tTo track progress, run:"
+    echo "\tdocker-compose logs -f api-webpack-watcher"
+    FIRST_RUN=false
+  fi
+  sleep 10
+done
+
+exec "$@"
+

--- a/api/ereqs_admin/static/admin/override.scss
+++ b/api/ereqs_admin/static/admin/override.scss
@@ -1,0 +1,1 @@
+// html { text-decoration: underline; }

--- a/api/ereqs_admin/templates/admin/base_site.html
+++ b/api/ereqs_admin/templates/admin/base_site.html
@@ -1,0 +1,11 @@
+{% extends 'admin_interface:admin/base_site.html' %}
+{% load static %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link
+    rel="stylesheet"
+    type="text/css"
+    href="{% static "bundles/css/admin/override.css" %}"
+  />
+{% endblock %}

--- a/api/omb_eregs/settings.py
+++ b/api/omb_eregs/settings.py
@@ -125,13 +125,17 @@ TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [],
-        'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+            ],
+            'loaders': [
+                'apptemplates.Loader',
+                'django.template.loaders.filesystem.Loader',
+                'django.template.loaders.app_directories.Loader',
             ],
         },
     },

--- a/api/package.json
+++ b/api/package.json
@@ -42,7 +42,10 @@
   },
   "devDependencies": {
     "@types/jest": "^22.0.1",
-    "jest": "^22.0.4"
+    "extract-text-webpack-plugin": "^3.0.2",
+    "jest": "^22.0.4",
+    "node-sass": "^4.7.2",
+    "sass-loader": "^6.0.6"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/api/requirements.in
+++ b/api/requirements.in
@@ -2,6 +2,7 @@ boto3
 cfenv
 django>=1.11,<1.12
 django-admin-interface
+django-apptemplates
 django-cas-ng
 django-cors-headers
 django-filter

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -12,6 +12,7 @@ chardet==3.0.4            # via pdfminer.six, requests
 decorator==4.1.2          # via networkx
 dj-database-url==0.4.2
 django-admin-interface==0.5.2
+django-apptemplates==1.4
 django-cas-ng==3.5.8
 django-colorfield==0.1.14  # via django-admin-interface
 django-cors-headers==2.1.0

--- a/api/requirements_dev.txt
+++ b/api/requirements_dev.txt
@@ -17,6 +17,7 @@ coverage==4.4.1           # via pytest-cov
 decorator==4.1.2
 dj-database-url==0.4.2
 django-admin-interface==0.5.2
+django-apptemplates==1.4
 django-cas-ng==3.5.8
 django-colorfield==0.1.14
 django-cors-headers==2.1.0

--- a/api/webpack.config.js
+++ b/api/webpack.config.js
@@ -1,35 +1,67 @@
-var webpack = require('webpack');
-var path = require('path');
+const path = require('path');
 
-module.exports = {
-  context: __dirname,
-  devtool: 'inline-source-map',
-  entry: {
-    'document.main': './document/js/main.ts',
-    'ombpdf.main': './ombpdf/js/main.ts',
-    'pdf.worker': 'pdfjs-dist/build/pdf.worker.entry'
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const webpack = require('webpack');
+
+
+module.exports = [
+  {
+    name: 'editor-js',
+    context: __dirname,
+    devtool: 'inline-source-map',
+    entry: {
+      'document.main': './document/js/main.ts',
+      'ombpdf.main': './ombpdf/js/main.ts',
+      'pdf.worker': 'pdfjs-dist/build/pdf.worker.entry'
+    },
+    resolve: {
+      extensions: ['.ts', '.tsx', '.js'],
+    },
+    module: {
+      rules: [
+        { test: /\.tsx?$/, loader: 'ts-loader' },
+        {
+          test: /\.css$/i,
+          use: ['style-loader', 'css-loader'],
+        },
+      ],
+    },
+    output: {
+      path: path.join(__dirname, 'webpack-static/bundles/js/'),
+      publicPath: 'static/bundles/js/',
+      filename: '[name].bundle.js',
+    },
   },
-  resolve: {
-    extensions: ['.ts', '.tsx', '.js'],
+  {
+    name: 'admin-styles',
+    context: __dirname,
+    devtool: 'source-map',
+    entry: path.join(__dirname, 'ereqs_admin', 'static', 'admin', 'override.scss'),
+    output: {
+      path: path.join(__dirname, 'webpack-static', 'bundles', 'css', 'admin'),
+      publicPath: 'static/bundles/css/admin/',
+      filename: 'override.css',
+    },
+    plugins: [new ExtractTextPlugin('override.css')],
+    module: {
+      rules: [{
+        test: /\.scss$/,
+        use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: [
+            { loader: 'css-loader',
+              options: { sourceMap: true } },
+            { loader: 'sass-loader',
+              options: { sourceMap: true } },
+          ],
+        }),
+      }],
+    },
   },
-  module: {
-    rules: [
-      { test: /\.tsx?$/, loader: 'ts-loader' },
-      {
-        test: /\.css$/i,
-        use: ['style-loader', 'css-loader'],
-      },
-    ],
-  },
-  output: {
-    path: path.join(__dirname, 'webpack-static/bundles/js/'),
-    publicPath: 'static/bundles/js/',
-    filename: '[name].bundle.js'
-  }
-};
+];
 
 if (process.env.USE_POLLING === 'true') {
-  module.exports.watchOptions = {
-    poll: true,
-  };
+  module.exports.forEach(exp => {
+    exp.watchOptions = { poll: true };
+  });
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     network_mode: service:proxy
   prod-api: &PROD_API
     <<: *PYTHON
-    command: .docker/wait_for_db_then .docker/activate_then ./run_api.sh
+    command: .docker/activate_then .docker/wait_for_db_then ./run_api.sh
     environment: &API_ENV
       DATABASE_URL: postgres://postgres@persistent_db/postgres
       PORT: 9001
@@ -68,6 +68,7 @@ services:
 
   dev-api: &DEV_API
     <<: *PROD_API
+    command: .docker/activate_then .docker/wait_for_webpack_then .docker/wait_for_db_then ./run_api.sh
     environment:
       <<: *API_ENV
       PORT: 8001


### PR DESCRIPTION
We know we'll want to reskin a significant chunk of the Django admin. Although [django-admin-interface](https://github.com/fabiocaccamo/django-admin-interface) will get us close, we'll likely want to override other styles as well.

This adds a config for building a SCSS bundle to the api webpack and includes that in the Django admin. The SCSS file includes a commented style, which quickly tests that everything works.