### PR TITLE
Add an end-to-end test for AKN

### DIFF
--- a/api/document/tests/end_to_end_test.py
+++ b/api/document/tests/end_to_end_test.py
@@ -17,6 +17,7 @@ MY_DIR = Path(__file__).parent.resolve()
 EXAMPLE_DOCS_DIR = MY_DIR / '..' / '..' / 'example_docs'
 
 
+@pytest.mark.xfail(raises=AssertionError, reason="Fix this!!")
 @pytest.mark.django_db
 def test_akn_works():
     # Phase 1: Import the document from XML, serialize it, and
@@ -40,16 +41,6 @@ def test_akn_works():
     data = DocCursorSerializer(cursor).data
     akn = AkomaNtosoRenderer().render(data)
 
-    # Phase 4: Parse the AKN, deserialize it, and save it.
-    parsed_akn_data = AkomaNtosoParser().parse(BytesIO(akn))
-    serializer = DocCursorSerializer(cursor, data=parsed_akn_data)
-    serializer.is_valid(raise_exception=True)
-    cursor = serializer.save()
-
-    # Phase 5: Re-serialize the document and render it to AKN.
-    data2 = DocCursorSerializer(cursor).data
-    akn2 = AkomaNtosoRenderer().render(data2)
-
-    # Now ensure the AKN from phase 3 matches the AKN from
-    # phase 5.
-    assert akn.decode('utf-8') == akn2.decode('utf-8')
+    # Now ensure the AKN from phase 1 matches the AKN from
+    # phase 3.
+    assert original_akn.decode('utf-8') == akn.decode('utf-8')

--- a/api/document/tests/end_to_end_test.py
+++ b/api/document/tests/end_to_end_test.py
@@ -1,0 +1,55 @@
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from django.core.management import call_command
+from model_mommy import mommy
+
+from document.models import DocNode
+from document.parsers import AkomaNtosoParser
+from document.renderers import AkomaNtosoRenderer
+from document.serializers.doc_cursor import DocCursorSerializer
+from document.tree import DocCursor
+from reqs.models import Policy
+
+MY_DIR = Path(__file__).parent.resolve()
+
+EXAMPLE_DOCS_DIR = MY_DIR / '..' / '..' / 'example_docs'
+
+
+@pytest.mark.django_db
+def test_akn_works():
+    # Phase 1: Import the document from XML, serialize it, and
+    # render it to AKN.
+    policy = mommy.make(Policy, omb_policy_id='M-16-19')
+    call_command('import_xml_doc', str(EXAMPLE_DOCS_DIR / 'm_16_19_1.xml'),
+                 'M-16-19')
+    docnode = DocNode.objects.filter(policy=policy, depth=1).first()
+    cursor = DocCursor.load_from_model(docnode)
+
+    original_data = DocCursorSerializer(cursor).data
+    original_akn = AkomaNtosoRenderer().render(original_data)
+
+    # Phase 2: Parse the AKN, deserialize it, and save it.
+    parsed_akn_data = AkomaNtosoParser().parse(BytesIO(original_akn))
+    serializer = DocCursorSerializer(cursor, data=parsed_akn_data)
+    serializer.is_valid(raise_exception=True)
+    cursor = serializer.save()
+
+    # Phase 3: Re-serialize the document and render it to AKN.
+    data = DocCursorSerializer(cursor).data
+    akn = AkomaNtosoRenderer().render(data)
+
+    # Phase 4: Parse the AKN, deserialize it, and save it.
+    parsed_akn_data = AkomaNtosoParser().parse(BytesIO(akn))
+    serializer = DocCursorSerializer(cursor, data=parsed_akn_data)
+    serializer.is_valid(raise_exception=True)
+    cursor = serializer.save()
+
+    # Phase 5: Re-serialize the document and render it to AKN.
+    data2 = DocCursorSerializer(cursor).data
+    akn2 = AkomaNtosoRenderer().render(data2)
+
+    # Now ensure the AKN from phase 3 matches the AKN from
+    # phase 5.
+    assert akn.decode('utf-8') == akn2.decode('utf-8')


### PR DESCRIPTION
This attempts to help with #924 by adding an end-to-end test for AKN using a real-world policy (M-16-19).

It is kind of convoluted, and I'm not sure how useful it is. It did, however, help me realize that the preamble of our XML example documents is actually part of the document that's stored in the database, which I hadn't realized--I thought the preamble was solely stored as metadata on the `Policy` model, but it actually seems to be stored in _both_ the `Policy` _and_ under a `preamble` node type in the document. But because some/all of our DRF pipeline ignores it, it gets lost at some point.

Because of this discrepancy, and a few others that I didn't investigate terribly closely, I ended up doing more round-trips between the AKN parser/renderer than I had originally intended. I'm not really sure how useful the approach is, and it's also possible that this test might be a lot simpler (and easier to parametrize to JSON instead of AKN) if it just operated via the REST API instead of using our renderer/parser/serializer subclasses directly.

Anyhow, @cmc333333 can you take a look at this and let me know what you think?