### PR TITLE
Add "para" and "sec" node types to editor

### DIFF
--- a/api/document/js/__tests__/fetch-doc.test.ts
+++ b/api/document/js/__tests__/fetch-doc.test.ts
@@ -39,6 +39,21 @@ describe('convertNode()', () => {
     expect(result.content.child(1).type.name).toBe('unimplemented_node');
   });
 
+  it('loads paragraph text', () => {
+    const node = {
+      node_type: 'para',
+      text: 'Some text here',
+      children: [{ node_type: 'unknown-child' }],
+    };
+
+    const result = convertNode(node);
+    expect(result.content.childCount).toBe(2);
+    expect(result.content.child(0).type.name).toBe('inline');
+    expect(result.content.child(0).content.childCount).toBe(1);
+    expect(result.content.child(0).content.child(0).text).toBe('Some text here');
+    expect(result.content.child(1).type.name).toBe('unimplemented_node');
+  });
+
   describe('unimplemented_node', () => {
     it('saves original data', () => {
       const node = {

--- a/api/document/js/__tests__/fetch-doc.test.ts
+++ b/api/document/js/__tests__/fetch-doc.test.ts
@@ -26,8 +26,8 @@ describe('convertNode()', () => {
     const node = {
       node_type: 'policy',
       children: [
-        { node_type: 'sec', children: [] },
-        { node_type: 'sec', children: [] },
+        { node_type: 'aaaaa', children: [] },
+        { node_type: 'bbbbb', children: [] },
       ],
     };
 

--- a/api/document/js/__tests__/fetch-doc.test.ts
+++ b/api/document/js/__tests__/fetch-doc.test.ts
@@ -53,22 +53,8 @@ describe('convertNode()', () => {
 
       const result = convertNode(node);
       expect(result.type).toBe('unimplemented_node');
-      expect(result.attrs).toEqual({ data: JSON.stringify(node) });
-      expect(result.content).toHaveLength(1);   // not the nested children
-    });
-
-    it('includes the node type as text', () => {
-      const result = convertNode({ node_type: 'something-unknown' });
-      expect(result.content).toEqual(
-        [{ type: 'text', text: 'something-unknown' }]);
-    });
-
-    it('falls back if no node type is present', () => {
-      const node = { bad: 'data' };
-      const result = convertNode(node);
-      expect(result.attrs).toEqual({ data: JSON.stringify(node) });
-      expect(result.content).toEqual(
-        [{ type: 'text', text: '[no-node-type]' }]);
+      expect(result.attrs).toEqual({ data: node });
+      expect(result.content).toBeUndefined();
     });
   });
 });

--- a/api/document/js/__tests__/fetch-doc.test.ts
+++ b/api/document/js/__tests__/fetch-doc.test.ts
@@ -33,10 +33,10 @@ describe('convertNode()', () => {
 
     const result = convertNode(node);
 
-    expect(result.type).toBe('doc');
-    expect(result.content).toHaveLength(2);
-    expect(result.content.map(c => c.type)).toEqual(
-      ['unimplemented_node', 'unimplemented_node'])
+    expect(result.type.name).toBe('doc');
+    expect(result.content.childCount).toBe(2);
+    expect(result.content.child(0).type.name).toBe('unimplemented_node');
+    expect(result.content.child(1).type.name).toBe('unimplemented_node');
   });
 
   describe('unimplemented_node', () => {
@@ -52,9 +52,9 @@ describe('convertNode()', () => {
       };
 
       const result = convertNode(node);
-      expect(result.type).toBe('unimplemented_node');
+      expect(result.type.name).toBe('unimplemented_node');
       expect(result.attrs).toEqual({ data: node });
-      expect(result.content).toBeUndefined();
+      expect(result.content.childCount).toBe(0);
     });
   });
 });

--- a/api/document/js/__tests__/schema.test.ts
+++ b/api/document/js/__tests__/schema.test.ts
@@ -1,0 +1,23 @@
+import { DOMSerializer } from 'prosemirror-model';
+
+import schema from '../schema';
+
+const serializer = DOMSerializer.fromSchema(schema);
+
+describe('unimplemented_node', () => {
+  it('includes the node type as text', () => {
+    const node = schema.nodes.unimplemented_node.create({
+      data: { node_type: 'something-unknown' },
+    });
+    const result = serializer.serializeNode(node);
+    expect(result.textContent).toBe('something-unknown');
+  });
+
+  it('falls back if no node type is present', () => {
+    const node = schema.nodes.unimplemented_node.create({
+      data: { bad: 'data' },
+    });
+    const result = serializer.serializeNode(node);
+    expect(result.textContent).toBe('[no-node-type]');
+  });
+});

--- a/api/document/js/fetch-doc.ts
+++ b/api/document/js/fetch-doc.ts
@@ -14,6 +14,10 @@ const NODE_TYPE_CONVERTERS = {
     type: 'doc',
     content: (node.children || []).map(convertNode),
   }),
