### PR TITLE
Revert "Footnote-finder also looks for matching 'marker'."

### DIFF
--- a/api/document/json_importer/annotations.py
+++ b/api/document/json_importer/annotations.py
@@ -23,7 +23,7 @@ def footnote_citation(cursor: JSONAwareCursor, content: PrimitiveDict,
     text = get_content_text(content['inlines'])
     referencing = list(cursor.filter(
         lambda m: m.node_type == 'footnote'
-        and m.type_emblem == text.strip() or m.marker == text.strip()
+        and m.type_emblem == text.strip()
     ))
     if not referencing:
         raise ValueError(f'unable to find footnote for citation {text}')


### PR DESCRIPTION
This reverts commit 18b3160d5e764b0e2520b410bae99eae2f3c5e9f, introduced in #884, and fixes #903.