### PR TITLE
Ensure logins redirect to the admin screens.

### DIFF
--- a/api/omb_eregs/settings.py
+++ b/api/omb_eregs/settings.py
@@ -276,6 +276,10 @@ DEBUG_TOOLBAR_CONFIG = {
 
 ADMIN_TITLE = 'OMB Policy Library Editor'
 
+# We only use accounts for admin access at the moment
+LOGIN_REDIRECT_URL = '/admin/'
+LOGIN_URL = '/admin/login/'
+
 if DEBUG and os.environ.get('USE_POLLING') == 'true':
     import django.utils.autoreload
 


### PR DESCRIPTION
By default, Django uses `/accounts/` urls for login redirects. We're only
using logins with the admin, however, so it makes sense to redirect to the
admin-specific sections.

This resolves #877.