### PR TITLE
Initial editor implementation for displaying/editing lists

### DIFF
--- a/api/document/js/__tests__/serialize-doc.test.ts
+++ b/api/document/js/__tests__/serialize-doc.test.ts
@@ -60,6 +60,52 @@ describe('serializeDoc()', () => {
     const result = serializeDoc(node);
     expect(result).toEqual({ some: 'random', attrs: 'here' });
   });
+
+  it('converts list nodes', () => {
+    const node = schema.nodes.list.create({}, [
+      schema.nodes.listitem.create({}, [
+        schema.nodes.listitemMarker.create({}, schema.text('a)')),
+        schema.nodes.listitemBody.create({}, [
+          schema.nodes.para.create(
+            {}, schema.nodes.inline.create({}, schema.text('First p'))),
+          schema.nodes.para.create(
+            {}, schema.nodes.inline.create({}, schema.text('Second p')),
+          ),
+        ]),
+      ]),
+      schema.nodes.listitem.create({}, [
+        schema.nodes.listitemMarker.create({}, schema.text('2.')),
+        schema.nodes.listitemBody.create(
+          {},
+          schema.nodes.para.create(
+            {},
+            schema.nodes.inline.create({}, schema.text('Content')),
+          ),
+        ),
+      ]),
+    ]);
+
+    const result = serializeDoc(node);
+    expect(result).toEqual(apiFactory.node('list', {
+      children: [
+        apiFactory.node('listitem', {
+          marker: 'a)',
+          type_emblem: 'a',
+          children: [
+            apiFactory.node('para', { content: [apiFactory.text('First p')] }),
+            apiFactory.node('para', { content: [apiFactory.text('Second p')] }),
+          ],
+        }),
+        apiFactory.node('listitem', {
+          marker: '2.',
+          type_emblem: '2',
+          children: [
+            apiFactory.node('para', { content: [apiFactory.text('Content')] }),
+          ],
+        }),
+      ],
+    }));
+  });
 });
 
 describe('convertTexts()', () => {

--- a/api/document/js/__tests__/serialize-doc.test.ts
+++ b/api/document/js/__tests__/serialize-doc.test.ts
@@ -26,21 +26,15 @@ describe('serializeDoc()', () => {
         apiFactory.node('sec', {
           children: [
             apiFactory.node('heading', {
-              content: [
-                apiFactory.content('__text__', { text: 'Some heading' }),
-              ],
+              content: [apiFactory.text('Some heading')],
             }),
             apiFactory.node('para', {
-              content: [
-                apiFactory.content('__text__', { text: 'First paragraph' }),
-              ],
+              content: [apiFactory.text('First paragraph')],
             }),
           ],
         }),
         apiFactory.node('para', {
-          content: [
-            apiFactory.content('__text__', { text: 'A later paragraph' }),
-          ],
+          content: [apiFactory.text('A later paragraph')],
         }),
       ],
     }));
@@ -55,7 +49,7 @@ describe('serializeDoc()', () => {
     expect(result).toEqual({
       node_type: 'heading',
       children: [],
-      content: [{ content_type: '__text__', inlines: [], text: 'Stuff stuff' }],
+      content: [apiFactory.text('Stuff stuff')],
     });
   });
 
@@ -98,18 +92,18 @@ describe('convertTexts()', () => {
     ]));
 
     expect(result).toEqual([
-      apiFactory.content('__text__', { text: 'Some ' }),
+      apiFactory.text('Some '),
       apiFactory.content('one', {
         outer: 'thing',
         inlines: [apiFactory.content('two', {
           inner: 'here',
           inlines: [apiFactory.content('three', {
             most: 'deep',
-            inlines: [apiFactory.content('__text__', { text: 'nested' })],
+            inlines: [apiFactory.text('nested')],
           })],
         })],
       }),
-      apiFactory.content('__text__', { text: ' content' }),
+      apiFactory.text(' content'),
     ]);
   });
 });

--- a/api/document/js/parse-doc.ts
+++ b/api/document/js/parse-doc.ts
@@ -34,6 +34,12 @@ const NODE_TYPE_CONVERTERS = {
     const text = (node.text || '').replace(/\s+/g, ' ');
     return schema.nodes.heading.create({ depth }, schema.text(text));
   },
