### PR TITLE
Get rid of DocCursor._prefetched_objects_cache hack

### DIFF
--- a/api/document/tree.py
+++ b/api/document/tree.py
@@ -78,18 +78,6 @@ class DocCursor():
         """Delegate fields/methods to wrapped model."""
         return getattr(self.model, attr)
 
-    @property
-    def _prefetched_objects_cache(self):
-        """Django REST Framework thinks we're a bona fide Django model,
-        and its UpdateModelMixin sometimes writes to the model's
-        undocumented _prefetched_objects_cache property, so we'll
-        need to make it writable too."""
-        return self.model._prefetched_objects_cache
-
-    @_prefetched_objects_cache.setter
-    def _prefetched_objects_cache(self, value):
-        self.model._prefetched_objects_cache = value
-
     @classmethod
     def new_tree(cls: Type[T], node_type: str, type_emblem: str='1',
                  policy=None, **attrs) -> T:

--- a/api/document/views.py
+++ b/api/document/views.py
@@ -1,7 +1,7 @@
 from django.db.models import Prefetch
 from django.shortcuts import get_object_or_404, render
 from rest_framework import status
-from rest_framework.generics import RetrieveUpdateAPIView
+from rest_framework.generics import GenericAPIView
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 
@@ -29,7 +29,7 @@ def optimize(queryset):
                          requirement_prefetch)
 
 
-class TreeView(RetrieveUpdateAPIView):
+class TreeView(GenericAPIView):
     serializer_class = DocCursorSerializer
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer,
                         AkomaNtosoRenderer, BrowsableAkomaNtosoRenderer)
@@ -54,12 +54,23 @@ class TreeView(RetrieveUpdateAPIView):
             'policy': getattr(self, 'policy', None),
         }
 
+    def get(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)
+
     def put(self, request, *args, **kwargs):
         if self.kwargs.get('identifier'):
             return Response({
                 'detail': 'Identifiers are unsupported on PUT requests.',
             }, status=status.HTTP_400_BAD_REQUEST)
-        return super().put(request, *args, **kwargs)
+
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        return Response(serializer.data)
 
 
 def editor(request):


### PR DESCRIPTION
This builds upon #861 and decouples `document.views.TreeView` from its Django-model-specific mixins, allowing us to get rid of the `DocCursor._prefetched_objects_cache` hack introduced in https://github.com/18F/omb-eregs/pull/815#pullrequestreview-87544955.

Note that the added code here is identical to what's in the original mixins that the `TreeView` previously used, with the exception of code that examined `_prefetched_objects_cache` and a bit of code that supported partial updating (which honestly, I don't even know if our serializer could support that right now, so I figure we can add it back if/when we need to). Concretely, that's [`RetrieveModelMixin` and `UpdateModelMixin`](https://github.com/encode/django-rest-framework/blob/master/rest_framework/mixins.py#L51-L84) and [`RetrieveUpdateAPIView`](https://github.com/encode/django-rest-framework/blob/master/rest_framework/generics.py#L247-L260)... Note that this PR also removes a lot of layers of indirection from the original code, which is why it's so concise (and, IMO, easier to understand, but then again I'm not a DRF expert).
