### PR TITLE
Support PUT requests w/ content type akn+xml

### DIFF
--- a/api/document/serializers/content.py
+++ b/api/document/serializers/content.py
@@ -92,7 +92,7 @@ class NestableAnnotationField(serializers.Field):
 
 class InlinesField(NestableAnnotationField):
     def __init__(self, is_leaf_node: bool) -> None:
-        super().__init__()
+        super().__init__(default=lambda: [])
         self.is_leaf_node = is_leaf_node
 
     def to_representation(self,

--- a/api/document/tests/serializers/doc_cursor_test.py
+++ b/api/document/tests/serializers/doc_cursor_test.py
@@ -295,7 +295,8 @@ def test_children_field_to_internal_value_works():
 
 
 def test_content_field_to_internal_value_works():
-    # TODO: We really shouldn't *have* to specify inlines here,
-    # especially since text nodes aren't even allowed to have any!
-    text = {'inlines': [], **f.text('boop')}
-    assert doc_cursor.ContentField().to_internal_value([text]) == [text]
+    text = f.text('boop')
+    assert doc_cursor.ContentField().to_internal_value([text]) == [{
+        'inlines': [],
+        **text,
+    }]

--- a/api/document/tests/views_test.py
+++ b/api/document/tests/views_test.py
@@ -33,7 +33,7 @@ def test_put_fails_with_identifier(admin_client):
 
 @pytest.mark.django_db
 @pytest.mark.urls('document.urls')
-def test_put_works_for_admin_users(admin_client):
+def test_json_put_works_for_admin_users(admin_client):
     policy = mommy.make(Policy)
     root = DocCursor.new_tree('root', '0', policy=policy)
     root.add_child('sec', text='blah')
@@ -57,6 +57,33 @@ def test_put_works_for_admin_users(admin_client):
     assert response.status_code == 200
     result = response.json()
     assert result['children'][0]['title'] == 'boop'
+    assert result['children'][0]['content'][0]['text'] == 'hallo'
+
+
+@pytest.mark.django_db
+@pytest.mark.urls('document.urls')
+def test_akn_put_works_for_admin_users(admin_client):
+    policy = mommy.make(Policy)
+    root = DocCursor.new_tree('root', '0', policy=policy)
+    root.add_child('sec', text='blah')
+    root.nested_set_renumber()
+
+    # Get the original document...
+    response = admin_client.get(f"/{policy.pk}?format=akn")
+    assert response.status_code == 200
+    assert response['content-type'] == 'application/akn+xml; charset=utf-8'
+
+    # Modify it a bit...
+    xml = response.content.replace(b'blah', b'hallo')
+
+    response = admin_client.put(f"/{policy.pk}", data=xml,
+                                content_type='application/akn+xml')
+    assert response.status_code == 200
+
+    # Now fetch it again, and make sure our modification stuck.
+    response = admin_client.get(f"/{policy.pk}")
+    assert response.status_code == 200
+    result = response.json()
     assert result['children'][0]['content'][0]['text'] == 'hallo'
 
 

--- a/api/document/views.py
+++ b/api/document/views.py
@@ -3,10 +3,12 @@ from django.db.models import Prefetch
 from django.shortcuts import get_object_or_404, render
 from rest_framework import status
 from rest_framework.generics import GenericAPIView
+from rest_framework.parsers import JSONParser
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 
 from document.models import DocNode, FootnoteCitation, InlineRequirement
+from document.parsers import AkomaNtosoParser
 from document.renderers import AkomaNtosoRenderer, BrowsableAkomaNtosoRenderer
 from document.serializers.doc_cursor import DocCursorSerializer
 from document.tree import DocCursor
@@ -34,6 +36,7 @@ class TreeView(GenericAPIView):
     serializer_class = DocCursorSerializer
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer,
                         AkomaNtosoRenderer, BrowsableAkomaNtosoRenderer)
+    parser_classes = (JSONParser, AkomaNtosoParser)
     queryset = DocNode.objects.none()   # Used to determine permissions
 
     def get_object(self):


### PR DESCRIPTION
This builds upon #868 by adding the Akoma Ntoso parser to our `TreeView` so clients can PUT Akoma Ntoso documents via the REST API.

Note that this PR does _not_ currently add `defusedxml` because I'm confused about whether it's actually needed, as explained in https://github.com/18F/omb-eregs/pull/868#issuecomment-358361139.  @cmc333333 let me know if you think I should add it, otherwise I'll leave it off!
