### PR TITLE
Disable admin nav menu

### DIFF
--- a/api/ereqs_admin/static/admin/override.scss
+++ b/api/ereqs_admin/static/admin/override.scss
@@ -4,7 +4,7 @@
 @import '../shared-styles/base/type-size';
 @import '../shared-styles/base/util';
 
-$nav-menu-active: true;
+$nav-menu-active: false;
 
 $banner-height: 60px;
 $nav-menu-width: if($nav-menu-active, 200px, 0);

--- a/api/ereqs_admin/static/admin/override.scss
+++ b/api/ereqs_admin/static/admin/override.scss
@@ -4,8 +4,10 @@
 @import '../shared-styles/base/type-size';
 @import '../shared-styles/base/util';
 
+$nav-menu-active: true;
+
 $banner-height: 60px;
-$nav-menu-width: 200px;
+$nav-menu-width: if($nav-menu-active, 200px, 0);
 
 #header {
   // Remove padding so our nav-menu can start at left:0
@@ -36,6 +38,11 @@ $nav-menu-width: 200px;
   margin-top: $banner-height;
   padding: 0 $space;
   width: 100%;
+
+  @if not($nav-menu-active) {
+    display: none;
+  }
+
 }
 
 .nav-menu {
@@ -45,4 +52,8 @@ $nav-menu-width: 200px;
   padding: 0;
   position: absolute;
   width: $nav-menu-width;
+
+  @if not($nav-menu-active) {
+    display: none;
+  }
 }


### PR DESCRIPTION
We didn't finish the styling for this menu, so this disables it. The changeset does make activation/deactivation as simple as flipping a variable, though.

## $nav-menu-active: true;
<img width="1264" alt="screen shot 2018-01-18 at 10 12 50 am" src="https://user-images.githubusercontent.com/326918/35104888-3804e196-fc38-11e7-8d67-e45836f9a233.png">

## $nav-menu-active: false;
<img width="1263" alt="screen shot 2018-01-18 at 10 12 16 am" src="https://user-images.githubusercontent.com/326918/35104901-42cf1c40-fc38-11e7-8431-5eaa9d8beb17.png">

