### PR TITLE
Add initial "mark" support to editor import.

### DIFF
--- a/api/document/js/__tests__/fetch-doc.test.ts
+++ b/api/document/js/__tests__/fetch-doc.test.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import fetchDoc, { convertNode } from '../fetch-doc';
+import fetchDoc, { convertContent, convertNode } from '../fetch-doc';
 
 jest.mock('axios');
 
@@ -42,7 +42,13 @@ describe('convertNode()', () => {
   it('loads paragraph text', () => {
     const node = {
       node_type: 'para',
-      text: 'Some text here',
+      content: [
+        { content_type: '__text__', text: 'Some text ' },
+        {
+          content_type: 'unknown-content',
+          inlines: [{ content_type: '__text__', text: 'here' }],
+        },
+      ],
       children: [{ node_type: 'unknown-child' }],
     };
 
@@ -50,8 +56,9 @@ describe('convertNode()', () => {
     expect(result.type.name).toBe('para');
     expect(result.content.childCount).toBe(2);
     expect(result.content.child(0).type.name).toBe('inline');
-    expect(result.content.child(0).content.childCount).toBe(1);
-    expect(result.content.child(0).content.child(0).text).toBe('Some text here');
+    expect(result.content.child(0).content.childCount).toBe(2);
+    expect(result.content.child(0).content.child(0).text).toBe('Some text ');
+    expect(result.content.child(0).content.child(1).text).toBe('here');
     expect(result.content.child(1).type.name).toBe('unimplemented_node');
   });
 
@@ -87,5 +94,45 @@ describe('convertNode()', () => {
       expect(result.attrs).toEqual({ data: node });
       expect(result.content.childCount).toBe(0);
     });
+  });
+});
+
+describe('convertContent()', () => {
+  it('bottoms out at a list of texts', () => {
+    const content = { content_type: '__text__', text: 'Stuff here!' };
+    const result = convertContent(content, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].type.name).toBe('text');
+    expect(result[0].text).toBe('Stuff here!');
+  });
+
+  it('deals with hierarchy', () => {
+    const content = {
+      content_type: 'doesnt-exist',
+      outer: 'props',
+      inlines: [
+        { content_type: '__text__', text: 'Initial ' },
+        {
+          content_type: 'inner-thing',
+          inner: 'stuff',
+          inlines: [{ content_type: '__text__', text: 'content.' }],
+        },
+      ],
+    };
+    const result = convertContent(content, []);
+    expect(result).toHaveLength(2);
+    const [text1, text2] = result;
+
+    expect(text1.type.name).toBe('text');
+    expect(text1.marks).toHaveLength(1);
+    expect(text1.marks[0].type.name).toBe('unimplemented_mark');
+    expect(text1.marks[0].attrs.data.outer).toBe('props');
+
+    expect(text2.type.name).toBe('text');
+    expect(text2.marks).toHaveLength(2);
+    expect(text2.marks[0].type.name).toBe('unimplemented_mark');
+    expect(text2.marks[0].attrs.data.outer).toBe('props');
+    expect(text2.marks[1].type.name).toBe('unimplemented_mark');
+    expect(text2.marks[1].attrs.data.inner).toBe('stuff');
   });
 });

--- a/api/document/js/fetch-doc.ts
+++ b/api/document/js/fetch-doc.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { Mark, Node } from 'prosemirror-model';
 
 import schema from './schema';
 
@@ -6,6 +7,20 @@ export function convertNode(node) {
   const nodeType = node.node_type in NODE_TYPE_CONVERTERS ?
     node.node_type : 'unimplemented_node';
   return NODE_TYPE_CONVERTERS[nodeType](node);
+}
+
+export function convertContent(content, marks: Mark[]): Node[] {
+  if (content.content_type === '__text__') {
+    const text = (content.text || '').replace(/\s+/g, ' ');
+    return [schema.text(text, marks)];
+  }
+  const contentType = content.content_type in CONTENT_TYPE_CONVERTERS ?
+    content.content_type : 'unimplemented_mark';
+  const mark = CONTENT_TYPE_CONVERTERS[contentType](content);
+  const updatedMarks = marks.concat([mark]);
+  const children = (content.inlines || []).map(child =>
+    convertContent(child, updatedMarks));
+  return [].concat(...children);
 }
 
 const NODE_TYPE_CONVERTERS = {
@@ -19,8 +34,9 @@ const NODE_TYPE_CONVERTERS = {
     return schema.nodes.heading.create({ depth }, schema.text(text));
   },
   para(node) {
-    const text = (node.text || '').replace(/\s+/g, ' ');
-    const inlineContent = schema.nodes.inline.create({}, schema.text(text));
+    const nested: Node[][] = (node.content || []).map(c => convertContent(c, []));
+    const empty: Node[] = [];
+    const inlineContent = schema.nodes.inline.create({}, empty.concat(...nested));
     const childContent = (node.children || []).map(convertNode);
     return schema.nodes.para.create({}, [inlineContent].concat(childContent));
   },
@@ -30,6 +46,11 @@ const NODE_TYPE_CONVERTERS = {
     schema.nodes.sec.create({}, (node.children || []).map(convertNode)),
   unimplemented_node: node =>
     schema.nodes.unimplemented_node.create({ data: node }),
+};
+
+const CONTENT_TYPE_CONVERTERS = {
+  unimplemented_mark: content =>
+    schema.marks.unimplemented_mark.create({ data: content }),
 };
 
 export default function fetchDoc(path?: string) {

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -40,7 +40,7 @@ const schema = new Schema({
     },
   },
   marks: {
-    unimplemented_content: {
+    unimplemented_mark: {
       attrs: {
         data: {}, // will hold unrendered content
       },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -21,6 +21,11 @@
       "integrity": "sha1-Y3Cm1gzOOEXkzV0Av2X2VCZGhbw=",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.93",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.93.tgz",
+      "integrity": "sha512-xI9Il9Fqxse5hSh6bVwowEC5RXyEVJ2hssRJXANU70H/+NlirvsNi87JjvGMxtn6yTemyUPkkzSl9SCKFW4U3g=="
+    },
     "@types/node": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/toolness/omb-pdfminer-fun#readme",
   "dependencies": {
+    "@types/lodash": "^4.14.93",
     "@types/prosemirror-commands": "^1.0.0",
     "@types/prosemirror-history": "^1.0.0",
     "@types/prosemirror-keymap": "^1.0.0",
@@ -30,6 +31,7 @@
     "@types/prosemirror-view": "^1.0.0",
     "axios": "^0.17.1",
     "css-loader": "0.28.7",
+    "lodash": "^4.17.4",
     "pdfjs-dist": "^2.0.185",
     "prosemirror-commands": "^1.0.3",
     "prosemirror-history": "^1.0.0",


### PR DESCRIPTION
This handles nested content by keeping a stack of derived markers and
linearizing them into an array of `text`s (each with the stack of marks).

Similar to the unimplemented_node, we want to track all of the meta
information around an unknown content/annotation/inline/mark type (yay
different names for similar concepts!).

Looks like
<img width="1251" alt="screen shot 2018-01-18 at 2 00 34 pm" src="https://user-images.githubusercontent.com/326918/35116008-ef945228-fc57-11e7-9ad5-d0476f421fdf.png">