+  list: node =>
+    schema.nodes.list.create({}, (node.children || []).map(parseDoc)),
+  listitem: node => schema.nodes.listitem.create({}, [
+    schema.nodes.listitemMarker.create({}, schema.text(node.marker)),
+    schema.nodes.listitemBody.create({}, (node.children || []).map(parseDoc)),
+  ]),
   para(node) {
     const nested: Node[][] = (node.content || []).map(c => convertContent(c, []));
     const inlineContent = schema.nodes.inline.create({}, flatten(nested));

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -1,4 +1,24 @@
-import { Schema } from 'prosemirror-model';
+import { NodeSpec, Schema } from 'prosemirror-model';
+
+const listSchemaNodes: { [name: string]: NodeSpec } = {
+  list: {
+    content: 'listitem+',
+    group: 'block',
+    toDOM: () => ['ol', { class: 'node-list' }, 0],
+  },
+  listitem: {
+    content: 'listitemMarker listitemBody',
+    toDOM: () => ['li', { class: 'node-list-item' }, 0],
+  },
+  listitemMarker: {
+    content: 'text+',
+    toDOM: () => ['span', { class: 'list-item-marker' }, 0],
+  },
+  listitemBody: {
+    content: 'block+',
+    toDOM: () => ['div', { class: 'list-item-text' }, 0],
+  },
+};
 
 const schema = new Schema({
   topNode: 'policy',
@@ -39,6 +59,7 @@ const schema = new Schema({
         return ['div', { class: 'unimplemented' }, nodeType];
       },
     },
+    ...listSchemaNodes,
   },
   marks: {
     unimplemented_mark: {

--- a/api/document/js/serialize-doc.ts
+++ b/api/document/js/serialize-doc.ts
@@ -32,6 +32,11 @@ export const apiFactory = {
       ...(overrides || {}),
     };
   },
+  text: value => ({
+    content_type: '__text__',
+    inlines: [],
+    text: value,
+  }),
 };
 
 
@@ -75,7 +80,7 @@ export default function serializeDoc(node: Node): ApiNode {
 // of nested annotations to wrap each chunk of text.
 export function nestMarks(text: string, marks: Mark[]): ApiContent {
   if (marks.length === 0) {
-    return apiFactory.content('__text__', { text });
+    return apiFactory.text(text);
   }
   const mark = marks[0];
   const converted = MARK_CONVERTERS[mark.type.name](mark);

--- a/api/document/js/serialize-doc.ts
+++ b/api/document/js/serialize-doc.ts
@@ -5,8 +5,10 @@ import schema from './schema';
 interface ApiNode {
   children: ApiNode[];
   content: ApiContent[];
+  marker?: string;
   node_type: string;
-  // at some point, we'll need: marker, title, type_emblem
+  type_emblem?: string;
+  // at some point, we'll need: title
 }
 
 interface ApiContent {
@@ -46,6 +48,22 @@ const NODE_CONVERTERS = {
     // Text isn't in an 'inline' block
     { content: convertTexts(node.content) },
   ),
+  listitem(node) {
+    // Note the existence of these two nodes is ensured by the schema
+    const markerNode = node.content.child(0);
+    const body = node.content.child(1);
+
+    const children: ApiNode[] = [];
+    body.forEach(child => children.push(serializeDoc(child)));
+    const marker = markerNode.textContent;
+    const typeEmblem = marker.replace(/[^a-zA-Z0-9]/, '');
+    return apiFactory.node(
+      node.type.name,
+      typeEmblem ?
+        { children, marker, type_emblem: typeEmblem } :
+        { children, marker },
+    );
+  },
   unimplemented_node: node => node.attrs.data,
 };
 

--- a/api/ereqs_admin/static/admin/override.scss
+++ b/api/ereqs_admin/static/admin/override.scss
@@ -10,7 +10,9 @@
 @import '../shared-styles/base/spacing';
 @import '../shared-styles/base/type-size';
 @import '../shared-styles/base/util';
+@import '../shared-styles/layout/markers';
 @import '../shared-styles/module/heading';
+@import '../shared-styles/module/list';
 @import '../shared-styles/module/paragraph';
 @import './layout/typography';
 @import './module/editor';

--- a/shared-styles/base/_util.scss
+++ b/shared-styles/base/_util.scss
@@ -7,3 +7,26 @@
   border-radius: 0;
   cursor: pointer;
 }
+
+@mixin reset-list() {
+  list-style: none;
+  padding-left: 0;
+}
+
+@mixin clearfix() {
+  &::before,
+  &::after {
+    content: ' ';
+    display: table;
+  }
+
+  &::after {
+    clear: both;
+  }
+}
+
+@mixin col($col-count) {
+  box-sizing: border-box;
+  float: left;
+  width: calc(#{$col-count} / 12 * 100%);
+}

--- a/shared-styles/layout/_markers.scss
+++ b/shared-styles/layout/_markers.scss
@@ -4,11 +4,12 @@ $marker-width-desktop: $marker-width-mobile + 8;
 $marker-whitespace-desktop: $marker-whitespace-mobile + 4;
 
 @mixin paragraph-marker() {
-  @extend .col;
-  @extend .right-align;
-  width: $marker-width-mobile;
-  margin-right: $marker-whitespace-mobile;
+  @include col(1);
+
   display: inline-block;
+  margin-right: $marker-whitespace-mobile;
+  text-align: right;
+  width: $marker-width-mobile;
 
   @media #{$on-desktop} {
     width: $marker-width-desktop;
@@ -17,8 +18,8 @@ $marker-whitespace-desktop: $marker-whitespace-mobile + 4;
 }
 
 @mixin paragraph-with-marker() {
-  @extend .col;
-  @extend .col-11;
+  @include col(11);
+
   width: calc(100% - #{$marker-width-mobile + $marker-whitespace-mobile});
   word-wrap: break-word;
 

--- a/shared-styles/module/_list.scss
+++ b/shared-styles/module/_list.scss
@@ -1,5 +1,9 @@
+.node-list {
+  @include reset-list();
+}
+
 .node-list-item {
-  @extend .clearfix;
+  @include clearfix();
   margin-bottom: $space-xs;
 
   .list-item-marker {

--- a/ui/components/node-renderers/list.js
+++ b/ui/components/node-renderers/list.js
@@ -6,7 +6,7 @@ import renderNode from '../../util/render-node';
 
 export default function List({ docNode }) {
   return (
-    <ol className="list-reset node-list" id={docNode.identifier}>
+    <ol className="node-list" id={docNode.identifier}>
       { docNode.children.map(renderNode) }
     </ol>
   );

--- a/ui/css/main.scss
+++ b/ui/css/main.scss
@@ -17,11 +17,11 @@ $fa-font-path: '~font-awesome/fonts';
 @import 'shared-styles/base/spacing';
 @import 'shared-styles/base/type-size';
 @import 'shared-styles/base/util';
+@import 'shared-styles/layout/markers';
 @import 'base/base';
 
 @import 'layout/typography';
 @import 'layout/layout';
-@import 'layout/markers';
 @import 'layout/icons';
 
 @import 'module/header';
@@ -37,11 +37,11 @@ $fa-font-path: '~font-awesome/fonts';
 @import 'module/policies';
 @import 'module/homepage';
 @import 'module/loading-indicator';
-@import 'module/listitem';
 @import 'module/tables';
 @import 'module/external-link';
 @import 'module/styleguide';
 @import 'shared-styles/module/heading';
+@import 'shared-styles/module/list';
 @import 'shared-styles/module/paragraph';
 
 @import 'state/print';


### PR DESCRIPTION
This displays lists and list items, including their marker text using the same styles (sans fonts) used in the frontend. There's no way to add a new list item at the moment, but this should get us started.

This allows the marker text (e.g. "1.") to be edited, which will likely be overly confusing for end users. We'll need to figure out what to do there as a team.

Looks like (please ignore misalignment due to font sizes)
<img width="626" alt="screen shot 2018-01-25 at 10 10 18 am" src="https://user-images.githubusercontent.com/326918/35395277-eaf62cfe-01b7-11e8-8793-d6ffcf791f3a.png">

