### PR TITLE
Link to document by slug, look at workflow phase

### DIFF
--- a/api/ombpdf/management/commands/import_pdfs_from_policies.py
+++ b/api/ombpdf/management/commands/import_pdfs_from_policies.py
@@ -55,9 +55,13 @@ def import_pdfs_from_policies() -> Tuple[Set[str], Set[str]]:
     """Attempt to import document text from all pdf policies which haven't
     already been imported."""
     successes, failures = set(), set()
-    query = Policy.objects.annotate_with_has_docnodes() \
-        .filter(uri__endswith='.pdf',
-                has_docnodes=False)  # not replacing data
+    query = Policy.objects.filter(
+        uri__endswith='.pdf',
+        workflow_phase__in=(    # not replacing data
+            WorkflowPhases.no_doc.name,
+            WorkflowPhases.failed.name,
+        ),
+    )
     for policy in query:
         ident = f"{policy.pk}: {policy.title_with_number}"
         with reversion.create_revision():

--- a/api/ombpdf/management/commands/scrape_memoranda.py
+++ b/api/ombpdf/management/commands/scrape_memoranda.py
@@ -64,9 +64,13 @@ def scrape_memoranda() -> Tuple[Set[MemoId], Set[MemoId]]:
     pdf listed on OMB's site."""
     successes, failures = set(), set()
     url_by_num = scrape_urls()
-    query = Policy.objects.annotate_with_has_docnodes() \
-        .filter(omb_policy_id__in=url_by_num.keys(),
-                has_docnodes=False)     # not replacing data
+    query = Policy.objects.filter(
+        omb_policy_id__in=url_by_num.keys(),
+        workflow_phase__in=(    # not replacing data
+            WorkflowPhases.no_doc.name,
+            WorkflowPhases.failed.name,
+        ),
+    )
     for policy in query:
         if parse_pdf(policy, url_by_num[policy.omb_policy_id]):
             successes.add(policy.omb_policy_id)

--- a/api/ombpdf/tests/test_management_commands_scrape_memoranda.py
+++ b/api/ombpdf/tests/test_management_commands_scrape_memoranda.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock
 import pytest
 from model_mommy import mommy
 
-from document.models import DocNode
 from ombpdf.management.commands import scrape_memoranda
 from reqs.models import Policy, WorkflowPhases
 
@@ -94,9 +93,11 @@ def test_scrape_memoranda(monkeypatch):
         lambda p, _: not p.omb_policy_id.endswith('3')
 
     for i in range(1, 5):
-        policy = mommy.make(Policy, omb_policy_id=f'M-0{i}-0{i}')
-        if i == 1:     # Immitate a policy having "already" been processed
-            mommy.make(DocNode, policy=policy)
+        workflow_phase = WorkflowPhases.no_doc.name
+        if i == 1:  # Immitate a policy having "already" been processed
+            workflow_phase = WorkflowPhases.published.name
+        mommy.make(Policy, omb_policy_id=f'M-0{i}-0{i}',
+                   workflow_phase=workflow_phase)
 
     successes, failures = scrape_memoranda.scrape_memoranda()
     # M-01-01 has a docnode, so is ignored

--- a/api/ombpdf/tests/test_management_commands_scrape_memoranda.py
+++ b/api/ombpdf/tests/test_management_commands_scrape_memoranda.py
@@ -94,7 +94,7 @@ def test_scrape_memoranda(monkeypatch):
 
     for i in range(1, 5):
         workflow_phase = WorkflowPhases.no_doc.name
-        if i == 1:  # Immitate a policy having "already" been processed
+        if i == 1:  # Imitate a policy having "already" been processed
             workflow_phase = WorkflowPhases.published.name
         mommy.make(Policy, omb_policy_id=f'M-0{i}-0{i}',
                    workflow_phase=workflow_phase)

--- a/api/reqs/models.py
+++ b/api/reqs/models.py
@@ -149,7 +149,7 @@ class Policy(models.Model):
         return self.requirements.prefetch_related('topics').distinct()
 
     @property
-    def has_docnodes(self):
+    def has_document(self):
         return self.workflow_phase == WorkflowPhases.published.name
 
     def __str__(self):

--- a/api/reqs/models.py
+++ b/api/reqs/models.py
@@ -149,7 +149,7 @@ class Policy(models.Model):
         return self.requirements.prefetch_related('topics').distinct()
 
     @property
-    def has_document(self):
+    def has_published_document(self):
         return self.workflow_phase == WorkflowPhases.published.name
 
     def __str__(self):

--- a/api/reqs/models.py
+++ b/api/reqs/models.py
@@ -4,8 +4,6 @@ from django.db import models
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy
 
