### PR TITLE
Remove pyinotify, add radon

### DIFF
--- a/api/omb_eregs/settings.py
+++ b/api/omb_eregs/settings.py
@@ -279,8 +279,3 @@ ADMIN_TITLE = 'OMB Policy Library Editor'
 # We only use accounts for admin access at the moment
 LOGIN_REDIRECT_URL = '/admin/'
 LOGIN_URL = '/admin/login/'
-
-if DEBUG and os.environ.get('USE_POLLING') == 'true':
-    import django.utils.autoreload
-
-    django.utils.autoreload.USE_INOTIFY = False

--- a/api/requirements_dev.in
+++ b/api/requirements_dev.in
@@ -14,8 +14,8 @@ jedi
 model_mommy
 mypy
 pep8-naming
-pyinotify
 pytest
 pytest-cov
 pytest-django
 pytest-watch
+radon

--- a/api/requirements_dev.txt
+++ b/api/requirements_dev.txt
@@ -12,7 +12,7 @@ botocore==1.7.4
 certifi==2017.7.27.1
 cfenv==0.5.3
 chardet==3.0.4
-colorama==0.3.9           # via pytest-watch
+colorama==0.3.9           # via pytest-watch, radon
 coverage==4.4.1           # via pytest-cov
 decorator==4.1.2
 dj-database-url==0.4.2
@@ -36,7 +36,7 @@ flake8-builtins==1.0
 flake8-comprehensions==1.4.1
 flake8-isort==2.2.2
 flake8-pep3101==1.0
-flake8-polyfill==1.0.1    # via flake8-isort
+flake8-polyfill==1.0.1    # via flake8-isort, radon
 flake8-print==2.0.2
 flake8-string-format==0.2.3
 flake8-tuple==0.2.13
@@ -50,6 +50,7 @@ isort==4.2.15             # via flake8-isort
 jedi==0.10.2
 jmespath==0.9.3
 lxml==4.1.0
+mando==0.6.4              # via radon
 mccabe==0.6.1             # via flake8
 model-mommy==1.3.2
 mypy==0.560
@@ -66,7 +67,6 @@ py==1.4.34                # via pytest
 pycodestyle==2.3.1        # via flake8
 pycryptodome==3.4.7
 pyflakes==1.5.0           # via flake8
-pyinotify==0.9.6
 pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest-watch==4.1.0
@@ -75,6 +75,7 @@ python-cas==1.2.0
 python-dateutil==2.6.1
 pytz==2017.2
 pyyaml==3.12              # via bandit, watchdog
+radon==2.2.0
 requests==2.18.4
 s3transfer==0.1.10
 six==1.10.0


### PR DESCRIPTION
This fixes #876 by removing `pyinotify`, and it also adds [`radon`](https://pypi.python.org/pypi/radon), which is what Code Climate uses for various metrics like cyclomatic complexity. Having it in our development dependencies will make it easier to reproduce CC feedback locally.