+  sec: node => ({
+    type: 'sec',
+    content: (node.children || []).map(convertNode),
+  }),
   unimplemented_node: node => ({
     type: 'unimplemented_node',
     attrs: { data: node },

--- a/api/document/js/fetch-doc.ts
+++ b/api/document/js/fetch-doc.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import { Node } from 'prosemirror-model';
 
 import schema from './schema';
 
@@ -10,24 +9,18 @@ export function convertNode(node) {
 }
 
 const NODE_TYPE_CONVERTERS = {
-  policy: node => ({
-    type: 'doc',
-    content: (node.children || []).map(convertNode),
-  }),
-  sec: node => ({
-    type: 'sec',
-    content: (node.children || []).map(convertNode),
-  }),
-  unimplemented_node: node => ({
-    type: 'unimplemented_node',
-    attrs: { data: node },
-  }),
+  policy: node =>
+    schema.nodes.doc.create({}, (node.children || []).map(convertNode)),
+  sec: node =>
+    schema.nodes.sec.create({}, (node.children || []).map(convertNode)),
+  unimplemented_node: node =>
+    schema.nodes.unimplemented_node.create({ data: node }),
 };
 
 export default function fetchDoc(path?: string) {
   const pathParts = (path || window.location.href).split('/');
   const policyId = pathParts[pathParts.length - 1];
   return axios.get(`/document/${policyId}`)
-    .then(response => Node.fromJSON(schema, convertNode(response.data)));
+    .then(response => convertNode(response.data));
 }
 

--- a/api/document/js/fetch-doc.ts
+++ b/api/document/js/fetch-doc.ts
@@ -9,6 +9,12 @@ export function convertNode(node) {
 }
 
 const NODE_TYPE_CONVERTERS = {
+  para(node) {
+    const text = (node.text || '').replace(/\s+/g, ' ');
+    const inlineContent = schema.nodes.inline.create({}, schema.text(text));
+    const childContent = (node.children || []).map(convertNode);
+    return schema.nodes.para.create({}, [inlineContent].concat(childContent));
+  },
   policy: node =>
     schema.nodes.doc.create({}, (node.children || []).map(convertNode)),
   sec: node =>

--- a/api/document/js/fetch-doc.ts
+++ b/api/document/js/fetch-doc.ts
@@ -10,17 +10,13 @@ export function convertNode(node) {
 }
 
 const NODE_TYPE_CONVERTERS = {
-  unimplemented_node: node => ({
-    type: 'unimplemented_node',
-    attrs: { data: JSON.stringify(node) },
-    content: [{
-      type: 'text',
-      text: node.node_type || '[no-node-type]',
-    }],
-  }),
   policy: node => ({
     type: 'doc',
     content: (node.children || []).map(convertNode),
+  }),
+  unimplemented_node: node => ({
+    type: 'unimplemented_node',
+    attrs: { data: node },
   }),
 };
 

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -3,22 +3,23 @@ import { Schema } from 'prosemirror-model';
 const schema = new Schema({
   nodes: {
     doc: {
-      content: '(paragraph | unimplemented_node)+',
+      content: 'block+',
     },
-    paragraph: {
-      content: 'inline*',
+    inline: {
+      content: 'text+',
       toDOM: () => ['p', 0],
     },
-    text: {
-      group: 'inline',
-    },
+    text: {},
     unimplemented_node: {
-      content: 'inline*',
+      group: 'block',
       atom: true,
       attrs: {
         data: {}, // will hold unrendered content
       },
-      toDOM: () => ['div', { class: 'unimplemented' }, 0],
+      toDOM(node) {
+        const nodeType = node.attrs.data.node_type || '[no-node-type]';
+        return ['div', { class: 'unimplemented' }, nodeType];
+      },
     },
   },
   marks: {

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -9,6 +9,11 @@ const schema = new Schema({
       content: 'text+',
       toDOM: () => ['p', 0],
     },
+    sec: {
+      content: 'block+',
+      group: 'block',
+      toDOM: () => ['section', 0],
+    },
     text: {},
     unimplemented_node: {
       group: 'block',

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -9,6 +9,11 @@ const schema = new Schema({
       content: 'text+',
       toDOM: () => ['p', 0],
     },
+    para: {
+      content: 'inline? block*',
+      group: 'block',
+      toDOM: () => ['div', 0],
+    },
     sec: {
       content: 'block+',
       group: 'block',


### PR DESCRIPTION
This
* Resolves #871 by avoiding text nodes within `unimplemented_node`
* Swaps our conversion step to using ProseMirror's node factories rather than raw objects
* Sets up the "para" and "sec" types. The former breaks from #798 a bit as it moves all of the text content into a single ProseMirror type ("inline") and only includes that at most once.

This doesn't handle the API's `content` (ProseMirror's `mark`) types; that'll be the next step.