### PR TITLE
Add support for 'cite' anno type to json_importer

### DIFF
--- a/api/document/json_importer/annotations.py
+++ b/api/document/json_importer/annotations.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from typing import Callable, DefaultDict, Dict, Iterator, List, Tuple, Type
 
-from document.models import Annotation, ExternalLink, FootnoteCitation
+from document.models import Annotation, Cite, ExternalLink, FootnoteCitation
 from document.tree import JSONAwareCursor, PrimitiveDict
 
 Annotator = Callable[
@@ -41,6 +41,14 @@ def external_link(cursor: JSONAwareCursor, content: PrimitiveDict,
         end=start + get_content_length(content['inlines']),
         href=content['href']
     )
+
+
+@annotator
+def cite(cursor: JSONAwareCursor, content: PrimitiveDict,
+         start: int) -> Cite:
+    text = get_content_text(content['inlines'])
+    return Cite(doc_node=cursor.model, start=start,
+                end=start + len(text))
 
 
 AnnotationDict = DefaultDict[Type[Annotation], List[Annotation]]

--- a/api/document/tests/factories.py
+++ b/api/document/tests/factories.py
@@ -43,3 +43,10 @@ def footnote(marker: int, content=List[PrimitiveDict],
         "content": content,
         "children": children or [],
     }
+
+
+def cite(inlines: List[PrimitiveDict]) -> PrimitiveDict:
+    return {
+        "content_type": "cite",
+        "inlines": inlines,
+    }

--- a/api/document/tests/json_importer/annotations_test.py
+++ b/api/document/tests/json_importer/annotations_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from document.json_importer.annotations import derive_annotations
 from document.json_importer.importer import convert_node
-from document.models import ExternalLink, FootnoteCitation
+from document.models import Cite, ExternalLink, FootnoteCitation
 
 from .. import factories as f
 
@@ -97,3 +97,17 @@ def test_derive_annotations_raises_err_on_invalid_annotation():
     with pytest.raises(ValueError,
                        match="no annotator found for blarg"):
         derive_annotations(para)
+
+
+def test_derive_annotations_works_with_cite():
+    annos = derive_annotations(convert_node(f.para(content=[
+        f.text('Hello '),
+        f.cite([f.text('Federal STEM Education 5-Year Strategic Plan')])
+    ])))
+
+    assert len(annos) == 1
+    assert len(annos[Cite]) == 1
+    cite = annos[Cite][0]
+    assert cite.start == len('Hello ')
+    assert cite.end == cite.start + len(
+        'Federal STEM Education 5-Year Strategic Plan')


### PR DESCRIPTION
This adds support for the `Cite` annotation type to the JSON importer.

This clears the path to #923, as `example_documents/m_15_16.xml` has `<cite>` annotations that can only be imported by the legacy XML importer at the moment.
