### PR TITLE
Serialize ProseMirror data

### DIFF
--- a/api/document/js/__tests__/fetch-doc.test.ts
+++ b/api/document/js/__tests__/fetch-doc.test.ts
@@ -26,7 +26,7 @@ describe('convertNode()', () => {
 
     const result = convertNode(node);
 
-    expect(result.type.name).toBe('doc');
+    expect(result.type.name).toBe('policy');
     expect(result.content.childCount).toBe(2);
     expect(result.content.child(0).type.name).toBe('unimplemented_node');
     expect(result.content.child(1).type.name).toBe('unimplemented_node');

--- a/api/document/js/__tests__/save-doc.test.ts
+++ b/api/document/js/__tests__/save-doc.test.ts
@@ -1,0 +1,115 @@
+import { Fragment } from 'prosemirror-model';
+
+import { apiFactory, convertNode, convertTexts } from '../save-doc';
+import schema from '../schema';
+
+
+describe('convertNode()', () => {
+  it('converts nested nodes', () => {
+    const node = schema.nodes.policy.create({}, [
+      schema.nodes.sec.create({}, [
+        schema.nodes.heading.create({ depth: 1 }, schema.text('Some heading')),
+        schema.nodes.para.create(
+          {},
+          schema.nodes.inline.create({}, schema.text('First paragraph')),
+        ),
+      ]),
+      schema.nodes.para.create(
+        {},
+        schema.nodes.inline.create({}, schema.text('A later paragraph')),
+      ),
+    ]);
+
+    const result = convertNode(node);
+    expect(result).toEqual(apiFactory.node('policy', {
+      children: [
+        apiFactory.node('sec', {
+          children: [
+            apiFactory.node('heading', {
+              content: [
+                apiFactory.content('__text__', { text: 'Some heading' }),
+              ],
+            }),
+            apiFactory.node('para', {
+              content: [
+                apiFactory.content('__text__', { text: 'First paragraph' }),
+              ],
+            }),
+          ],
+        }),
+        apiFactory.node('para', {
+          content: [
+            apiFactory.content('__text__', { text: 'A later paragraph' }),
+          ],
+        }),
+      ],
+    }));
+  });
+
+  it('converts headings', () => {
+    const node = schema.nodes.heading.create(
+      { depth: 2 }, // this will be ignored
+      schema.text('Stuff stuff'),
+    );
+    const result = convertNode(node);
+    expect(result).toEqual({
+      node_type: 'heading',
+      children: [],
+      content: [{ content_type: '__text__', inlines: [], text: 'Stuff stuff' }],
+    });
+  });
+
+  it('converts unimplemented nodes', () => {
+    const node = schema.nodes.unimplemented_node.create({
+      data: { some: 'random', attrs: 'here' },
+    });
+    const result = convertNode(node);
+    expect(result).toEqual({ some: 'random', attrs: 'here' });
+  });
+});
+
+describe('convertTexts()', () => {
+  it('converts simple text', () => {
+    const result = convertTexts(Fragment.fromArray([
+      schema.text('Some content'),
+    ]));
+    expect(result).toEqual([{
+      content_type: '__text__',
+      inlines: [],
+      text: 'Some content',
+    }]);
+  });
+
+  it('converts nested marks', () => {
+    const result = convertTexts(Fragment.fromArray([
+      schema.text('Some '),
+      schema.text('nested', [
+        schema.marks.unimplemented_mark.create({
+          data: { content_type: 'one', outer: 'thing' },
+        }),
+        schema.marks.unimplemented_mark.create({
+          data: { content_type: 'two', inner: 'here' },
+        }),
+        schema.marks.unimplemented_mark.create({
+          data: { content_type: 'three', most: 'deep' },
+        }),
+      ]),
+      schema.text(' content'),
+    ]));
+
+    expect(result).toEqual([
+      apiFactory.content('__text__', { text: 'Some ' }),
+      apiFactory.content('one', {
+        outer: 'thing',
+        inlines: [apiFactory.content('two', {
+          inner: 'here',
+          inlines: [apiFactory.content('three', {
+            most: 'deep',
+            inlines: [apiFactory.content('__text__', { text: 'nested' })],
+          })],
+        })],
+      }),
+      apiFactory.content('__text__', { text: ' content' }),
+    ]);
+  });
+});

--- a/api/document/js/fetch-doc.ts
+++ b/api/document/js/fetch-doc.ts
@@ -41,7 +41,7 @@ const NODE_TYPE_CONVERTERS = {
     return schema.nodes.para.create({}, [inlineContent].concat(childContent));
   },
   policy: node =>
-    schema.nodes.doc.create({}, (node.children || []).map(convertNode)),
+    schema.nodes.policy.create({}, (node.children || []).map(convertNode)),
   sec: node =>
     schema.nodes.sec.create({}, (node.children || []).map(convertNode)),
   unimplemented_node: node =>

--- a/api/document/js/keyboard.ts
+++ b/api/document/js/keyboard.ts
@@ -2,10 +2,13 @@ import { baseKeymap } from 'prosemirror-commands';
 import { undo, redo } from 'prosemirror-history';
 import { keymap } from 'prosemirror-keymap';
 
+import saveDoc from './save-doc';
+
 const keyboard = keymap({
   ...baseKeymap,
   'Mod-z': undo,
   'Shift-Mod-z': redo,
+  'Mod-s': saveDoc,
 });
 
 export default keyboard;

--- a/api/document/js/save-doc.ts
+++ b/api/document/js/save-doc.ts
@@ -1,0 +1,97 @@
+import { Fragment, Mark, Node } from 'prosemirror-model';
+
+import schema from './schema';
+
+interface ApiNode {
+  children: ApiNode[];
+  content: ApiContent[];
+  node_type: string;
+  // at some point, we'll need: marker, title, type_emblem
+}
+
+interface ApiContent {
+  content_type: string;
+  inlines: ApiContent[];
+  text: string;
+}
+
+export const apiFactory = {
+  node(nodeType, overrides): ApiNode {
+    return {
+      node_type: nodeType,
+      children: [],
+      content: [],
+      ...(overrides || {}),
+    };
+  },
+  content(contentType, overrides): ApiContent {
+    return {
+      content_type: contentType,
+      inlines: [],
+      text: '',
+      ...(overrides || {}),
+    };
+  },
+};
+
+
+const NODE_CONVERTERS = {
+  heading: node => apiFactory.node(
+    node.type.name,
+    // Text isn't in an 'inline' block
+    { content: convertTexts(node.content) },
+  ),
+  unimplemented_node: node => node.attrs.data,
+};
+
+function defaultNodeConverter(node): ApiNode {
+  const children: ApiNode[] = [];
+  let content: ApiContent[] = [];
+  node.content.forEach((child) => {
+    if (child.type === schema.nodes.inline) {
+      content = convertTexts(child.content);
+    } else {
+      children.push(convertNode(child));
+    }
+  });
+  return apiFactory.node(
+    node.type.name,
+    { children, content },
+  );
+}
+
+const MARK_CONVERTERS = {
+  unimplemented_mark: node =>
+    apiFactory.content(node.type.name, node.attrs.data),
+};
+
+
+export function convertNode(node: Node): ApiNode {
+  const converter = NODE_CONVERTERS[node.type.name] || defaultNodeConverter;
+  return converter(node);
+}
+
+// This doesn't combine adjacent marks at all; instead we'll make a "tall" set
+// of nested annotations to wrap each chunk of text.
+export function nestMarks(text: string, marks: Mark[]): ApiContent {
+  if (marks.length === 0) {
+    return apiFactory.content('__text__', { text });
+  }
+  const mark = marks[0];
+  const converted = MARK_CONVERTERS[mark.type.name](mark);
+  converted.inlines = [nestMarks(text, marks.slice(1))];
+  return converted;
+}
+
+export function convertTexts(textNodes: Fragment): ApiContent[] {
+  const result: any[] = [];
+  textNodes.forEach((textNode) => {
+    result.push(nestMarks(textNode.text || '', textNode.marks));
+  });
+  return result;
+}
+
+export default function saveDoc(state) {
+  console.log(convertNode(state.doc));
+  return true;
+}

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -1,8 +1,9 @@
 import { Schema } from 'prosemirror-model';
 
 const schema = new Schema({
+  topNode: 'policy',
   nodes: {
-    doc: {
+    policy: {
       content: 'block+',
     },
     inline: {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15,6 +15,11 @@
         "js-tokens": "3.0.2"
       }
     },
+    "@types/codemirror": {
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.55.tgz",
+      "integrity": "sha512-sDuo5cONKBd0Rre2kaJ1mdc0NinqoPb96Yy3T3bzEMe72BzbEP+kAZiwBbZj/NzV93oAFdcjodknsA93ICXLoA=="
+    },
     "@types/jest": {
       "version": "22.0.1",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.0.1.tgz",
@@ -1005,6 +1010,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "codemirror": {
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.33.0.tgz",
+      "integrity": "sha512-HT6PKVqkwpzwB3jl5hXFoQteEWXbSWMzG3Z8RVYlx8hZwCOLCy4NU7vkSB3dYX3e6ORwRfGw4uFOXaw4rn/a9Q=="
     },
     "color": {
       "version": "0.11.4",


### PR DESCRIPTION
This adds an initial serializer for the ProseMirror data, which is triggered on Ctrl/Cmd-s. This doesn't actually write to the API yet; I need to refactor the components shared with the AKN editor first. I figured this was already big enough for review.