### PR TITLE
Save data from prosemirror

### DIFF
--- a/api/document/js/Api.ts
+++ b/api/document/js/Api.ts
@@ -22,7 +22,7 @@ export default class Api {
   contentType: string;
   csrfToken: string;
 
-  constructor(url: string, contentType: string, csrfToken: string) {
+  constructor({ contentType, csrfToken, url }) {
     this.url = url;
     this.contentType = contentType;
     this.csrfToken = csrfToken;

--- a/api/document/js/Api.ts
+++ b/api/document/js/Api.ts
@@ -1,0 +1,56 @@
+import axios from 'axios';
+
+import { getEl } from './util';
+
+function setStatus(msg: string, className: 'editor-status-error'|'' = '') {
+  const status = getEl('#status');
+  status.textContent = msg;
+  status.className = className;
+}
+
+function setStatusError(e: Error) {
+  let errMsg = `An error occurred: ${e}`;
+  const data = e['response'] && e['response']['data'];
+  if (data) {
+    errMsg += '\n' + JSON.stringify(data, null, 2);
+  }
+  setStatus(errMsg, 'editor-status-error');
+}
+
+export default class Api {
+  url: string;
+  contentType: string;
+  csrfToken: string;
+
+  constructor(url: string, contentType: string, csrfToken: string) {
+    this.url = url;
+    this.contentType = contentType;
+    this.csrfToken = csrfToken;
+  }
+
+  async fetch() {
+    try {
+      setStatus('Loading document...');
+      const response = await axios.get(this.url, { headers: {
+        Accept: this.contentType,
+      } });
+      setStatus('Document loaded.');
+      return response.data;
+    } catch (e) {
+      setStatusError(e);
+    }
+  }
+
+  async write(data) {
+    try {
+      setStatus('Saving...');
+      await axios.put(this.url, data, { headers: {
+        'Content-Type': this.contentType,
+        'X-CSRFToken': this.csrfToken,
+      } });
+      setStatus(`Document saved at ${new Date()}.`);
+    } catch (e) {
+      setStatusError(e);
+    }
+  }
+}

--- a/api/document/js/__tests__/Api.test.ts
+++ b/api/document/js/__tests__/Api.test.ts
@@ -1,0 +1,91 @@
+jest.mock('axios');
+jest.mock('../util', () => ({
+  getEl: jest.fn(jest.fn),
+}));
+
+import axios from 'axios';
+
+import Api from '../Api';
+import { getEl } from '../util';
+
+function mockSetStatus() {
+  const textContent = jest.fn();
+  const statusEl = {};
+  Object.defineProperty(statusEl, 'textContent', { set: textContent });
+  (getEl as any).mockReturnValue(statusEl);
+  return textContent;
+}
+
+const api = new Api('http://example.com/path', 'c-type', 'some-token');
+
+describe('fetch()', () => {
+  it('passes the correct args', () => {
+    api.fetch();
+    expect(axios.get).toHaveBeenCalledWith(
+      'http://example.com/path', { headers: { Accept: 'c-type' } });
+  });
+
+  it('loads the data', async () => {
+    axios.get = jest.fn(() => ({ data: 'some stuff!' }));
+    const result = await api.fetch();
+    expect(result).toBe('some stuff!');
+  });
+
+  it('sets the proper status messages', async () => {
+    const textContent = mockSetStatus();
+    await api.fetch();
+
+    expect(textContent.mock.calls).toEqual([
+      ['Loading document...'],
+      ['Document loaded.'],
+    ]);
+  });
+
+  it('handles exceptions', async () => {
+    const textContent = mockSetStatus();
+    const error: any = new Error();
+    error.response = { data: { oh: 'noes', and: 6 } };
+    axios.get = jest.fn(() => { throw error; });
+
+    await api.fetch();
+
+    expect(textContent).toHaveBeenCalledTimes(2);
+    const message = textContent.mock.calls[1][0];
+    expect(message).toMatch(/oh.*noes/);
+    expect(message).toMatch(/An error occurred/);
+  });
+});
+
+describe('write()', () => {
+  it('passes the correct args', () => {
+    api.write('some data here');
+    expect(axios.put).toHaveBeenCalledWith(
+      'http://example.com/path',
+      'some data here',
+      { headers: { 'Content-Type': 'c-type', 'X-CSRFToken': 'some-token' } },
+    );
+  });
+
+  it('sets success', async () => {
+    const textContent = mockSetStatus();
+    await api.write('');
+
+    expect(textContent).toHaveBeenCalledTimes(2);
+    expect(textContent.mock.calls[0]).toEqual(['Saving...']);
+    expect(textContent.mock.calls[1][0]).toMatch(/Document saved at/);
+  });
+
+  it('handles exceptions', async () => {
+    const textContent = mockSetStatus();
+    const error: any = new Error();
+    error.response = { data: { some: 'warning' } };
+    axios.get = jest.fn(() => { throw error; });
+
+    await api.fetch();
+
+    expect(textContent).toHaveBeenCalledTimes(2);
+    const message = textContent.mock.calls[1][0];
+    expect(message).toMatch(/some.*warning/);
+    expect(message).toMatch(/An error occurred/);
+  });
+});

--- a/api/document/js/__tests__/Api.test.ts
+++ b/api/document/js/__tests__/Api.test.ts
@@ -16,7 +16,11 @@ function mockSetStatus() {
   return textContent;
 }
 
-const api = new Api('http://example.com/path', 'c-type', 'some-token');
+const api = new Api({
+  contentType: 'c-type',
+  csrfToken: 'some-token',
+  url: 'http://example.com/path',
+});
 
 describe('fetch()', () => {
   it('passes the correct args', () => {

--- a/api/document/js/__tests__/parse-doc.test.ts
+++ b/api/document/js/__tests__/parse-doc.test.ts
@@ -1,20 +1,10 @@
 import axios from 'axios';
 
-import fetchDoc, { convertContent, convertNode } from '../fetch-doc';
+import parseDoc, { convertContent } from '../parse-doc';
 
 jest.mock('axios');
 
-describe('fetchDoc()', () => {
-  it('raises 404, etc. Eventually we will catch them', () => {
-    const error404: any = new Error('Not Found');
-    error404.response = { status: 404 };
-
-    axios.get = jest.fn(() => { throw error404; });
-    expect(() => fetchDoc('/admin/document-editor/M-12-34')).toThrow(error404);
-  });
-});
-
-describe('convertNode()', () => {
+describe('parseDoc()', () => {
   it('handles the root', () => {
     const node = {
       node_type: 'policy',
@@ -24,7 +14,7 @@ describe('convertNode()', () => {
       ],
     };
 
-    const result = convertNode(node);
+    const result = parseDoc(node);
 
     expect(result.type.name).toBe('policy');
     expect(result.content.childCount).toBe(2);
@@ -45,7 +35,7 @@ describe('convertNode()', () => {
       children: [{ node_type: 'unknown-child' }],
     };
 
-    const result = convertNode(node);
+    const result = parseDoc(node);
     expect(result.type.name).toBe('para');
     expect(result.content.childCount).toBe(2);
     expect(result.content.child(0).type.name).toBe('inline');
@@ -63,7 +53,7 @@ describe('convertNode()', () => {
       text: 'Some heading',
     };
 
-    const result = convertNode(node);
+    const result = parseDoc(node);
     expect(result.type.name).toBe('heading');
     expect(result.attrs.depth).toBe(3);
     expect(result.content.childCount).toBe(1);
@@ -82,7 +72,7 @@ describe('convertNode()', () => {
         ],
       };
 
-      const result = convertNode(node);
+      const result = parseDoc(node);
       expect(result.type.name).toBe('unimplemented_node');
       expect(result.attrs).toEqual({ data: node });
       expect(result.content.childCount).toBe(0);

--- a/api/document/js/__tests__/serialize-doc.test.ts
+++ b/api/document/js/__tests__/serialize-doc.test.ts
@@ -1,10 +1,10 @@
 import { Fragment } from 'prosemirror-model';
 
-import { apiFactory, convertNode, convertTexts } from '../save-doc';
+import serializeDoc, { apiFactory, convertTexts } from '../serialize-doc';
 import schema from '../schema';
 
 
-describe('convertNode()', () => {
+describe('serializeDoc()', () => {
   it('converts nested nodes', () => {
     const node = schema.nodes.policy.create({}, [
       schema.nodes.sec.create({}, [
@@ -20,7 +20,7 @@ describe('convertNode()', () => {
       ),
     ]);
 
-    const result = convertNode(node);
+    const result = serializeDoc(node);
     expect(result).toEqual(apiFactory.node('policy', {
       children: [
         apiFactory.node('sec', {
@@ -51,7 +51,7 @@ describe('convertNode()', () => {
       { depth: 2 }, // this will be ignored
       schema.text('Stuff stuff'),
     );
-    const result = convertNode(node);
+    const result = serializeDoc(node);
     expect(result).toEqual({
       node_type: 'heading',
       children: [],
@@ -63,7 +63,7 @@ describe('convertNode()', () => {
     const node = schema.nodes.unimplemented_node.create({
       data: { some: 'random', attrs: 'here' },
     });
-    const result = convertNode(node);
+    const result = serializeDoc(node);
     expect(result).toEqual({ some: 'random', attrs: 'here' });
   });
 });

--- a/api/document/js/akn/main.ts
+++ b/api/document/js/akn/main.ts
@@ -5,49 +5,14 @@ import 'codemirror/addon/search/search.js';
 import 'codemirror/addon/search/searchcursor.js';
 import 'codemirror/addon/dialog/dialog.js';
 
+import Api from '../Api';
 import { getEl, getElAttr } from '../util';
-
 
 const EDITOR_SEL = '#editor';
 const DOC_URL_ATTR = 'data-document-url';
 const AKN_CONTENT_TYPE = 'application/akn+xml';
 
-function fetchDoc() {
-  return axios({
-    method: 'GET',
-    url: getElAttr(EDITOR_SEL, DOC_URL_ATTR),
-    headers: { Accept: AKN_CONTENT_TYPE },
-  }).then(response => response.data);
-}
-
-function saveDoc(data: string) {
-  return axios({
-    data,
-    method: 'put',
-    url: getElAttr(EDITOR_SEL, DOC_URL_ATTR),
-    headers: {
-      'Content-Type': AKN_CONTENT_TYPE,
-      'X-CSRFToken': getElAttr('[name=csrfmiddlewaretoken]', 'value'),
-    },
-  });
-}
-
-function setStatusError(e: Error) {
-  let errMsg = `An error occurred: ${e}`;
-  const data = e['response'] && e['response']['data'];
-  if (data) {
-    errMsg += '\n' + JSON.stringify(data, null, 2);
-  }
-  setStatus(errMsg, 'editor-status-error');
-}
-
-function setStatus(msg: string, className: 'editor-status-error'|'' = '') {
-  const status = getEl('#status');
-  status.textContent = msg;
-  status.className = className;
-}
-
-function createEditor(value: string) {
+function createEditor(value: string, api: Api) {
   const cm = CodeMirror(getEl(EDITOR_SEL), {
     value,
     lineNumbers: true,
@@ -55,18 +20,15 @@ function createEditor(value: string) {
     theme: 'eclipse',
   });
 
-  CodeMirror['commands'].save = (cm) => {
-    setStatus('Saving...');
-    saveDoc(cm.getValue()).then((_) => {
-      setStatus(`Document saved at ${new Date()}.`);
-    }).catch(setStatusError);
-  };
+  CodeMirror['commands'].save = cm => api.write(cm.getValue());
 }
 
 window.addEventListener('load', () => {
-  setStatus('Loading document...');
-  fetchDoc().then((value) => {
-    setStatus('Document loaded.');
-    createEditor(value);
-  }).catch(setStatusError);
+  const api = new Api(
+    getElAttr(EDITOR_SEL, DOC_URL_ATTR),
+    AKN_CONTENT_TYPE,
+    getElAttr('[name=csrfmiddlewaretoken]', 'value'),
+  );
+
+  api.fetch().then(data => createEditor(data, api));
 });

--- a/api/document/js/akn/main.ts
+++ b/api/document/js/akn/main.ts
@@ -24,11 +24,11 @@ function createEditor(value: string, api: Api) {
 }
 
 window.addEventListener('load', () => {
-  const api = new Api(
-    getElAttr(EDITOR_SEL, DOC_URL_ATTR),
-    AKN_CONTENT_TYPE,
-    getElAttr('[name=csrfmiddlewaretoken]', 'value'),
-  );
+  const api = new Api({
+    contentType: AKN_CONTENT_TYPE,
+    csrfToken: getElAttr('[name=csrfmiddlewaretoken]', 'value'),
+    url: getElAttr(EDITOR_SEL, DOC_URL_ATTR),
+  });
 
   api.fetch().then(data => createEditor(data, api));
 });

--- a/api/document/js/akn/main.ts
+++ b/api/document/js/akn/main.ts
@@ -8,15 +8,6 @@ import 'codemirror/addon/dialog/dialog.js';
 import { getEl, getElAttr } from '../util';
 
 
-// We need to load our CSS via require() rather than import;
-// using the latter raises errors about not being able to find
-// the module.
-declare function require(path: string): null;
-
-require('codemirror/lib/codemirror.css');
-require('codemirror/theme/eclipse.css');
-require('codemirror/addon/dialog/dialog.css');
-
 const EDITOR_SEL = '#editor';
 const DOC_URL_ATTR = 'data-document-url';
 const AKN_CONTENT_TYPE = 'application/akn+xml';

--- a/api/document/js/akn/main.ts
+++ b/api/document/js/akn/main.ts
@@ -47,10 +47,10 @@ function setStatusError(e: Error) {
   if (data) {
     errMsg += '\n' + JSON.stringify(data, null, 2);
   }
-  setStatus(errMsg, 'error');
+  setStatus(errMsg, 'editor-status-error');
 }
 
-function setStatus(msg: string, className: 'error'|'' = '') {
+function setStatus(msg: string, className: 'editor-status-error'|'' = '') {
   const status = getEl('#status');
   status.textContent = msg;
   status.className = className;

--- a/api/document/js/create-editor-state.ts
+++ b/api/document/js/create-editor-state.ts
@@ -2,15 +2,17 @@ import { Node } from 'prosemirror-model';
 import { EditorState } from 'prosemirror-state';
 import { history } from 'prosemirror-history';
 
-import menu from './menu';
+import Api from './Api';
 import keyboard from './keyboard';
+import menu from './menu';
+import parseDoc from './parse-doc';
 
-export default function createEditorState(doc: Node): EditorState {
+export default function createEditorState(data, api: Api): EditorState {
   return EditorState.create({
-    doc,
+    doc: parseDoc(data),
     plugins: [
       menu,
-      keyboard,
+      keyboard(api),
       history(),
     ],
   });

--- a/api/document/js/keyboard.ts
+++ b/api/document/js/keyboard.ts
@@ -2,13 +2,14 @@ import { baseKeymap } from 'prosemirror-commands';
 import { undo, redo } from 'prosemirror-history';
 import { keymap } from 'prosemirror-keymap';
 
-import saveDoc from './save-doc';
+import Api from './Api';
+import serializeDoc from './serialize-doc';
 
-const keyboard = keymap({
-  ...baseKeymap,
-  'Mod-z': undo,
-  'Shift-Mod-z': redo,
-  'Mod-s': saveDoc,
-});
-
-export default keyboard;
+export default function menu(api: Api) {
+  return keymap({
+    ...baseKeymap,
+    'Mod-z': undo,
+    'Shift-Mod-z': redo,
+    'Mod-s': async state => api.write(serializeDoc(state.doc)),
+  });
+}

--- a/api/document/js/main.ts
+++ b/api/document/js/main.ts
@@ -4,21 +4,6 @@ import { getEl, getElAttr } from './util';
 import createEditorState from './create-editor-state';
 import fetchDoc from './fetch-doc';
 
-// We need to load our CSS via require() rather than import;
-// using the latter raises errors about not being able to find
-// the module.
-//
-// I *suspect* it is because ts-loader (the TypeScript plugin for
-// webpack) probably loads import statements on its own,
-// without going through webpack, and it doesn't know what to
-// do with non-standard kinds of imports like CSS, so using require()
-// likely bypasses TypeScript and goes straight to webpack, which
-// deals with it correctly. I could be wrong, though. -AV
-declare function require(path: string): null;
-
-require('prosemirror-view/style/prosemirror.css');
-require('prosemirror-menu/style/menu.css');
-
 const EDITOR_SEL = '#editor';
 
 window.addEventListener('load', async () => {

--- a/api/document/js/main.ts
+++ b/api/document/js/main.ts
@@ -1,14 +1,21 @@
 import { EditorView } from 'prosemirror-view';
 
-import { getEl, getElAttr } from './util';
+import Api from './Api';
 import createEditorState from './create-editor-state';
-import fetchDoc from './fetch-doc';
+import { getEl, getElAttr } from './util';
 
 const EDITOR_SEL = '#editor';
+const DOC_URL_ATTR = 'data-document-url';
 
-window.addEventListener('load', async () => {
-  const doc = await fetchDoc(getElAttr(EDITOR_SEL, 'data-document-url'));
-  new EditorView(getEl(EDITOR_SEL), {
-    state: createEditorState(doc),
+window.addEventListener('load', () => {
+  const api = new Api(
+    getElAttr(EDITOR_SEL, DOC_URL_ATTR),
+    'application/json',
+    getElAttr('[name=csrfmiddlewaretoken]', 'value'),
+  );
+
+  api.fetch().then((data) => {
+    const state = createEditorState(data, api);
+    new EditorView(getEl(EDITOR_SEL), { state });
   });
 });

--- a/api/document/js/main.ts
+++ b/api/document/js/main.ts
@@ -8,11 +8,11 @@ const EDITOR_SEL = '#editor';
 const DOC_URL_ATTR = 'data-document-url';
 
 window.addEventListener('load', () => {
-  const api = new Api(
-    getElAttr(EDITOR_SEL, DOC_URL_ATTR),
-    'application/json',
-    getElAttr('[name=csrfmiddlewaretoken]', 'value'),
-  );
+  const api = new Api({
+    contentType: 'application/json',
+    csrfToken: getElAttr('[name=csrfmiddlewaretoken]', 'value'),
+    url: getElAttr(EDITOR_SEL, DOC_URL_ATTR),
+  });
 
   api.fetch().then((data) => {
     const state = createEditorState(data, api);

--- a/api/document/js/parse-doc.ts
+++ b/api/document/js/parse-doc.ts
@@ -4,7 +4,7 @@ import { Mark, Node } from 'prosemirror-model';
 
 import schema from './schema';
 
-export function convertNode(node) {
+export default function parseDoc(node): Node {
   const nodeType = node.node_type in NODE_TYPE_CONVERTERS ?
     node.node_type : 'unimplemented_node';
   return NODE_TYPE_CONVERTERS[nodeType](node);
@@ -37,13 +37,13 @@ const NODE_TYPE_CONVERTERS = {
   para(node) {
     const nested: Node[][] = (node.content || []).map(c => convertContent(c, []));
     const inlineContent = schema.nodes.inline.create({}, flatten(nested));
-    const childContent = (node.children || []).map(convertNode);
+    const childContent = (node.children || []).map(parseDoc);
     return schema.nodes.para.create({}, [inlineContent].concat(childContent));
   },
   policy: node =>
-    schema.nodes.policy.create({}, (node.children || []).map(convertNode)),
+    schema.nodes.policy.create({}, (node.children || []).map(parseDoc)),
   sec: node =>
-    schema.nodes.sec.create({}, (node.children || []).map(convertNode)),
+    schema.nodes.sec.create({}, (node.children || []).map(parseDoc)),
   unimplemented_node: node =>
     schema.nodes.unimplemented_node.create({ data: node }),
 };
@@ -52,7 +52,3 @@ const CONTENT_TYPE_CONVERTERS = {
   unimplemented_mark: content =>
     schema.marks.unimplemented_mark.create({ data: content }),
 };
-
-export default function fetchDoc(path: string) {
-  return axios.get(path).then(response => convertNode(response.data));
-}

--- a/api/document/js/serialize-doc.ts
+++ b/api/document/js/serialize-doc.ts
@@ -51,7 +51,7 @@ function defaultNodeConverter(node): ApiNode {
     if (child.type === schema.nodes.inline) {
       content = convertTexts(child.content);
     } else {
-      children.push(convertNode(child));
+      children.push(serializeDoc(child));
     }
   });
   return apiFactory.node(
@@ -66,7 +66,7 @@ const MARK_CONVERTERS = {
 };
 
 
-export function convertNode(node: Node): ApiNode {
+export default function serializeDoc(node: Node): ApiNode {
   const converter = NODE_CONVERTERS[node.type.name] || defaultNodeConverter;
   return converter(node);
 }
@@ -89,9 +89,4 @@ export function convertTexts(textNodes: Fragment): ApiContent[] {
     result.push(nestMarks(textNode.text || '', textNode.marks));
   });
   return result;
-}
-
-export default function saveDoc(state) {
-  console.log(convertNode(state.doc));
-  return true;
 }

--- a/api/document/templates/document/editor.html
+++ b/api/document/templates/document/editor.html
@@ -8,11 +8,17 @@
       rel="stylesheet"
       type="text/css"
     />
-    <title>Document editor</title>
+    <title>{{ title }}</title>
   </head>
   <body>
-    <h1>Document editor</h1>
+    <h1>{{ title }}</h1>
+    <pre id="status"></pre>
     <div class="editor-container" id="editor" data-document-url="{{ document_url }}"></div>
-    <script src="{% static 'bundles/js/document.main.bundle.js' %}"></script>
+    {% csrf_token %}
+    {% block instructions %}
+    {% endblock %}
+    {% block editor-js %}
+      <script src="{% static 'bundles/js/document.main.bundle.js' %}"></script>
+    {% endblock %}
   </body>
 </html>

--- a/api/document/templates/document/editor_akn.html
+++ b/api/document/templates/document/editor_akn.html
@@ -1,67 +1,32 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <style>
-    #editor {
-      border: 1px solid black;
-    }
+{% extends 'document/editor.html' %}
+{% load static %}
 
-    .error {
-        color: red;
-    }
+{% block instructions %}
+<h2>Help</h2>
+<dl>
+  <dt><kbd>Ctrl</kbd>+<kbd>S</kbd> or <kbd>⌘</kbd>+<kbd>S</kbd></dt>
+  <dd>Save document</dd>
 
-    /* https://meta.superuser.com/q/4788 */
-    kbd {
-      -moz-border-radius:3px;
-      -moz-box-shadow:0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
-      -webkit-border-radius:3px;
-      -webkit-box-shadow:0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
-      background-color:#f7f7f7;
-      border:1px solid #ccc;
-      border-radius:3px;
-      box-shadow:0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
-      color:#333;
-      display:inline-block;
-      font-family:Arial,Helvetica,sans-serif;
-      font-size:11px;
-      line-height:1.4;
-      margin:0 .1em;
-      padding:.1em .6em;
-      text-shadow:0 1px 0 #fff;
-    }
-    </style>
-    <title>Akoma Ntoso Document editor</title>
-  </head>
-  <body>
-    <h1>Akoma Ntoso Document editor</h1>
-    <pre id="status"></pre>
-    <div id="editor" data-document-url="{{ document_url }}"></div>
-    {% csrf_token %}
-    <h2>Help</h2>
-    <dl>
-      <dt><kbd>Ctrl</kbd>+<kbd>S</kbd> or <kbd>⌘</kbd>+<kbd>S</kbd></dt>
-      <dd>Save document</dd>
+  <dt><kbd>Ctrl</kbd>+<kbd>F</kbd> or <kbd>⌘</kbd>+<kbd>F</kbd></dt>
+  <dd>Start searching</dd>
 
-      <dt><kbd>Ctrl</kbd>+<kbd>F</kbd> or <kbd>⌘</kbd>+<kbd>F</kbd></dt>
-      <dd>Start searching</dd>
+  <dt><kbd>Ctrl</kbd>+<kbd>G</kbd> or <kbd>⌘</kbd>+<kbd>G</kbd></dt>
+  <dd>Find next</dd>
 
-      <dt><kbd>Ctrl</kbd>+<kbd>G</kbd> or <kbd>⌘</kbd>+<kbd>G</kbd></dt>
-      <dd>Find next</dd>
+  <dt><kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>G</kbd> or
+    <kbd>Shift</kbd>+<kbd>⌘</kbd>+<kbd>G</kbd></dt>
+  <dd>Find previous</dd>
 
-      <dt><kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>G</kbd> or
-        <kbd>Shift</kbd>+<kbd>⌘</kbd>+<kbd>G</kbd></dt>
-      <dd>Find previous</dd>
+  <dt><kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>F</kbd> or
+    <kbd>⌘</kbd>+<kbd>⌥</kbd>+<kbd>F</kbd></dt>
+  <dd>Replace</dd>
 
-      <dt><kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>F</kbd> or
-        <kbd>⌘</kbd>+<kbd>⌥</kbd>+<kbd>F</kbd></dt>
-      <dd>Replace</dd>
+  <dt><kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>R</kbd> or
+    <kbd>Shift</kbd>+<kbd>⌘</kbd>+<kbd>⌥</kbd>+<kbd>F</kbd></dt>
+  <dd>Replace all</dd>
+</dl>
+{% endblock %}
 
-      <dt><kbd>Shift</kbd>+<kbd>Ctrl</kbd>+<kbd>R</kbd> or
-        <kbd>Shift</kbd>+<kbd>⌘</kbd>+<kbd>⌥</kbd>+<kbd>F</kbd></dt>
-      <dd>Replace all</dd>
-    </dl>
-    {% load static %}
-    <script src="{% static 'bundles/js/document.akn.main.bundle.js' %}"></script>
-  </body>
-</html>
+{% block editor-js %}
+<script src="{% static 'bundles/js/document.akn.main.bundle.js' %}"></script>
+{% endblock %}

--- a/api/document/views.py
+++ b/api/document/views.py
@@ -67,20 +67,23 @@ class TreeView(GenericAPIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-def render_editor(request, policy_id, filename):
+def render_editor(request, policy_id, filename, title):
     # Verify that the policy is valid; 404 when not. We don't actually load
     # the document content as they'll be retrieved from the API
     policy_or_404(policy_id)
     return render(request, filename, {
         'document_url': reverse('document', kwargs={'policy_id': policy_id}),
+        'title': title,
     })
 
 
 @login_required
 def editor(request, policy_id):
-    return render_editor(request, policy_id, 'document/editor.html')
+    return render_editor(request, policy_id, 'document/editor.html',
+                         'Document Editor')
 
 
 @login_required
 def editor_akn(request, policy_id):
-    return render_editor(request, policy_id, 'document/editor_akn.html')
+    return render_editor(request, policy_id, 'document/editor_akn.html',
+                         'Akoma Ntoso Editor')

--- a/api/ereqs_admin/static/admin/module/_editor.scss
+++ b/api/ereqs_admin/static/admin/module/_editor.scss
@@ -15,22 +15,16 @@
   }
 }
 
-/* https://meta.superuser.com/q/4788 */
+// https://meta.superuser.com/q/4788
 kbd {
-  -moz-border-radius:3px;
-  -moz-box-shadow:0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
-  -webkit-border-radius:3px;
-  -webkit-box-shadow:0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
-  background-color:#f7f7f7;
-  border:1px solid #ccc;
-  border-radius:3px;
-  box-shadow:0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
-  color:#333;
-  display:inline-block;
-  font-family:Arial,Helvetica,sans-serif;
-  font-size:11px;
-  line-height:1.4;
-  margin:0 .1em;
-  padding:.1em .6em;
-  text-shadow:0 1px 0 #fff;
+  background-color: $color-lt-gray;
+  border: 1px solid $color-gray;
+  border-radius: 3px;
+  box-shadow: 0 1px 0 rgba($color-black, 0.2), 0 0 0 2px $color-white inset;
+  color: $color-black;
+  display: inline-block;
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 0 .1em;
+  padding: .1em .6em;
+  text-shadow: 0 1px 0 $color-white;
 }

--- a/api/ereqs_admin/static/admin/module/_editor.scss
+++ b/api/ereqs_admin/static/admin/module/_editor.scss
@@ -9,4 +9,28 @@
   div.unimplemented {
     padding: 2px 4px;
   }
+
+  .editor-status-error {
+    color: $color-red;
+  }
+}
+
+/* https://meta.superuser.com/q/4788 */
+kbd {
+  -moz-border-radius:3px;
+  -moz-box-shadow:0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
+  -webkit-border-radius:3px;
+  -webkit-box-shadow:0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
+  background-color:#f7f7f7;
+  border:1px solid #ccc;
+  border-radius:3px;
+  box-shadow:0 1px 0 rgba(0,0,0,0.2),0 0 0 2px #fff inset;
+  color:#333;
+  display:inline-block;
+  font-family:Arial,Helvetica,sans-serif;
+  font-size:11px;
+  line-height:1.4;
+  margin:0 .1em;
+  padding:.1em .6em;
+  text-shadow:0 1px 0 #fff;
 }

--- a/api/ereqs_admin/static/admin/override.scss
+++ b/api/ereqs_admin/static/admin/override.scss
@@ -1,3 +1,9 @@
+@import '~codemirror/addon/dialog/dialog.css';
+@import '~codemirror/lib/codemirror.css';
+@import '~codemirror/theme/eclipse.css';
+@import '~prosemirror-view/style/prosemirror.css';
+@import '~prosemirror-menu/style/menu.css';
+
 @import '../shared-styles/base/colors';
 @import '../shared-styles/base/media-queries';
 @import '../shared-styles/base/spacing';


### PR DESCRIPTION
This moved and combined templates, stylesheets, and a shared Api module so that the ProseMirror editor can re-use a goodly chunk of the AKN logic. With that, it was pretty straight forward to add a save function.

This is a lot of changes in terms of line count, but much of it is composed of renaming and moving functions around.