### PR TITLE
Add documentation for DocNode, Annotation, and DocCursor (w/ doctests)

### DIFF
--- a/api/document/tests/doctest_test.py
+++ b/api/document/tests/doctest_test.py
@@ -1,0 +1,18 @@
+import doctest
+from importlib import import_module
+
+import pytest
+
+
+@pytest.mark.parametrize('module_name', [
+    'document.tree',
+])
+def test_doctests(module_name):
+    _, test_count = doctest.testmod(
+        import_module(module_name),
+        report=True,
+        verbose=True,
+        raise_on_error=True,
+        optionflags=doctest.NORMALIZE_WHITESPACE,
+    )
+    assert test_count > 0

--- a/api/document/tree.py
+++ b/api/document/tree.py
@@ -59,6 +59,11 @@ class DocCursor():
 
         >>> root.jump_to('root_1__sec_1').node_type
         'sec'
+
+    Immediate children of a cursor's node can also be retrieved:
+
+        >>> root['sec_1'].node_type
+        'sec'
     """
 
     __slots__ = ('tree', 'identifier')
@@ -110,7 +115,7 @@ class DocCursor():
     def model(self) -> DocNode:
         return self.tree.node[self.identifier]['model']
 
-    def __getitem__(self, child_suffix: str):
+    def __getitem__(self, child_suffix: str) -> 'DocCursor':
         child_id = f"{self.identifier}__{child_suffix}"
         if child_id not in self.tree:
             raise KeyError(f"No {child_id} element")

--- a/api/document/tree.py
+++ b/api/document/tree.py
@@ -248,7 +248,11 @@ class DocCursor():
             while child.left > parent.right:
                 parents_parent = parent.parent()
                 if parents_parent is None:
-                    raise AssertionError("Parent's parent must exist!")
+                    raise AssertionError(
+                        "Couldn't convert DocNodes into a tree. "
+                        "Perhaps they weren't sorted or there was data "
+                        "corruption?"
+                    )
                 parent = parents_parent
             self.tree.add_node(child.identifier, model=child)
             self.tree.add_edge(parent.identifier, child.identifier,


### PR DESCRIPTION
This documents our `DocCursor` model a bit more.  I ended up also adding a `__str__()` implementation to it (though we could rename it to `describe()` or something if we don't like the idea of `__str__()` returning multiple lines of text) to make it easier to see what a cursor is "pointing" at.

Note that the documentation is tested via a weird `doctest_test.py` that's largely copy-pasted from #758.  As mentioned in that issue, it's a workaround because enabling doctest finding in pytest across the whole codebase results in a mysterious segfault. What's also unfortunate is that if the test fails, it produces unhelpful output; the most helpful output can be found by running `pytest --doctest-modules document/tree.py` (which doesn't segfault because it's only looking at one file).

**Update:** This PR also adds some documentation to `document.models`.