### PR TITLE
Override fonts in Django admin, editor

### DIFF
--- a/api/ereqs_admin/static/admin/layout/_typography.scss
+++ b/api/ereqs_admin/static/admin/layout/_typography.scss
@@ -1,0 +1,20 @@
+// --- Rules to override Django's font selection
+body {
+  @include font-san-serif();
+  @include size-regular();
+}
+
+td,
+th {
+  @include font-san-serif();
+  @include size-small();
+}
+
+input,
+textarea,
+select,
+.form-row p,
+form .button {
+  @include font-san-serif();
+  @include size-small();
+}

--- a/api/ereqs_admin/static/admin/override.scss
+++ b/api/ereqs_admin/static/admin/override.scss
@@ -5,12 +5,14 @@
 @import '~prosemirror-menu/style/menu.css';
 
 @import '../shared-styles/base/colors';
+@import '../shared-styles/base/fonts';
 @import '../shared-styles/base/media-queries';
 @import '../shared-styles/base/spacing';
 @import '../shared-styles/base/type-size';
 @import '../shared-styles/base/util';
 @import '../shared-styles/module/heading';
 @import '../shared-styles/module/paragraph';
+@import './layout/typography';
 @import './module/editor';
 
 $nav-menu-active: false;

--- a/shared-styles/base/_type-size.scss
+++ b/shared-styles/base/_type-size.scss
@@ -2,3 +2,8 @@
   font-size: 1rem;
   line-height: 1.6875rem;
 }
+
+@mixin size-small() {
+  font-size: .875rem;
+  line-height: 1.312rem;
+}

--- a/shared-styles/module/_paragraph.scss
+++ b/shared-styles/module/_paragraph.scss
@@ -3,5 +3,7 @@
 }
 
 .node-paragraph-text {
+  @include font-serif();
+
   margin: 0;
 }

--- a/ui/css/layout/_typography.scss
+++ b/ui/css/layout/_typography.scss
@@ -71,8 +71,7 @@ h4,
 
 h5,
 .h5 {
-  font-size: .875rem;
-  line-height: 1.312rem;
+  @include size-small();
 }
 
 h6,


### PR DESCRIPTION
This should resolve #916 and #917 by overriding the default fonts in Django's admin. Not a radical change, but worth the consistency.

## Before
<img width="1245" alt="screen shot 2018-01-25 at 11 03 07 am" src="https://user-images.githubusercontent.com/326918/35398321-919794ba-01bf-11e8-91be-795fcfd72134.png">
<img width="1127" alt="screen shot 2018-01-25 at 11 03 29 am" src="https://user-images.githubusercontent.com/326918/35398320-9187f956-01bf-11e8-9fb9-41ba37b2d75c.png">
<img width="868" alt="screen shot 2018-01-25 at 11 03 46 am" src="https://user-images.githubusercontent.com/326918/35398319-9179c82c-01bf-11e8-9414-3cf8bf5f676b.png">

## After
<img width="1253" alt="screen shot 2018-01-25 at 11 04 24 am" src="https://user-images.githubusercontent.com/326918/35398317-9154cacc-01bf-11e8-841b-3c920ddf0264.png">
<img width="967" alt="screen shot 2018-01-25 at 11 04 33 am" src="https://user-images.githubusercontent.com/326918/35398316-9146a97e-01bf-11e8-94d8-aa46c65cce91.png">
<img width="884" alt="screen shot 2018-01-25 at 11 04 44 am" src="https://user-images.githubusercontent.com/326918/35398309-8fe065fc-01bf-11e8-85f3-daa47c7b454c.png">