### PR TITLE
Use factories when creating ProseMirror nodes, alert on schema fail

### DIFF
--- a/api/document/js/Api.ts
+++ b/api/document/js/Api.ts
@@ -9,7 +9,7 @@ function setStatus(msg: string, className: 'editor-status-error'|'' = '') {
   status.className = `editor-status ${className}`;
 }
 
-function setStatusError(e: Error) {
+export function setStatusError(e: Error) {
   let errMsg = 'An error occurred.';
   const data = e['response'] && e['response']['data'];
   if (data) {

--- a/api/document/js/__tests__/create-editor-state.test.ts
+++ b/api/document/js/__tests__/create-editor-state.test.ts
@@ -1,0 +1,22 @@
+jest.mock('../Api');
+jest.mock('../parse-doc');
+
+import Api, { setStatusError } from '../Api';
+import createEditorState from '../create-editor-state';
+import parseDoc from '../parse-doc';
+import schema, { factory } from '../schema';
+
+
+describe('createEditorState()', () => {
+  it('alerts of doc schema errors', () => {
+    (parseDoc as jest.Mock).mockImplementationOnce(() => factory.policy([
+      // can't use a factory method here because we're intentionally creating
+      // an invalid doc
+      schema.nodes.heading.create({ depth: 1 }, factory.sec()),
+    ]));
+
+    createEditorState('', new Api({ contentType: '', csrfToken: '', url: '' }));
+
+    expect(setStatusError).toHaveBeenCalled();
+  });
+});

--- a/api/document/js/__tests__/parse-doc.test.ts
+++ b/api/document/js/__tests__/parse-doc.test.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 import parseDoc, { convertContent } from '../parse-doc';
 import { apiFactory } from '../serialize-doc';
+import schema from '../schema';
 
 jest.mock('axios');
 
@@ -19,8 +20,8 @@ describe('parseDoc()', () => {
 
     expect(result.type.name).toBe('policy');
     expect(result.content.childCount).toBe(2);
-    expect(result.content.child(0).type.name).toBe('unimplemented_node');
-    expect(result.content.child(1).type.name).toBe('unimplemented_node');
+    expect(result.content.child(0).type).toBe(schema.nodes.unimplementedNode);
+    expect(result.content.child(1).type).toBe(schema.nodes.unimplementedNode);
   });
 
   it('loads paragraph text', () => {
@@ -43,7 +44,7 @@ describe('parseDoc()', () => {
     expect(result.content.child(0).content.childCount).toBe(2);
     expect(result.content.child(0).content.child(0).text).toBe('Some text ');
     expect(result.content.child(0).content.child(1).text).toBe('here');
-    expect(result.content.child(1).type.name).toBe('unimplemented_node');
+    expect(result.content.child(1).type).toBe(schema.nodes.unimplementedNode);
   });
 
   it('figures out heading depth', () => {
@@ -101,7 +102,7 @@ describe('parseDoc()', () => {
     expect(body2.content.child(1).type.name).toBe('para');
   });
 
-  describe('unimplemented_node', () => {
+  describe('unimplementedNode', () => {
     it('saves original data', () => {
       const node = {
         node_type: 'something-unknown',
@@ -114,7 +115,7 @@ describe('parseDoc()', () => {
       };
 
       const result = parseDoc(node);
-      expect(result.type.name).toBe('unimplemented_node');
+      expect(result.type).toBe(schema.nodes.unimplementedNode);
       expect(result.attrs).toEqual({ data: node });
       expect(result.content.childCount).toBe(0);
     });
@@ -149,14 +150,14 @@ describe('convertContent()', () => {
 
     expect(text1.type.name).toBe('text');
     expect(text1.marks).toHaveLength(1);
-    expect(text1.marks[0].type.name).toBe('unimplemented_mark');
+    expect(text1.marks[0].type).toBe(schema.marks.unimplementedMark);
     expect(text1.marks[0].attrs.data.outer).toBe('props');
 
     expect(text2.type.name).toBe('text');
     expect(text2.marks).toHaveLength(2);
-    expect(text2.marks[0].type.name).toBe('unimplemented_mark');
+    expect(text2.marks[0].type).toBe(schema.marks.unimplementedMark);
     expect(text2.marks[0].attrs.data.outer).toBe('props');
-    expect(text2.marks[1].type.name).toBe('unimplemented_mark');
+    expect(text2.marks[1].type).toBe(schema.marks.unimplementedMark);
     expect(text2.marks[1].attrs.data.inner).toBe('stuff');
   });
 });

--- a/api/document/js/__tests__/schema.test.ts
+++ b/api/document/js/__tests__/schema.test.ts
@@ -1,22 +1,18 @@
 import { DOMSerializer } from 'prosemirror-model';
 
-import schema from '../schema';
+import schema, { factory } from '../schema';
 
 const serializer = DOMSerializer.fromSchema(schema);
 
-describe('unimplemented_node', () => {
+describe('unimplementedNode', () => {
   it('includes the node type as text', () => {
-    const node = schema.nodes.unimplemented_node.create({
-      data: { node_type: 'something-unknown' },
-    });
+    const node = factory.unimplementedNode({ node_type: 'something-unknown' });
     const result = serializer.serializeNode(node);
     expect(result.textContent).toBe('something-unknown');
   });
 
   it('falls back if no node type is present', () => {
-    const node = schema.nodes.unimplemented_node.create({
-      data: { bad: 'data' },
-    });
+    const node = factory.unimplementedNode({ bad: 'data' });
     const result = serializer.serializeNode(node);
     expect(result.textContent).toBe('[no-node-type]');
   });
@@ -27,7 +23,7 @@ describe('heading', () => {
     const hTag = `H${depth}`;
 
     it(`uses the ${hTag} tag`, () => {
-      const node = schema.nodes.heading.create({ depth });
+      const node = factory.heading('Header', depth);
       const result = serializer.serializeNode(node);
       expect(result.nodeName).toBe(hTag);
     });

--- a/api/document/js/__tests__/serialize-doc.test.ts
+++ b/api/document/js/__tests__/serialize-doc.test.ts
@@ -1,23 +1,17 @@
 import { Fragment } from 'prosemirror-model';
 
 import serializeDoc, { apiFactory, convertTexts } from '../serialize-doc';
-import schema from '../schema';
+import schema, { factory } from '../schema';
 
 
 describe('serializeDoc()', () => {
   it('converts nested nodes', () => {
-    const node = schema.nodes.policy.create({}, [
-      schema.nodes.sec.create({}, [
-        schema.nodes.heading.create({ depth: 1 }, schema.text('Some heading')),
-        schema.nodes.para.create(
-          {},
-          schema.nodes.inline.create({}, schema.text('First paragraph')),
-        ),
+    const node = factory.policy([
+      factory.sec([
+        factory.heading('Some heading', 1),
+        factory.para('First paragraph'),
       ]),
-      schema.nodes.para.create(
-        {},
-        schema.nodes.inline.create({}, schema.text('A later paragraph')),
-      ),
+      factory.para('A later paragraph'),
     ]);
 
     const result = serializeDoc(node);
@@ -41,10 +35,7 @@ describe('serializeDoc()', () => {
   });
 
   it('converts headings', () => {
-    const node = schema.nodes.heading.create(
-      { depth: 2 }, // this will be ignored
-      schema.text('Stuff stuff'),
-    );
+    const node = factory.heading('Stuff stuff', 2); // depth is ignored
     const result = serializeDoc(node);
     expect(result).toEqual({
       node_type: 'heading',
@@ -54,35 +45,18 @@ describe('serializeDoc()', () => {
   });
 
   it('converts unimplemented nodes', () => {
-    const node = schema.nodes.unimplemented_node.create({
-      data: { some: 'random', attrs: 'here' },
-    });
+    const node = factory.unimplementedNode({ some: 'random', attrs: 'here' });
     const result = serializeDoc(node);
     expect(result).toEqual({ some: 'random', attrs: 'here' });
   });
 
   it('converts list nodes', () => {
-    const node = schema.nodes.list.create({}, [
-      schema.nodes.listitem.create({}, [
-        schema.nodes.listitemMarker.create({}, schema.text('a)')),
-        schema.nodes.listitemBody.create({}, [
-          schema.nodes.para.create(
-            {}, schema.nodes.inline.create({}, schema.text('First p'))),
-          schema.nodes.para.create(
-            {}, schema.nodes.inline.create({}, schema.text('Second p')),
-          ),
-        ]),
+    const node = factory.list([
+      factory.listitem('a)', [
+        factory.para('First p'),
+        factory.para('Second p'),
       ]),
-      schema.nodes.listitem.create({}, [
-        schema.nodes.listitemMarker.create({}, schema.text('2.')),
-        schema.nodes.listitemBody.create(
-          {},
-          schema.nodes.para.create(
-            {},
-            schema.nodes.inline.create({}, schema.text('Content')),
-          ),
-        ),
-      ]),
+      factory.listitem('2.', [factory.para('Content')]),
     ]);
 
     const result = serializeDoc(node);
@@ -124,15 +98,9 @@ describe('convertTexts()', () => {
     const result = convertTexts(Fragment.fromArray([
       schema.text('Some '),
       schema.text('nested', [
-        schema.marks.unimplemented_mark.create({
-          data: { content_type: 'one', outer: 'thing' },
-        }),
-        schema.marks.unimplemented_mark.create({
-          data: { content_type: 'two', inner: 'here' },
-        }),
-        schema.marks.unimplemented_mark.create({
-          data: { content_type: 'three', most: 'deep' },
-        }),
+        factory.unimplementedMark({ content_type: 'one', outer: 'thing' }),
+        factory.unimplementedMark({ content_type: 'two', inner: 'here' }),
+        factory.unimplementedMark({ content_type: 'three', most: 'deep' }),
       ]),
       schema.text(' content'),
     ]));

--- a/api/document/js/create-editor-state.ts
+++ b/api/document/js/create-editor-state.ts
@@ -2,14 +2,21 @@ import { Node } from 'prosemirror-model';
 import { EditorState } from 'prosemirror-state';
 import { history } from 'prosemirror-history';
 
-import Api from './Api';
+import Api, { setStatusError } from './Api';
 import keyboard from './keyboard';
 import menu from './menu';
 import parseDoc from './parse-doc';
 
 export default function createEditorState(data, api: Api): EditorState {
+  const doc = parseDoc(data);
+  try {
+    doc.check();
+  } catch (e) {
+    setStatusError(e);
+  }
+
   return EditorState.create({
-    doc: parseDoc(data),
+    doc,
     plugins: [
       menu,
       keyboard(api),

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -32,6 +32,7 @@ const schema = new Schema({
     },
     heading: {
       content: 'text+',
+      group: 'block',
       attrs: {
         depth: {}, // will hold the header depth
       },

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -1,4 +1,4 @@
-import { NodeSpec, Schema } from 'prosemirror-model';
+import { Node, NodeSpec, Schema } from 'prosemirror-model';
 
 const listSchemaNodes: { [name: string]: NodeSpec } = {
   list: {
@@ -48,7 +48,7 @@ const schema = new Schema({
       toDOM: () => ['section', { class: 'node-section' }, 0],
     },
     text: {},
-    unimplemented_node: {
+    unimplementedNode: {
       group: 'block',
       atom: true,
       attrs: {
@@ -62,7 +62,7 @@ const schema = new Schema({
     ...listSchemaNodes,
   },
   marks: {
-    unimplemented_mark: {
+    unimplementedMark: {
       attrs: {
         data: {}, // will hold unrendered content
       },
@@ -70,5 +70,30 @@ const schema = new Schema({
     },
   },
 });
+
+export const factory = {
+  heading: (text: string, depth: number) =>
+    schema.nodes.heading.create({ depth }, schema.text(text)),
+  list: (children?: Node[]) =>
+    schema.nodes.list.create({}, children || []),
+  listitem: (marker: string, children?: Node[]) =>
+    schema.nodes.listitem.create({}, [
+      schema.nodes.listitemMarker.create({}, schema.text(marker)),
+      schema.nodes.listitemBody.create({}, children || []),
+    ]),
+  para: (textContent: string | Node[], children?: Node[]) =>
+    schema.nodes.para.create({}, [schema.nodes.inline.create(
+      {},
+      typeof textContent === 'string' ? schema.text(textContent) : textContent,
+    )].concat(children || [])),
+  policy: (children?: Node[]) =>
+    schema.nodes.policy.create({}, children || []),
+  sec: (children?: Node[]) =>
+    schema.nodes.sec.create({}, children || []),
+  unimplementedMark: (original: any) =>
+    schema.marks.unimplementedMark.create({ data: original }),
+  unimplementedNode: (original: any) =>
+    schema.nodes.unimplementedNode.create({ data: original }),
+};
 
 export default schema;

--- a/api/document/js/serialize-doc.ts
+++ b/api/document/js/serialize-doc.ts
@@ -64,7 +64,7 @@ const NODE_CONVERTERS = {
         { children, marker },
     );
   },
-  unimplemented_node: node => node.attrs.data,
+  unimplementedNode: node => node.attrs.data,
 };
 
 function defaultNodeConverter(node): ApiNode {
@@ -84,7 +84,7 @@ function defaultNodeConverter(node): ApiNode {
 }
 
 const MARK_CONVERTERS = {
-  unimplemented_mark: node =>
+  unimplementedMark: node =>
     apiFactory.content(node.type.name, node.attrs.data),
 };
 


### PR DESCRIPTION
In a few spots, our ProseMirror schema is a bit complex (having required nodes, needing specific attributes, etc.). Rather than require we remember the schema, we can use factory methods with parameters for each of the relevant bits.

This also alerts the user on schema validation failure (we had been loading an invalid doc structure without knowing).