### PR TITLE
Improve Serializer deserialization propriety

### DIFF
--- a/api/document/serializers/content.py
+++ b/api/document/serializers/content.py
@@ -5,7 +5,6 @@ from rest_framework.serializers import ValidationError
 
 from document.models import (Annotation, Cite, ExternalLink, FootnoteCitation,
                              InlineRequirement, PlainText)
-from document.serializers.util import list_to_internal_value
 from document.tree import DocCursor, PrimitiveDict
 from reqs.models import Requirement
 
@@ -106,7 +105,9 @@ class InlinesField(NestableAnnotationField):
     def to_internal_value(self,
                           data: List[PrimitiveDict]) -> List[PrimitiveDict]:
         if not self.is_leaf_node:
-            return list_to_internal_value(data, NestedAnnotationSerializer)
+            serializer = NestedAnnotationSerializer(data=data, many=True)
+            serializer.is_valid(raise_exception=True)
+            return serializer.validated_data
         elif data:
             raise ValidationError('leaf nodes cannot contain nested content')
         return []

--- a/api/document/serializers/util.py
+++ b/api/document/serializers/util.py
@@ -1,7 +1,5 @@
 from typing import Iterator, List, Set, Type, TypeVar  # noqa
 
-from rest_framework.serializers import Serializer
-
 from document.tree import PrimitiveDict
 
 T = TypeVar('T')
@@ -45,21 +43,3 @@ def iter_inlines(inlines: List[PrimitiveDict]) -> Iterator[PrimitiveDict]:
     for inline in inlines:
         yield inline
         yield from iter_inlines(inline['inlines'])
-
-
-def list_to_internal_value(data: List[PrimitiveDict],
-                           serializer_class: Type[Serializer],
-                           *args, **kwargs) -> List[PrimitiveDict]:
-    # The only real reason this function exists is because
-    # the way DRF's `many=True` changes the type signatures of
-    # a serializer's methods is extremely hard/impossible to
-    # express as a type annotation. So this is really just a
-    # way to "twist mypy's arm" into annotating things the way we
-    # want.
-    serializer = serializer_class(*args, **{
-        'many': True,
-        'data': data,
-        **kwargs
-    })
-    serializer.is_valid(raise_exception=True)
-    return serializer.validated_data

--- a/api/document/serializers/util.py
+++ b/api/document/serializers/util.py
@@ -1,6 +1,6 @@
 from typing import Iterator, List, Set, Type, TypeVar  # noqa
 
-from rest_framework.serializers import Field
+from rest_framework.serializers import Serializer
 
 from document.tree import PrimitiveDict
 
@@ -48,7 +48,7 @@ def iter_inlines(inlines: List[PrimitiveDict]) -> Iterator[PrimitiveDict]:
 
 
 def list_to_internal_value(data: List[PrimitiveDict],
-                           field_class: Type[Field],
+                           serializer_class: Type[Serializer],
                            *args, **kwargs) -> List[PrimitiveDict]:
     # The only real reason this function exists is because
     # the way DRF's `many=True` changes the type signatures of
@@ -56,5 +56,10 @@ def list_to_internal_value(data: List[PrimitiveDict],
     # express as a type annotation. So this is really just a
     # way to "twist mypy's arm" into annotating things the way we
     # want.
-    serializer = field_class(*args, **{'many': True, **kwargs})
-    return serializer.to_internal_value(data)
+    serializer = serializer_class(*args, **{
+        'many': True,
+        'data': data,
+        **kwargs
+    })
+    serializer.is_valid(raise_exception=True)
+    return serializer.validated_data


### PR DESCRIPTION
This improves upon #959 by using our `Serializer` subclasses the proper way for deserialization, e.g. by passing `data` to their constructor, then calling `.is_valid()`, then returning `.validated_data`.  Also, since we're no longer calling `to_internal_value()` directly and expecting a list back instead of a dict, mypy is no longer confused, which removes the need for that [`list_to_internal_value()` hack](https://github.com/18F/omb-eregs/pull/959#discussion_r164209536). Hooray! 🎉 
