### PR TITLE
Add a few "problem" policies.

### DIFF
--- a/api/ombpdf/management/commands/import_pdfs_from_policies.py
+++ b/api/ombpdf/management/commands/import_pdfs_from_policies.py
@@ -13,7 +13,10 @@ from reqs.models import Policy, WorkflowPhases
 OLD_DOMAIN = 'www.whitehouse.gov'
 NEW_DOMAIN = 'obamawhitehouse.archives.gov'
 PROBLEM_PDFS = (
+    'BILLS-103s1587enr.pdf',
     'a11_2016.pdf',
+    'a136_revised_2014.pdf',
+    'hr_5005_enr.pdf',
 )
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
We have stricter memory limits in our cloud.gov environment than on our
development machines. This adds exceptions for a handful of pdfs that could be
processed locally, but can't in cloud.gov.