### PR TITLE
Fix type annotations in document.serializers.content

### DIFF
--- a/api/document/serializers/content.py
+++ b/api/document/serializers/content.py
@@ -92,15 +92,10 @@ class NestedAnnotationSerializer(serializers.Serializer):
     @classmethod
     def register(cls, klass: Type['BaseAnnotationSerializer']) \
             -> Type['BaseAnnotationSerializer']:
-        name = klass.__name__
+        obj = klass()
 
-        if klass.ANNOTATION_CLASS is None:
-            raise ValueError(f'{name} must define ANNOTATION_CLASS')
-        cls.serializer_mapping[klass.ANNOTATION_CLASS] = klass
-
-        if klass.CONTENT_TYPE is None:
-            raise ValueError(f'{name} must define CONTENT_TYPE')
-        cls.content_type_mapping[klass.CONTENT_TYPE] = klass
+        cls.serializer_mapping[obj.ANNOTATION_CLASS] = klass
+        cls.content_type_mapping[obj.CONTENT_TYPE] = klass
 
         return klass
 
@@ -182,9 +177,13 @@ class BaseAnnotationSerializer(serializers.Serializer):
     inlines = InlinesField(is_leaf_node=False)
     text = TextField(is_leaf_node=False)
 
-    # Subclasses need to implement these.
-    CONTENT_TYPE: Optional[str] = None
-    ANNOTATION_CLASS: Optional[Type['Annotation']] = None
+    @property
+    def CONTENT_TYPE(self) -> str:  # noqa
+        raise NotImplementedError()
+
+    @property
+    def ANNOTATION_CLASS(self) -> Type['Annotation']:  # noqa
+        raise NotImplementedError()
 
     @property
     def cursor_tree(self):

--- a/api/document/serializers/content.py
+++ b/api/document/serializers/content.py
@@ -71,7 +71,11 @@ def nest_annotations(annotations: Iterator[Annotation],
         # compare ends when determining nesting
         while anote not in last:
             if last.parent is None:
-                raise AssertionError('last.parent is None!')
+                raise AssertionError(
+                    f"{type(anote).__name__} {anote.pk} "
+                    f"({anote.start} - {anote.end}) doesn't fit in "
+                    f"the text (0 - {text_length}). Data corruption?"
+                )
             last = last.parent
         # Enforce all annotations to be nested rather than overlapping
         anote.end = min(anote.end, last.end)

--- a/api/document/tests/serializers/content_test.py
+++ b/api/document/tests/serializers/content_test.py
@@ -23,6 +23,13 @@ def test_nest_annotations_no_overlapping():
     ]
 
 
+def test_nest_annotations_raises_assertion_error():
+    with pytest.raises(AssertionError, matches="doesn't fit in the text"):
+        content.nest_annotations([
+            mommy.prepare(ExternalLink, start=50, end=60),
+        ], 30)
+
+
 def test_nest_annotations_entirely_nested():
     annotations = [
         mommy.prepare(ExternalLink, start=4, end=8),

--- a/api/mypy-files.txt
+++ b/api/mypy-files.txt
@@ -1,7 +1,6 @@
 document/models.py
 document/renderers.py
-document/serializers/meta.py
-document/serializers/doc_cursor.py
+document/serializers/
 document/tree.py
 document/xml_importer/importer.py
 document/json_importer/


### PR DESCRIPTION
This fixes #826 and also makes the module's annotation-to-serializer mapping a bit more understandable (maybe) by introducing a `NestedAnnotationSerializer.register` decorator that "registers" an annotation serializer with the system.

Both changes are in separate commits, so if we dislike one we can just commit the other.