### PR TITLE
Ensure ValidationErrors raised by serializers are dictionaries

### DIFF
--- a/api/document/serializers/content.py
+++ b/api/document/serializers/content.py
@@ -198,9 +198,11 @@ class NestedAnnotationSerializer(serializers.Serializer):
     def to_internal_value(self, data: PrimitiveDict) -> PrimitiveDict:
         content_type = data.get('content_type')
         if content_type is None:
-            raise ValidationError("missing content_type")
+            raise ValidationError({"content_type": "This field is required."})
         if content_type not in self.content_type_mapping:
-            raise ValidationError(f"unknown content_type: {content_type}")
+            raise ValidationError({
+                "content_type": f"'{content_type}' is an invalid content type."
+            })
         serializer = self.content_type_mapping[content_type]()
         return serializer.to_internal_value(data)
 

--- a/api/document/tests/serializers/content_test.py
+++ b/api/document/tests/serializers/content_test.py
@@ -175,17 +175,19 @@ def test_inline_requirement_with_link_integration():
 def test_error_raised_on_invalid_content_type():
     serializer = content.NestedAnnotationSerializer()
 
-    with pytest.raises(ValidationError,
-                       match="unknown content_type: blarg"):
+    with pytest.raises(ValidationError) as einfo:
         serializer.to_internal_value({'content_type': 'blarg'})
+    assert einfo.value.detail == {
+        'content_type': "'blarg' is an invalid content type."
+    }
 
 
 def test_error_raised_on_missing_content_type():
     serializer = content.NestedAnnotationSerializer()
 
-    with pytest.raises(ValidationError,
-                       match="missing content_type"):
+    with pytest.raises(ValidationError) as einfo:
         serializer.to_internal_value({'foo': 'bar'})
+    assert einfo.value.detail == {'content_type': 'This field is required.'}
 
 
 def test_text_deserialization_works():

--- a/api/document/tests/serializers/doc_cursor_test.py
+++ b/api/document/tests/serializers/doc_cursor_test.py
@@ -296,55 +296,51 @@ def test_children_field_to_internal_value_works():
 
 
 def test_footnote_type_emblem_existence_is_validated():
-    serializer = doc_cursor.DocCursorSerializer()
-
     footnote = f.footnote(1, [])
 
-    serializer.to_internal_value(footnote)
+    doc_cursor.DocCursorSerializer(data=footnote)\
+        .is_valid(raise_exception=True)
 
