### PR TITLE
Add source line metadata to validation errors if possible

### DIFF
--- a/api/document/parsers.py
+++ b/api/document/parsers.py
@@ -14,16 +14,20 @@ def text(text_content: str) -> PrimitiveDict:
     }
 
 
-def convert_content(xml_el: etree.Element) -> List[PrimitiveDict]:
+def convert_content(xml_el: etree.Element,
+                    sourcelines=True) -> List[PrimitiveDict]:
     data = []
     if xml_el.text:
         data.append(text(xml_el.text))
     for child in xml_el:
-        data.append({
+        child_data = {
             **child.attrib,
             'content_type': child.tag,
-            'inlines': convert_content(child)
-        })
+            'inlines': convert_content(child, sourcelines),
+        }
+        if sourcelines:
+            child_data['_sourceline'] = child.sourceline
+        data.append(child_data)
         if child.tail:
             data.append(text(child.tail))
     return data
@@ -35,23 +39,26 @@ def ensure_at_most_one_child_has_tag(xml_el: etree.Element, tag: str):
                          f'<{tag}> elements')
 
 
-def convert_node(xml_el: etree.Element) -> PrimitiveDict:
+def convert_node(xml_el: etree.Element,
+                 sourcelines=True) -> PrimitiveDict:
     data = {
         'node_type': xml_el.tag,
         'children': [],
         'content': [],
     }
+    if sourcelines:
+        data['_sourceline'] = xml_el.sourceline
     ensure_at_most_one_child_has_tag(xml_el, 'content')
     ensure_at_most_one_child_has_tag(xml_el, 'num')
     if 'emblem' in xml_el.attrib:
         data['type_emblem'] = xml_el.attrib['emblem']
     for child in xml_el:
         if child.tag == 'content':
-            data['content'] = convert_content(child)
+            data['content'] = convert_content(child, sourcelines)
         elif child.tag == 'num':
             data['marker'] = child.text
         else:
-            data['children'].append(convert_node(child))
+            data['children'].append(convert_node(child, sourcelines))
     return {**xml_el.attrib, **data}
 
 

--- a/api/document/serializers/content.py
+++ b/api/document/serializers/content.py
@@ -5,7 +5,7 @@ from rest_framework.serializers import ValidationError
 
 from document.models import (Annotation, Cite, ExternalLink, FootnoteCitation,
                              InlineRequirement, PlainText)
-from document.serializers.util import (SourcelineErrorMixin,
+from document.serializers.util import (add_sourceline_to_errors,
                                        list_to_internal_value)
 from document.tree import DocCursor, PrimitiveDict
 from reqs.models import Requirement
@@ -168,7 +168,7 @@ class BaseAnnotationSerializer(serializers.Serializer):
         return result
 
 
-class NestedAnnotationSerializer(SourcelineErrorMixin, serializers.Serializer):
+class NestedAnnotationSerializer(serializers.Serializer):
     """Figures out which AnnotationSerializer to use when serializing
     content."""
     serializer_mapping: Dict[
@@ -206,6 +206,10 @@ class NestedAnnotationSerializer(SourcelineErrorMixin, serializers.Serializer):
             })
         serializer = self.content_type_mapping[content_type]()
         return serializer.to_internal_value(data)
+
+    def run_validation(self, data=serializers.empty):
+        with add_sourceline_to_errors(data):
+            return super().run_validation(data)
 
 
 @NestedAnnotationSerializer.register

--- a/api/document/serializers/content.py
+++ b/api/document/serializers/content.py
@@ -5,7 +5,8 @@ from rest_framework.serializers import ValidationError
 
 from document.models import (Annotation, Cite, ExternalLink, FootnoteCitation,
                              InlineRequirement, PlainText)
-from document.serializers.util import list_to_internal_value
+from document.serializers.util import (SourcelineErrorMixin,
+                                       list_to_internal_value)
 from document.tree import DocCursor, PrimitiveDict
 from reqs.models import Requirement
 
@@ -167,7 +168,7 @@ class BaseAnnotationSerializer(serializers.Serializer):
         return result
 
 