-from document.models import DocNode
-
 
 class Agency(models.Model):
     class Meta:
@@ -107,22 +105,10 @@ class Office(models.Model):
         return self.name
 
 
-class PolicyQueryset(models.QuerySet):
-    def annotate_with_has_docnodes(self):
-        """We frequently want to filter a Policy queryset by whether or not
-        the policies have associated DocNodes. This annotates a queryset with
-        that data."""
-
-        subquery = DocNode.objects.filter(policy=models.OuterRef('pk'))
-        return self.annotate(has_docnodes=models.Exists(subquery))
-
-
 class Policy(models.Model):
     class Meta:
         verbose_name_plural = ugettext_lazy('Policies')
         ordering = ['policy_number']
-
-    objects = PolicyQueryset.as_manager()
 
     policy_number = models.IntegerField(unique=True)
     title = models.CharField(max_length=1024)
@@ -161,6 +147,10 @@ class Policy(models.Model):
     @property
     def requirements_with_topics(self):
         return self.requirements.prefetch_related('topics').distinct()
+
+    @property
+    def has_docnodes(self):
+        return self.workflow_phase == WorkflowPhases.published.name
 
     def __str__(self):
         text = self.title_with_number

--- a/api/reqs/serializers.py
+++ b/api/reqs/serializers.py
@@ -36,7 +36,7 @@ class PolicySerializer(serializers.ModelSerializer):
             'id',
             'issuance',
             'issuing_body',
-            'has_document',
+            'has_published_document',
             'omb_policy_id',
             'original_url',
             'policy_number',

--- a/api/reqs/serializers.py
+++ b/api/reqs/serializers.py
@@ -36,7 +36,7 @@ class PolicySerializer(serializers.ModelSerializer):
             'id',
             'issuance',
             'issuing_body',
-            'has_docnodes',
+            'has_document',
             'omb_policy_id',
             'original_url',
             'policy_number',

--- a/api/reqs/serializers.py
+++ b/api/reqs/serializers.py
@@ -42,6 +42,7 @@ class PolicySerializer(serializers.ModelSerializer):
             'policy_number',
             'policy_type',
             'relevant_reqs',
+            'slug',
             'sunset',
             'title',
             'title_with_number',

--- a/api/reqs/serializers.py
+++ b/api/reqs/serializers.py
@@ -24,7 +24,6 @@ class GroupWithAgenciesSerializer(serializers.ModelSerializer):
 
 
 class PolicySerializer(serializers.ModelSerializer):
-    has_docnodes = serializers.BooleanField(read_only=True)
     total_reqs = serializers.IntegerField(read_only=True)
     relevant_reqs = serializers.IntegerField(read_only=True)
     title_with_number = serializers.CharField(read_only=True)
@@ -37,6 +36,7 @@ class PolicySerializer(serializers.ModelSerializer):
             'id',
             'issuance',
             'issuing_body',
+            'has_docnodes',
             'omb_policy_id',
             'original_url',
             'policy_number',
@@ -48,7 +48,6 @@ class PolicySerializer(serializers.ModelSerializer):
             'title_with_number',
             'total_reqs',
             'uri',
-            'has_docnodes',
             'workflow_phase',
         )
 

--- a/api/reqs/tests/model_tests.py
+++ b/api/reqs/tests/model_tests.py
@@ -33,6 +33,19 @@ def test_original_url():
     assert policy.original_url == 'http://example.com/uploaded'
 
 
+@pytest.mark.parametrize('phase, has_docnodes', (
+    (models.WorkflowPhases.edit, False),
+    (models.WorkflowPhases.cleanup, False),
+    (models.WorkflowPhases.failed, False),
+    (models.WorkflowPhases.no_doc, False),
+    (models.WorkflowPhases.published, True),
+    (models.WorkflowPhases.review, False),
+))
+def test_has_docnodes(phase, has_docnodes):
+    policy = models.Policy(workflow_phase=phase.name)
+    assert policy.has_docnodes is has_docnodes
+
+
 @pytest.mark.django_db
 def test_slug_is_created_from_title_on_save_if_slug_is_empty():
     policy = mommy.prepare(models.Policy, title="hello there", slug="")

--- a/api/reqs/tests/model_tests.py
+++ b/api/reqs/tests/model_tests.py
@@ -33,7 +33,7 @@ def test_original_url():
     assert policy.original_url == 'http://example.com/uploaded'
 
 
