### PR TITLE
Make ValidationErrors more detailed/accurate

### DIFF
--- a/api/document/serializers/content.py
+++ b/api/document/serializers/content.py
@@ -5,6 +5,7 @@ from rest_framework.serializers import ValidationError
 
 from document.models import (Annotation, Cite, ExternalLink, FootnoteCitation,
                              InlineRequirement, PlainText)
+from document.serializers.util import list_to_internal_value
 from document.tree import DocCursor, PrimitiveDict
 from reqs.models import Requirement
 
@@ -105,8 +106,7 @@ class InlinesField(NestableAnnotationField):
     def to_internal_value(self,
                           data: List[PrimitiveDict]) -> List[PrimitiveDict]:
         if not self.is_leaf_node:
-            serializer = NestedAnnotationSerializer()
-            return [serializer.to_internal_value(d) for d in data]
+            return list_to_internal_value(data, NestedAnnotationSerializer)
         elif data:
             raise ValidationError('leaf nodes cannot contain nested content')
         return []

--- a/api/document/serializers/doc_cursor.py
+++ b/api/document/serializers/doc_cursor.py
@@ -1,4 +1,4 @@
-from typing import List, Set, Tuple, Iterator  # noqa
+from typing import List, Set, Tuple, Type, Iterator  # noqa
 
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -38,10 +38,11 @@ class ChildrenField(DocCursorField):
 
     def to_internal_value(self,
                           data: List[PrimitiveDict]) -> List[PrimitiveDict]:
-        serializer = DocCursorSerializer(
-            context={**self.context, 'is_root': False},
+        children = util.list_to_internal_value(
+            data,
+            DocCursorSerializer,
+            context={**self.context, 'is_root': False}
         )
-        children = [serializer.to_internal_value(item) for item in data]
         self.validate_type_emblem_uniqueness(children)
         return children
 
@@ -59,10 +60,7 @@ class ContentField(DocCursorField):
 
     def to_internal_value(self,
                           data: List[PrimitiveDict]) -> List[PrimitiveDict]:
-        serializer = NestedAnnotationSerializer()
-        return [
-            serializer.to_internal_value(item) for item in data
-        ]
+        return util.list_to_internal_value(data, NestedAnnotationSerializer)
 
 
 class DocCursorSerializer(serializers.Serializer):

--- a/api/document/serializers/util.py
+++ b/api/document/serializers/util.py
@@ -1,4 +1,6 @@
-from typing import Iterator, List, Set, TypeVar  # noqa
+from typing import Iterator, List, Set, Type, TypeVar  # noqa
+
+from rest_framework.serializers import Field
 
 from document.tree import PrimitiveDict
 
@@ -43,3 +45,16 @@ def iter_inlines(inlines: List[PrimitiveDict]) -> Iterator[PrimitiveDict]:
     for inline in inlines:
         yield inline
         yield from iter_inlines(inline['inlines'])
+
+
+def list_to_internal_value(data: List[PrimitiveDict],
+                           field_class: Type[Field],
+                           *args, **kwargs) -> List[PrimitiveDict]:
+    # The only real reason this function exists is because
+    # the way DRF's `many=True` changes the type signatures of
+    # a serializer's methods is extremely hard/impossible to
+    # express as a type annotation. So this is really just a
+    # way to "twist mypy's arm" into annotating things the way we
+    # want.
+    serializer = field_class(*args, **{'many': True, **kwargs})
+    return serializer.to_internal_value(data)

--- a/api/document/tests/serializers/content_test.py
+++ b/api/document/tests/serializers/content_test.py
@@ -246,3 +246,10 @@ def test_unimplemented_content_type_or_annotation_class_raises_error():
 def test_nestable_annotation_repr_works():
     na = content.NestableAnnotation('my annotation', None)
     assert repr(na) == "NestableAnnotation('my annotation') []"
+
+
+def test_non_leaf_inlines_field_validation_error_detail_is_list():
+    with pytest.raises(ValidationError) as excinfo:
+        content.InlinesField(is_leaf_node=False)\
+            .to_internal_value([{}])
+    assert isinstance(excinfo.value.detail, list)

--- a/api/document/tests/serializers/doc_cursor_test.py
+++ b/api/document/tests/serializers/doc_cursor_test.py
@@ -387,3 +387,15 @@ def test_create_works():
 
     assert cursor.node_type == 'para'
     assert cursor.text == 'hi'
+
+
+def test_children_field_validation_error_detail_is_list():
+    with pytest.raises(ValidationError) as excinfo:
+        doc_cursor.ChildrenField().to_internal_value([{}])
+    assert isinstance(excinfo.value.detail, list)
+
+
+def test_content_field_validation_error_detail_is_list():
+    with pytest.raises(ValidationError) as excinfo:
+        doc_cursor.ContentField().to_internal_value([{}])
+    assert isinstance(excinfo.value.detail, list)


### PR DESCRIPTION
This helps with #904 by making `ValidationError` exceptions raised by our `DocCursorSerializer` less vague, in that they will contain enough data to allow someone to figure out _where_ in their payload a validation error occurred. See https://github.com/18F/omb-eregs/issues/904#issuecomment-360800292 for more details.