-class NestedAnnotationSerializer(serializers.Serializer):
+class NestedAnnotationSerializer(SourcelineErrorMixin, serializers.Serializer):
     """Figures out which AnnotationSerializer to use when serializing
     content."""
     serializer_mapping: Dict[

--- a/api/document/serializers/doc_cursor.py
+++ b/api/document/serializers/doc_cursor.py
@@ -63,7 +63,7 @@ class ContentField(DocCursorField):
         return util.list_to_internal_value(data, NestedAnnotationSerializer)
 
 
-class DocCursorSerializer(util.SourcelineErrorMixin, serializers.Serializer):
+class DocCursorSerializer(serializers.Serializer):
     """
     A Serializer for the DocCursor class.
 
@@ -164,6 +164,10 @@ class DocCursorSerializer(util.SourcelineErrorMixin, serializers.Serializer):
             footnote_emblems = self.validate_footnote_emblems(data)
             self.validate_footnote_citations(data, footnote_emblems)
         return data
+
+    def run_validation(self, data=serializers.empty):
+        with util.add_sourceline_to_errors(data):
+            return super().run_validation(data)
 
     def create(self, validated_data: PrimitiveDict) -> JSONAwareCursor:
         return import_json_doc(self.context['policy'], validated_data)

--- a/api/document/serializers/doc_cursor.py
+++ b/api/document/serializers/doc_cursor.py
@@ -63,7 +63,7 @@ class ContentField(DocCursorField):
         return util.list_to_internal_value(data, NestedAnnotationSerializer)
 
 
-class DocCursorSerializer(serializers.Serializer):
+class DocCursorSerializer(util.SourcelineErrorMixin, serializers.Serializer):
     """
     A Serializer for the DocCursor class.
 

--- a/api/document/serializers/util.py
+++ b/api/document/serializers/util.py
@@ -48,10 +48,8 @@ def iter_inlines(inlines: List[PrimitiveDict]) -> Iterator[PrimitiveDict]:
         yield from iter_inlines(inline['inlines'])
 
 
-def has_sourceline(data: Any):
-    if not isinstance(data, dict):
-        return False
-    return '_sourceline' in data
+def has_sourceline(data: Any) -> bool:
+    return isinstance(data, dict) and '_sourceline' in data
 
 
 @contextmanager

--- a/api/document/serializers/util.py
+++ b/api/document/serializers/util.py
@@ -82,6 +82,7 @@ def add_sourceline_to_errors(data: Any):
     try:
         yield
     except ValidationError as e:
-        if not has_sourceline(e.detail) and has_sourceline(data):
+        if (isinstance(e.detail, dict) and not has_sourceline(e.detail)
+                and has_sourceline(data)):
             e.detail['_sourceline'] = data['_sourceline']
         raise e

--- a/api/document/tests/parsers_test.py
+++ b/api/document/tests/parsers_test.py
@@ -31,7 +31,7 @@ BILLION_LAUGHS_XML = """\
 
 
 def convert_xml_node(text: str) -> PrimitiveDict:
-    return parsers.convert_node(etree.fromstring(text))
+    return parsers.convert_node(etree.fromstring(text), sourcelines=False)
 
 
 def convert_content_node(text) -> List[PrimitiveDict]:
@@ -49,6 +49,7 @@ def test_parser_works():
         "node_type": "policy",
         "content": [],
         "children": [],
+        "_sourceline": 1,
     }
 
 

--- a/api/document/tests/serializers/content_test.py
+++ b/api/document/tests/serializers/content_test.py
@@ -255,3 +255,11 @@ def test_non_leaf_inlines_field_validation_error_detail_is_list():
         content.InlinesField(is_leaf_node=False)\
             .to_internal_value([{}])
     assert isinstance(excinfo.value.detail, list)
+
+
+def test_sourceline_is_added_to_nested_annotation_errors():
+    serializer = content.NestedAnnotationSerializer(data={
+        '_sourceline': 5
+    })
+    assert not serializer.is_valid()
+    assert serializer.errors['_sourceline'] == 5

--- a/api/document/tests/serializers/doc_cursor_test.py
+++ b/api/document/tests/serializers/doc_cursor_test.py
@@ -401,3 +401,11 @@ def test_content_field_validation_error_detail_is_list():
     with pytest.raises(ValidationError) as excinfo:
         doc_cursor.ContentField().to_internal_value([{}])
     assert isinstance(excinfo.value.detail, list)
+
+
+def test_sourceline_is_added_to_doc_cursor_errors():
+    serializer = doc_cursor.DocCursorSerializer(data={
+        '_sourceline': 5
+    })
+    assert not serializer.is_valid()
+    assert serializer.errors['_sourceline'] == 5

--- a/api/document/tests/serializers/util_test.py
+++ b/api/document/tests/serializers/util_test.py
@@ -1,0 +1,33 @@
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from document.serializers import util
+
+
+@pytest.mark.parametrize('data', [{}, None, 1, "blah"])
+def test_add_sourceline_to_errors_ignores_data_without_sourceline(data):
+    with pytest.raises(ValidationError) as excinfo:
+        with util.add_sourceline_to_errors(data):
+            raise ValidationError({'blah': 'hmm'})
+    assert excinfo.value.detail == {'blah': 'hmm'}
+
+
+@pytest.mark.parametrize('detail', [(), [], None, 1, "blah"])
+def test_add_sourceline_to_errors_ignores_err_without_detail_dict(detail):
+    with pytest.raises(ValidationError):
+        with util.add_sourceline_to_errors({'_sourceline': 1}):
+            raise ValidationError(detail)
+
+
+def test_add_sourceline_to_errors_adds_sourceline_to_err():
+    with pytest.raises(ValidationError) as excinfo:
+        with util.add_sourceline_to_errors({'_sourceline': 1}):
+            raise ValidationError({'a': 'b'})
+    assert excinfo.value.detail == {'a': 'b', '_sourceline': 1}
+
+
+def test_add_sourceline_to_errors_does_not_overwrite_sourceline():
+    with pytest.raises(ValidationError) as excinfo:
+        with util.add_sourceline_to_errors({'_sourceline': 50}):
+            raise ValidationError({'a': 'b', '_sourceline': 'meh'})
+    assert excinfo.value.detail == {'a': 'b', '_sourceline': 'meh'}


### PR DESCRIPTION
~~**Note: this PR is targeted against #959, not `master`.**~~

This helps with #904 by "annotating" validation errors with source line metadata. Accomplishing this requires two steps:

1. The AKN parser "annotates" each node and annotation object with a `_sourceline` property that indicates the line where the XML element representing the object came from.

2. During validation, our node and annotation serializers catch any raised `ValidationError`s and "annotate" them with the `_sourceline` property passed into them by the upstream parser. If the upstream parser didn't include a `_sourceline` property (e.g. DRF's default JSON parser), nothing additional is done. The `ValidationError` is then re-raised.

Here's example validation error output of an <code>&lt;external_link&gt;</code> tag that lacks an <code>href</code> attribute:

```json
{
  "children": [
    {
      "children": [
        {
          "content": [
            {},
            {
              "href": [
                "This field is required."
              ],
              "_sourceline": "4"
            },
            {}
          ],
          "_sourceline": "3"
        },
        {},
        {},
        {},
        {}
      ],
      "_sourceline": "2"
    },
    {},
    {}
  ],
  "_sourceline": "1"
}
```

## To do

- [x] Add tests
- [x] ~~Consider moving some of our `ValidationError` raising from `to_internal_value()` to `validate()` (which will effectively convert the raised error into a dictionary that can be annotated with a source line). **Update:** Given https://github.com/18F/omb-eregs/issues/957#issuecomment-360925181, we really ought to do this, though it can (and probably should) be done in a separate PR.~~ Done in #961.

@cmc333333 does this kind of strategy seem OK to you?  There doesn't seem to be any particular guidance on how to do this kind of thing in the DRF docs, so I'm basically improvising, but I'm not sure how sound (or just plain understandable) my approach is.