-@pytest.mark.parametrize('phase, has_document', (
+@pytest.mark.parametrize('phase, has_published_document', (
     (models.WorkflowPhases.edit, False),
     (models.WorkflowPhases.cleanup, False),
     (models.WorkflowPhases.failed, False),
@@ -41,9 +41,9 @@ def test_original_url():
     (models.WorkflowPhases.published, True),
     (models.WorkflowPhases.review, False),
 ))
-def test_has_document(phase, has_document):
+def test_has_published_document(phase, has_published_document):
     policy = models.Policy(workflow_phase=phase.name)
-    assert policy.has_document is has_document
+    assert policy.has_published_document is has_published_document
 
 
 @pytest.mark.django_db

--- a/api/reqs/tests/model_tests.py
+++ b/api/reqs/tests/model_tests.py
@@ -33,7 +33,7 @@ def test_original_url():
     assert policy.original_url == 'http://example.com/uploaded'
 
 
-@pytest.mark.parametrize('phase, has_docnodes', (
+@pytest.mark.parametrize('phase, has_document', (
     (models.WorkflowPhases.edit, False),
     (models.WorkflowPhases.cleanup, False),
     (models.WorkflowPhases.failed, False),
@@ -41,9 +41,9 @@ def test_original_url():
     (models.WorkflowPhases.published, True),
     (models.WorkflowPhases.review, False),
 ))
-def test_has_docnodes(phase, has_docnodes):
+def test_has_document(phase, has_document):
     policy = models.Policy(workflow_phase=phase.name)
-    assert policy.has_docnodes is has_docnodes
+    assert policy.has_document is has_document
 
 
 @pytest.mark.django_db

--- a/api/reqs/tests/views_policies_tests.py
+++ b/api/reqs/tests/views_policies_tests.py
@@ -5,7 +5,6 @@ from django.http import Http404
 from model_mommy import mommy
 from rest_framework.test import APIClient
 
-from document.models import DocNode
 from reqs.models import Agency, AgencyGroup, Policy, Requirement, Topic
 from reqs.views import policies as policies_views
 
@@ -60,24 +59,6 @@ def test_topics_counts_filter_req(policy_topic_setup):
     assert response['count'] == 1
     assert response['results'][0]['total_reqs'] == len(reqs[1])
     assert response['results'][0]['relevant_reqs'] == 1
-
-
-@pytest.mark.django_db
-def test_has_docnodes_works(policy_setup):
-    (policies, reqs) = policy_setup
-    client = APIClient()
-
-    path = "/policies/?requirements__req_id=" + reqs[1][1].req_id
-    response = client.get(path).json()
-
-    assert response['results'][0]['has_docnodes'] is False
-
-    policies[1].docnode = mommy.make(DocNode, policy=policies[1])
-    policies[1].save()
-
-    response = client.get(path).json()
-
-    assert response['results'][0]['has_docnodes'] is True
 
 
 @pytest.mark.django_db

--- a/api/reqs/views/policies.py
+++ b/api/reqs/views/policies.py
@@ -82,7 +82,6 @@ class PolicyViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         queryset = super().get_queryset() \
-            .annotate_with_has_docnodes() \
             .annotate(total_reqs=relevant_reqs_count({}),
                       relevant_reqs=relevant_reqs_count(self.request.GET)) \
             .filter(public=True, relevant_reqs__gt=0)

--- a/ui/__tests__/components/policies/policy-view.test.js
+++ b/ui/__tests__/components/policies/policy-view.test.js
@@ -9,7 +9,7 @@ describe('<PolicyView />', () => {
     id: 1,
     title_with_number: 'Funky Policy',
     omb_policy_id: 'M-16-19',
-    has_document: false,
+    has_published_document: false,
     relevant_reqs: 1,
     total_reqs: 2,
   };
@@ -17,7 +17,7 @@ describe('<PolicyView />', () => {
   it('does not link to policy if no docnode for it exists', () => {
     const policy = new Policy({
       ...basePolicy,
-      has_document: false,
+      has_published_document: false,
     });
     const result = shallow(<PolicyView policy={policy} topicsIds="" />);
     expect(result.find('h2 Link').exists()).toBeFalsy();
@@ -27,7 +27,7 @@ describe('<PolicyView />', () => {
   it('links to policy if a docnode for it exists', () => {
     const policy = new Policy({
       ...basePolicy,
-      has_document: true,
+      has_published_document: true,
     });
     const result = shallow(<PolicyView policy={policy} topicsIds="" />);
     const link = result.find('h2 Link');

--- a/ui/__tests__/components/policies/policy-view.test.js
+++ b/ui/__tests__/components/policies/policy-view.test.js
@@ -9,7 +9,7 @@ describe('<PolicyView />', () => {
     id: 1,
     title_with_number: 'Funky Policy',
     omb_policy_id: 'M-16-19',
-    has_docnodes: false,
+    has_document: false,
     relevant_reqs: 1,
     total_reqs: 2,
   };
@@ -17,7 +17,7 @@ describe('<PolicyView />', () => {
   it('does not link to policy if no docnode for it exists', () => {
     const policy = new Policy({
       ...basePolicy,
-      has_docnodes: false,
+      has_document: false,
     });
     const result = shallow(<PolicyView policy={policy} topicsIds="" />);
     expect(result.find('h2 Link').exists()).toBeFalsy();
@@ -27,7 +27,7 @@ describe('<PolicyView />', () => {
   it('links to policy if a docnode for it exists', () => {
     const policy = new Policy({
       ...basePolicy,
-      has_docnodes: true,
+      has_document: true,
     });
     const result = shallow(<PolicyView policy={policy} topicsIds="" />);
     const link = result.find('h2 Link');

--- a/ui/__tests__/util/policy.test.js
+++ b/ui/__tests__/util/policy.test.js
@@ -3,7 +3,7 @@ import Policy from '../../util/policy';
 function policy(props = {}) {
   return new Policy({
     id: 1,
-    has_document: false,
+    has_published_document: false,
     omb_policy_id: 'M-16-19',
     slug: 'ew-a-slug',
     ...props,
@@ -19,20 +19,22 @@ describe('Policy', () => {
     expect(policy({ id: 4 }).id).toBe(4);
   });
 
-  describe('hasDocument', () => {
+  describe('hasPublishedDocument', () => {
     it('returns false if the policy has no document', () => {
-      expect(policy({ has_document: false }).hasDocument).toBe(false);
+      const pol = policy({ has_published_document: false });
+      expect(pol.hasPublishedDocument).toBe(false);
     });
 
     it('returns true if the policy has a document', () => {
-      expect(policy({ has_document: true }).hasDocument).toBe(true);
+      const pol = policy({ has_published_document: true });
+      expect(pol.hasPublishedDocument).toBe(true);
     });
   });
 
   describe('getDocumentLinkProps()', () => {
     it('returns link props with OMB policy id', () => {
       expect(policy({
-        has_document: true,
+        has_published_document: true,
         omb_policy_id: 'blarg', // preferred
         slug: 'something-else',
       }).getDocumentLinkProps()).toEqual({
@@ -43,7 +45,7 @@ describe('Policy', () => {
 
     it('returns link props with a slug', () => {
       expect(policy({
-        has_document: true,
+        has_published_document: true,
         omb_policy_id: '',
         slug: 'some-slug-here',
       }).getDocumentLinkProps()).toEqual({

--- a/ui/__tests__/util/policy.test.js
+++ b/ui/__tests__/util/policy.test.js
@@ -3,7 +3,7 @@ import Policy from '../../util/policy';
 function policy(props = {}) {
   return new Policy({
     id: 1,
-    has_docnodes: false,
+    has_document: false,
     omb_policy_id: 'M-16-19',
     slug: 'ew-a-slug',
     ...props,
@@ -19,20 +19,20 @@ describe('Policy', () => {
     expect(policy({ id: 4 }).id).toBe(4);
   });
 
-  describe('hasDocument()', () => {
+  describe('hasDocument', () => {
     it('returns false if the policy has no document', () => {
-      expect(policy({ has_docnodes: false }).hasDocument()).toBe(false);
+      expect(policy({ has_document: false }).hasDocument).toBe(false);
     });
 
     it('returns true if the policy has a document', () => {
-      expect(policy({ has_docnodes: true }).hasDocument()).toBe(true);
+      expect(policy({ has_document: true }).hasDocument).toBe(true);
     });
   });
 
   describe('getDocumentLinkProps()', () => {
     it('returns link props with OMB policy id', () => {
       expect(policy({
-        has_docnodes: true,
+        has_document: true,
         omb_policy_id: 'blarg', // preferred
         slug: 'something-else',
       }).getDocumentLinkProps()).toEqual({
@@ -43,7 +43,7 @@ describe('Policy', () => {
 
     it('returns link props with a slug', () => {
       expect(policy({
-        has_docnodes: true,
+        has_document: true,
         omb_policy_id: '',
         slug: 'some-slug-here',
       }).getDocumentLinkProps()).toEqual({

--- a/ui/__tests__/util/policy.test.js
+++ b/ui/__tests__/util/policy.test.js
@@ -5,6 +5,7 @@ function policy(props = {}) {
     id: 1,
     has_docnodes: false,
     omb_policy_id: 'M-16-19',
+    slug: 'ew-a-slug',
     ...props,
   });
 }
@@ -32,10 +33,22 @@ describe('Policy', () => {
     it('returns link props with OMB policy id', () => {
       expect(policy({
         has_docnodes: true,
-        omb_policy_id: 'blarg',
+        omb_policy_id: 'blarg', // preferred
+        slug: 'something-else',
       }).getDocumentLinkProps()).toEqual({
         route: 'document',
         params: { policyId: 'blarg' },
+      });
+    });
+
+    it('returns link props with a slug', () => {
+      expect(policy({
+        has_docnodes: true,
+        omb_policy_id: '',
+        slug: 'some-slug-here',
+      }).getDocumentLinkProps()).toEqual({
+        route: 'document',
+        params: { policyId: 'some-slug-here' },
       });
     });
   });

--- a/ui/components/policies/policy-view.js
+++ b/ui/components/policies/policy-view.js
@@ -13,7 +13,7 @@ export default function PolicyView({ policy, topicsIds }) {
   const countClass = relevantReqCount === '99+' ? 'ninety-nine-plus' : '';
   let policyTitle = policy.titleWithNumber;
 
-  if (policy.hasDocument) {
+  if (policy.hasPublishedDocument) {
     policyTitle = (
       <Link {...policy.getDocumentLinkProps()}>
         {policyTitle}

--- a/ui/components/policies/policy-view.js
+++ b/ui/components/policies/policy-view.js
@@ -13,7 +13,7 @@ export default function PolicyView({ policy, topicsIds }) {
   const countClass = relevantReqCount === '99+' ? 'ninety-nine-plus' : '';
   let policyTitle = policy.titleWithNumber;
 
-  if (policy.hasDocument()) {
+  if (policy.hasDocument) {
     policyTitle = (
       <Link {...policy.getDocumentLinkProps()}>
         {policyTitle}

--- a/ui/util/policy.js
+++ b/ui/util/policy.js
@@ -17,6 +17,7 @@ export default class Policy {
     this.ombPolicyId = initial.ombPolicyId || initial.omb_policy_id || '';
     this.originalUrl = initial.originalUrl || initial.original_url || '';
     this.relevantReqs = initial.relevantReqs || initial.relevant_reqs || 0;
+    this.slug = initial.slug || '';
     this.title = initial.title || '';
     this.titleWithNumber = initial.titleWithNumber || initial.title_with_number || '';
     this.totalReqs = initial.totalReqs || initial.total_reqs || 0;
@@ -24,14 +25,14 @@ export default class Policy {
   }
 
   hasDocument() {
-    return this.ombPolicyId && this.hasDocnodes;
+    return this.hasDocnodes;
   }
 
   getDocumentLinkProps() {
     return {
       route: 'document',
       params: {
-        policyId: this.ombPolicyId,
+        policyId: this.ombPolicyId || this.slug,
       },
     };
   }

--- a/ui/util/policy.js
+++ b/ui/util/policy.js
@@ -10,7 +10,7 @@ const DATE_FORMAT = 'MMMM D, YYYY';
 
 export default class Policy {
   constructor(initial) {
-    this.hasDocnodes = initial.hasDocnodes || initial.has_docnodes || false;
+    this.hasDocument = initial.hasDocument || initial.has_document || false;
     this.id = initial.id || '';
     this.issuance = initial.issuance || '';
     this.issuingBody = initial.issuingBody || initial.issuing_body || '';
@@ -22,10 +22,6 @@ export default class Policy {
     this.titleWithNumber = initial.titleWithNumber || initial.title_with_number || '';
     this.totalReqs = initial.totalReqs || initial.total_reqs || 0;
     Object.freeze(this);
-  }
-
-  hasDocument() {
-    return this.hasDocnodes;
   }
 
   getDocumentLinkProps() {

--- a/ui/util/policy.js
+++ b/ui/util/policy.js
@@ -10,7 +10,8 @@ const DATE_FORMAT = 'MMMM D, YYYY';
 
 export default class Policy {
   constructor(initial) {
-    this.hasDocument = initial.hasDocument || initial.has_document || false;
+    this.hasPublishedDocument =
+      initial.hasPublishedDocument || initial.has_published_document || false;
     this.id = initial.id || '';
     this.issuance = initial.issuance || '';
     this.issuingBody = initial.issuingBody || initial.issuing_body || '';


### PR DESCRIPTION
This resolves #678 by linking to the document page when a policy doesn't have an M-number.

It also checks the workflow phase field rather than the presence/absence of docnodes when determining what to link to. Note, however, this means we'll be removing all our current links. I figure we can use the admin to adjust where desired, but we can also do a data migration if there's a better option.