### PR TITLE
Factor out tests/json_importer/factories.py

### DIFF
--- a/api/document/tests/json_importer/factories.py
+++ b/api/document/tests/json_importer/factories.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 
 from document.tree import PrimitiveDict
 
@@ -19,7 +19,7 @@ def external_link(href: str, inlines: List[PrimitiveDict]) -> PrimitiveDict:
 
 
 def para(content: List[PrimitiveDict],
-         children: Optional[List[PrimitiveDict]]=None) -> PrimitiveDict:
+         children: List[PrimitiveDict]=None) -> PrimitiveDict:
     return {
         "node_type": "para",
         "content": content,
@@ -35,7 +35,7 @@ def footnote_citation(inlines: List[PrimitiveDict]) -> PrimitiveDict:
 
 
 def footnote(marker: int, content=List[PrimitiveDict],
-             children: Optional[List[PrimitiveDict]]=None) -> PrimitiveDict:
+             children: List[PrimitiveDict]=None) -> PrimitiveDict:
     return {
         "node_type": "footnote",
         "marker": str(marker),

--- a/api/document/tests/json_importer/factories.py
+++ b/api/document/tests/json_importer/factories.py
@@ -1,0 +1,45 @@
+from typing import List, Optional
+
+from document.tree import PrimitiveDict
+
+
+def text(value: str) -> PrimitiveDict:
+    return {
+        "content_type": "__text__",
+        "text": value
+    }
+
+
+def external_link(href: str, inlines: List[PrimitiveDict]) -> PrimitiveDict:
+    return {
+        "content_type": "external_link",
+        "href": href,
+        "inlines": inlines,
+    }
+
+
+def para(content: List[PrimitiveDict],
+         children: Optional[List[PrimitiveDict]]=None) -> PrimitiveDict:
+    return {
+        "node_type": "para",
+        "content": content,
+        "children": children or [],
+    }
+
+
+def footnote_citation(inlines: List[PrimitiveDict]) -> PrimitiveDict:
+    return {
+        "content_type": 'footnote_citation',
+        "inlines": inlines,
+    }
+
+
+def footnote(marker: int, content=List[PrimitiveDict],
+             children: Optional[List[PrimitiveDict]]=None) -> PrimitiveDict:
+    return {
+        "node_type": "footnote",
+        "marker": str(marker),
+        "type_emblem": str(marker),
+        "content": content,
+        "children": children or [],
+    }

--- a/api/document/tests/json_importer/importer_test.py
+++ b/api/document/tests/json_importer/importer_test.py
@@ -1,36 +1,15 @@
-from typing import List
+from document.json_importer.importer import convert_node
 
-from document.json_importer.importer import PrimitiveDict, convert_node
-
-
-def text(value: str) -> PrimitiveDict:
-    return {
-        "content_type": "__text__",
-        "text": value
-    }
-
-
-def external_link(href: str, inlines: List[PrimitiveDict]) -> PrimitiveDict:
-    return {
-        "content_type": "external_link",
-        "href": href,
-        "inlines": inlines,
-    }
-
-
-PARA_WITH_LINK = {
-    "node_type": 'para',
-    "children": [],
-    "content": [
-        text('Hello '),
-        external_link('http://example.org/', [text('there')])
-    ],
-}
+from . import factories as f
 
 
 def test_convert_paragraph_works():
-    para = convert_node(PARA_WITH_LINK)
+    para_primitive = f.para(content=[
+        f.text('Hello '),
+        f.external_link('http://example.org/', [f.text('there')])
+    ])
+    para = convert_node(para_primitive)
 
     assert para.node_type == 'para'
     assert para.text == 'Hello there'
-    assert para.json_content == PARA_WITH_LINK['content']
+    assert para.json_content == para_primitive['content']


### PR DESCRIPTION
This gets rid of a janky code smell introduced in #815. whereby one of our test suites was importing factory functions and fixtures introduced in an unrelated test suite. It also hopefully lays some groundwork for less verbose JSON and/or serializer-related tests going forward.
