### PR TITLE
Add button for add-paragraph

### DIFF
--- a/api/document/js/__tests__/commands.test.ts
+++ b/api/document/js/__tests__/commands.test.ts
@@ -1,0 +1,87 @@
+import { EditorState, TextSelection } from 'prosemirror-state';
+
+import { addParagraph } from '../commands';
+import schema, { factory } from '../schema';
+
+function executeTransform(initialState: EditorState, transform): EditorState {
+  const dispatch = jest.fn();
+
+  transform(initialState, dispatch);
+  const transaction = dispatch.mock.calls[0][0];
+  return initialState.apply(transaction);
+}
+
+
+describe('addParagraph()', () => {
+  it('adds a paragraph after the current', () => {
+    const doc = factory.policy([
+      factory.para('aaa'),
+      factory.para('bbb'),
+      factory.para('ccc'),
+    ]);
+    // Inside the 'bbb' paragraph
+    const selection = new TextSelection(doc.resolve(11));
+    const state = EditorState.create({ doc, selection });
+    const modifiedDoc = executeTransform(state, addParagraph).doc;
+
+    expect(modifiedDoc.content.childCount).toBe(4);
+    const texts: string[] = [];
+    modifiedDoc.content.forEach((child) => {
+      expect(child.type).toBe(schema.nodes.para);
+      texts.push(child.textContent);
+    });
+    expect(texts).toEqual(['aaa', 'bbb', ' ', 'ccc']);
+  });
+
+  it('inserts at the right layer of nesting', () => {
+    const doc = factory.policy([
+      factory.para('aaa', [
+        factory.para('subpar'),
+        factory.unimplementedNode({}),
+      ]),
+    ]);
+    // Inside the 'subpar' paragraph
+    const selection = new TextSelection(doc.resolve(12));
+    const state = EditorState.create({ doc, selection });
+    const modifiedDoc = executeTransform(state, addParagraph).doc;
+
+    expect(modifiedDoc.content.childCount).toBe(1);
+    const parA = modifiedDoc.content.child(0);
+    expect(parA.content.childCount).toBe(4); // inline + 3 children
+    expect(parA.content.child(2).textContent).toBe(' ');
+  });
+
+  it('skips over children', () => {
+    const doc = factory.policy([
+      factory.para('aaa', [
+        factory.para('subpar'),
+        factory.unimplementedNode({}),
+      ]),
+    ]);
+    // Inside the 'aaa' paragraph
+    const selection = new TextSelection(doc.resolve(4));
+    const state = EditorState.create({ doc, selection });
+    const modifiedDoc = executeTransform(state, addParagraph).doc;
+
+    expect(modifiedDoc.content.childCount).toBe(2);
+    expect(modifiedDoc.content.child(1).textContent).toBe(' ');
+  });
+
+  it('puts the cursor in the right place', () => {
+    const doc = factory.policy([
+      factory.para('aaa'),
+      factory.para('bbb'),
+      factory.para('ccc'),
+    ]);
+    // Inside the 'bbb' paragraph
+    const selection = new TextSelection(doc.resolve(11));
+    const state = EditorState.create({ doc, selection });
+    const modified = executeTransform(state, addParagraph);
+
+    const resolvedPos = modified.selection.$anchor;
+    expect(resolvedPos.depth).toBe(2);
+    expect(resolvedPos.parent.type).toBe(schema.nodes.inline);
+    expect(resolvedPos.parent).toBe(
+      modified.doc.content.child(2).content.child(0));
+  });
+});

--- a/api/document/js/__tests__/commands.test.ts
+++ b/api/document/js/__tests__/commands.test.ts
@@ -1,6 +1,6 @@
 import { EditorState, TextSelection } from 'prosemirror-state';
 