-    with pytest.raises(ValidationError) as excinfo:
-        del footnote['type_emblem']
-        serializer.to_internal_value(footnote)
-    assert excinfo.value.detail == {
-        'type_emblem': "'footnote' nodes must have type emblems."
+    del footnote['type_emblem']
+
+    s = doc_cursor.DocCursorSerializer(data=footnote)
+    assert not s.is_valid()
+    assert s.errors == {
+        'type_emblem': ["'footnote' nodes must have type emblems."]
     }
 
 
 def test_footnote_type_emblem_uniqueness_is_validated():
-    serializer = doc_cursor.DocCursorSerializer()
-
-    serializer.to_internal_value(f.para([], children=[
+    doc_cursor.DocCursorSerializer(data=f.para([], children=[
         f.footnote(1, []),
         f.footnote(2, [])
-    ]))
+    ])).is_valid(raise_exception=True)
 
-    with pytest.raises(ValidationError) as excinfo:
-        serializer.to_internal_value(f.para([], children=[
-            f.para([], children=[f.footnote(1, [])]),
-            f.para([], children=[f.footnote(1, [])]),
-        ]))
-    assert excinfo.value.detail == {
-        'non_field_errors': "Multiple footnotes exist with type emblem '1'"
+    s = doc_cursor.DocCursorSerializer(data=f.para([], children=[
+        f.para([], children=[f.footnote(1, [])]),
+        f.para([], children=[f.footnote(1, [])]),
+    ]))
+    assert not s.is_valid()
+    assert s.errors == {
+        'non_field_errors': ["Multiple footnotes exist with type emblem '1'"]
     }
 
 
 def test_footnote_citations_are_validated():
-    serializer = doc_cursor.DocCursorSerializer()
-
-    serializer.to_internal_value(f.para([
+    doc_cursor.DocCursorSerializer(data=f.para([
         f.footnote_citation([f.text('1')]),
     ], children=[
         f.footnote(1, []),
-    ]))
+    ])).is_valid(raise_exception=True)
 
-    with pytest.raises(ValidationError) as excinfo:
-        serializer.to_internal_value(f.para([
-            f.footnote_citation([f.text('2')]),
-        ], children=[
-            f.footnote(1, []),
-        ]))
-    assert excinfo.value.detail == {
-        'non_field_errors': "Citation for '2' has no matching footnote"
+    s = doc_cursor.DocCursorSerializer(data=f.para([
+        f.footnote_citation([f.text('2')]),
+    ], children=[
+        f.footnote(1, []),
+    ]))
+    assert not s.is_valid()
+    assert s.errors == {
+        'non_field_errors': ["Citation for '2' has no matching footnote"]
     }
 
 

--- a/api/document/tests/serializers/doc_cursor_test.py
+++ b/api/document/tests/serializers/doc_cursor_test.py
@@ -302,10 +302,12 @@ def test_footnote_type_emblem_existence_is_validated():
 
     serializer.to_internal_value(footnote)
 
-    err_msg = "Footnotes must have type emblems"
-    with pytest.raises(ValidationError, match=err_msg):
+    with pytest.raises(ValidationError) as excinfo:
         del footnote['type_emblem']
         serializer.to_internal_value(footnote)
+    assert excinfo.value.detail == {
+        'type_emblem': "'footnote' nodes must have type emblems."
+    }
 
 
 def test_footnote_type_emblem_uniqueness_is_validated():
@@ -316,12 +318,14 @@ def test_footnote_type_emblem_uniqueness_is_validated():
         f.footnote(2, [])
     ]))
 
-    err_msg = "Multiple footnotes exist with type emblem '1'"
-    with pytest.raises(ValidationError, match=err_msg):
+    with pytest.raises(ValidationError) as excinfo:
         serializer.to_internal_value(f.para([], children=[
             f.para([], children=[f.footnote(1, [])]),
             f.para([], children=[f.footnote(1, [])]),
         ]))
+    assert excinfo.value.detail == {
+        'non_field_errors': "Multiple footnotes exist with type emblem '1'"
+    }
 
 
 def test_footnote_citations_are_validated():
@@ -333,13 +337,15 @@ def test_footnote_citations_are_validated():
         f.footnote(1, []),
     ]))
 
-    err_msg = "Citation for '2' has no matching footnote"
-    with pytest.raises(ValidationError, match=err_msg):
+    with pytest.raises(ValidationError) as excinfo:
         serializer.to_internal_value(f.para([
             f.footnote_citation([f.text('2')]),
         ], children=[
             f.footnote(1, []),
         ]))
+    assert excinfo.value.detail == {
+        'non_field_errors': "Citation for '2' has no matching footnote"
+    }
 
 
 def test_children_field_type_emblem_uniqueness_is_validated():


### PR DESCRIPTION
This fixes #957.

I find validation for DRF very confusing; in _some_ cases, [such as simple fields](http://www.django-rest-framework.org/api-guide/fields/#raising-validation-errors), it's recommended to raise one with a string `detail` during `to_internal_value()`. The DRF code that calls this method takes care of turning such errors into ones with dict-based `detail`.

However, in _other_ cases, such as [deserializers with multiple fields](http://www.django-rest-framework.org/api-guide/serializers/#overriding-serialization-and-deserialization-behavior), there are multiple options, one of which is also raise a `ValidationError` during `to_internal_value()`, _except passing a dictionary instead of a string for `detail`_.  This is super confusing and DRF doesn't even seem to care whether we follow it, until something unexpected like #957 occurs.