-import { addParagraph } from '../commands';
+import { appendParagraphNear } from '../commands';
 import schema, { factory } from '../schema';
 
 function executeTransform(initialState: EditorState, transform): EditorState {
@@ -12,7 +12,7 @@ function executeTransform(initialState: EditorState, transform): EditorState {
 }
 
 
-describe('addParagraph()', () => {
+describe('appendParagraphNear()', () => {
   it('adds a paragraph after the current', () => {
     const doc = factory.policy([
       factory.para('aaa'),
@@ -22,7 +22,7 @@ describe('addParagraph()', () => {
     // Inside the 'bbb' paragraph
     const selection = new TextSelection(doc.resolve(11));
     const state = EditorState.create({ doc, selection });
-    const modifiedDoc = executeTransform(state, addParagraph).doc;
+    const modifiedDoc = executeTransform(state, appendParagraphNear).doc;
 
     expect(modifiedDoc.content.childCount).toBe(4);
     const texts: string[] = [];
@@ -43,7 +43,7 @@ describe('addParagraph()', () => {
     // Inside the 'subpar' paragraph
     const selection = new TextSelection(doc.resolve(12));
     const state = EditorState.create({ doc, selection });
-    const modifiedDoc = executeTransform(state, addParagraph).doc;
+    const modifiedDoc = executeTransform(state, appendParagraphNear).doc;
 
     expect(modifiedDoc.content.childCount).toBe(1);
     const parA = modifiedDoc.content.child(0);
@@ -61,7 +61,7 @@ describe('addParagraph()', () => {
     // Inside the 'aaa' paragraph
     const selection = new TextSelection(doc.resolve(4));
     const state = EditorState.create({ doc, selection });
-    const modifiedDoc = executeTransform(state, addParagraph).doc;
+    const modifiedDoc = executeTransform(state, appendParagraphNear).doc;
 
     expect(modifiedDoc.content.childCount).toBe(2);
     expect(modifiedDoc.content.child(1).textContent).toBe(' ');
@@ -76,7 +76,7 @@ describe('addParagraph()', () => {
     // Inside the 'bbb' paragraph
     const selection = new TextSelection(doc.resolve(11));
     const state = EditorState.create({ doc, selection });
-    const modified = executeTransform(state, addParagraph);
+    const modified = executeTransform(state, appendParagraphNear);
 
     const resolvedPos = modified.selection.$anchor;
     expect(resolvedPos.depth).toBe(2);

--- a/api/document/js/commands.ts
+++ b/api/document/js/commands.ts
@@ -1,0 +1,26 @@
+import { Node } from 'prosemirror-model';
+import { TextSelection } from 'prosemirror-state';
+
+import { factory } from './schema';
+
+export function addParagraph(state, dispatch) {
+  if (!dispatch) {
+    return true;
+  }
+  const pos = state.selection.$head;
+  let depth = pos.depth;
+  while (depth >= 0) {
+    const node = pos.node(depth);
+    if (node.type.spec.group === 'block') {
+      const insertPos = pos.after(depth);
+      let tr = state.tr.insert(insertPos, factory.para(' '));
+      // + 2 to get us inside the inline
+      tr = tr.setSelection(TextSelection.create(tr.doc, insertPos + 2));
+      dispatch(tr.scrollIntoView());
+      return true;
+    }
+    depth -= 1;
+  }
+
+  return true;
+}

--- a/api/document/js/commands.ts
+++ b/api/document/js/commands.ts
@@ -3,12 +3,25 @@ import { TextSelection } from 'prosemirror-state';
 
 import { factory } from './schema';
 
-export function addParagraph(state, dispatch) {
+function safeDocCheck(doc: Node) {
+  try {
+    doc.check();
+  } catch (e) {
+    console.error('Doc no longer valid', e);
+  }
+}
+
+// Appends a mostly-empty `para` in the closest valid point after the user's
+// cursor/head of the current selection.
+export function appendParagraphNear(state, dispatch) {
+  // Checking whether or not this action is possible
   if (!dispatch) {
     return true;
   }
   const pos = state.selection.$head;
   let depth = pos.depth;
+  // Walk up the document until we hit a "block" element. We'll assume that
+  // if there's one, there can be many (including a new para).
   while (depth >= 0) {
     const node = pos.node(depth);
     if (node.type.spec.group === 'block') {
@@ -17,6 +30,7 @@ export function addParagraph(state, dispatch) {
       // + 2 to get us inside the inline
       tr = tr.setSelection(TextSelection.create(tr.doc, insertPos + 2));
       dispatch(tr.scrollIntoView());
+      safeDocCheck(tr.doc);
       return true;
     }
     depth -= 1;

--- a/api/document/js/menu.ts
+++ b/api/document/js/menu.ts
@@ -1,4 +1,18 @@
-import { menuBar, undoItem, redoItem, MenuItem } from 'prosemirror-menu';
+import { menuBar, undoItem, redoItem, MenuItem, MenuItemSpec } from 'prosemirror-menu';
+
+import { addParagraph } from './commands';
+
+
+const newParagraph = new MenuItem({
+  css: 'cursor: pointer;',
+  title: 'Add paragraph',
+  run: addParagraph,
+  label: 'P',
+  // These defaults are needed due to a doc issue. See
+  // https://github.com/ProseMirror/prosemirror-menu/issues/15
+  class: '',
+  execEvent: 'mousedown',
+});
 
 const menu = menuBar({
   floating: true,
@@ -11,6 +25,7 @@ const menu = menuBar({
       // https://github.com/ProseMirror/prosemirror-menu/issues/12
       undoItem as any as MenuItem,
       redoItem as any as MenuItem,
+      newParagraph,
     ],
   ],
 });

--- a/api/document/js/menu.ts
+++ b/api/document/js/menu.ts
@@ -1,12 +1,12 @@
 import { menuBar, undoItem, redoItem, MenuItem, MenuItemSpec } from 'prosemirror-menu';
 
-import { addParagraph } from './commands';
+import { appendParagraphNear } from './commands';
 
 
 const newParagraph = new MenuItem({
   css: 'cursor: pointer;',
   title: 'Add paragraph',
-  run: addParagraph,
+  run: appendParagraphNear,
   label: 'P',
   // These defaults are needed due to a doc issue. See
   // https://github.com/ProseMirror/prosemirror-menu/issues/15


### PR DESCRIPTION
This builds on #969. We'll most likely want to do paragraph splitting, collapsing, and other fun logic, but this starts us off by allowing a paragraph to be added through a button press. We'll no doubt be re-working this soon.

## Looks like
![create-paragraph](https://user-images.githubusercontent.com/326918/35539257-d8b51b3a-051e-11e8-86d6-4bed3863dfee.gif)