### PR TITLE
Make errors in AKN XML editor a bit friendlier.

### DIFF
--- a/api/document/js/Api.ts
+++ b/api/document/js/Api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 import { getEl } from './util';
+import { makeErrorFriendly } from './friendly-error';
 
 function setStatus(msg: string, className: 'editor-status-error'|'' = '') {
   const status = getEl('#status');
@@ -9,10 +10,10 @@ function setStatus(msg: string, className: 'editor-status-error'|'' = '') {
 }
 
 function setStatusError(e: Error) {
-  let errMsg = `An error occurred: ${e}`;
+  let errMsg = 'An error occurred.';
   const data = e['response'] && e['response']['data'];
   if (data) {
-    errMsg += '\n' + JSON.stringify(data, null, 2);
+    errMsg += '\n' + makeErrorFriendly(data);
   }
   setStatus(errMsg, 'editor-status-error');
 }

--- a/api/document/js/__tests__/friendly-error.test.ts
+++ b/api/document/js/__tests__/friendly-error.test.ts
@@ -1,0 +1,98 @@
+import { makeErrorFriendly } from '../friendly-error';
+
+describe('makeErrorFriendly()', () => {
+  it('converts simple "detail" errors', () => {
+    const detail = ('XML syntax error - expected \'>\', line 4, ' +
+                    'column 3 (<string>, line 4)');
+    expect(makeErrorFriendly({ detail })).toBe(detail);
+  });
+
+  it('returns string errors as-is', () => {
+    const msg = 'NameError at /document/M-16-19\nname \'boom\' is not ...';
+    expect(makeErrorFriendly(msg)).toBe(msg);
+  });
+
+  it('returns other errors as their JSON stringification', () => {
+    expect(makeErrorFriendly(null)).toBe('null');
+  });
+
+  it('provides details on XML errors w/ invalid content types', () => {
+    /* tslint:disable */
+    const err = {
+      "children": [
+        {
+          "content": [
+            {
+              "content_type": "'k' is an invalid content type.",
+              "_sourceline": "3"
+            },
+            {}
+          ],
+          "_sourceline": "2"
+        }
+      ],
+      "_sourceline": "1"
+    };
+    /* tslint:enable */
+    expect(makeErrorFriendly(err)).toBe(
+      `In an element starting at line 3:\n` +
+      `* content_type - 'k' is an invalid content type.`,
+    );
+  });
+
+  it('provides details on XML errors w/ sibling emblem conflicts', () => {
+    /* tslint:disable */
+    const err =   {
+      "children": [
+        "Multiple occurrences of 'a' with emblem '1' exist as siblings"
+      ],
+      "_sourceline": "1"
+    };
+    /* tslint:enable */
+    expect(makeErrorFriendly(err)).toBe(
+      `In an element starting at line 1:\n` +
+      `* children - Multiple occurrences of 'a' with emblem '1' exist as siblings`,
+    );
+  });
+
+  it('provides details on XML errors w/ non-field errors', () => {
+    /* tslint:disable */
+    const err = {
+      "non_field_errors": [
+        "Multiple footnotes exist with type emblem '1'"
+      ],
+      "_sourceline": "1"
+    };
+    /* tslint:enable */
+    expect(makeErrorFriendly(err)).toBe(
+      `In an element starting at line 1:\n` +
+      `* non_field_errors - Multiple footnotes exist with type emblem '1'`,
+    );
+  });
+
+  it('provides details on XML errors w/ missing attributes', () => {
+    /* tslint:disable */
+    const err = {
+      "children": [
+        {},
+        {
+          "content": [
+            {
+              "href": [
+                "This field is required."
+              ],
+              "_sourceline": "4"
+            }
+          ],
+          "_sourceline": "3"
+        }
+      ],
+      "_sourceline": "1"
+    };
+    /* tslint:enable */
+    expect(makeErrorFriendly(err)).toBe(
+      `In an element starting at line 4:\n` +
+      `* href - This field is required.`,
+    );
+  });
+});

--- a/api/document/js/friendly-error.ts
+++ b/api/document/js/friendly-error.ts
@@ -1,0 +1,80 @@
+class XMLErrorInfo {
+  nestedErrors: XMLErrorInfo[];
+  errors: string[];
+  sourceline: number;
+
+  static isXMLError(err: any): boolean {
+    return (typeof err === 'object' && err !== null &&
+            '_sourceline' in err);
+  }
+
+  constructor(err: object) {
+    this.nestedErrors = [];
+    this.errors = [];
+    this.sourceline = parseInt(err['_sourceline'], 10);
+
+    Object.keys(err)
+      .filter(name => name !== '_sourceline')
+      .forEach((name) => {
+        const value = err[name];
+        if (Array.isArray(value)) {
+          this.diveIntoArrayProp(name, value);
+        } else {
+          this.addError(name, makeErrorFriendly(value));
+        }
+      });
+  }
+
+  addError(name: string, value: string) {
+    this.errors.push(`${name} - ${value}`);
+  }
+
+  diveIntoArrayProp(name: string, value: any[]) {
+    value.forEach((item) => {
+      if (XMLErrorInfo.isXMLError(item)) {
+        this.nestedErrors.push(new XMLErrorInfo(item));
+      } else if (!isEmptyObject(item)) {
+        this.addError(name, makeErrorFriendly(item));
+      }
+    });
+  }
+
+  toString(indent: string = ''): string {
+    const lines: string[] = [];
+    let nextIndent = indent;
+    if (this.errors.length) {
+      lines.push(`${indent}In an element starting at line ` +
+                 `${this.sourceline}:`);
+      this.errors.forEach((text) => {
+        lines.push(`${indent}* ${text}`);
+      });
+      nextIndent += '  ';
+    }
+    this.nestedErrors.forEach((err) => {
+      lines.push(err.toString(nextIndent));
+    });
+
+    return lines.join('\n');
+  }
+}
+
+function isEmptyObject(obj: any) {
+  return typeof obj === 'object' && obj !== null &&
+    Object.keys(obj).length === 0;
+}
+
+export function makeErrorFriendly(err: any): string {
+  if (typeof err === 'string') {
+    return err;
+  }
+  if (typeof err === 'object' && err !== null) {
+    if (Object.keys(err).length === 1 &&
+        typeof(err.detail) === 'string') {
+      return err.detail;
+    }
+    if (XMLErrorInfo.isXMLError(err)) {
+      return (new XMLErrorInfo(err)).toString();
+    }
+  }
+  return JSON.stringify(err, null, 2);
+}

--- a/api/ereqs_admin/static/admin/module/_editor.scss
+++ b/api/ereqs_admin/static/admin/module/_editor.scss
@@ -9,8 +9,12 @@
   div.unimplemented {
     padding: 2px 4px;
   }
+}
 
-  .editor-status-error {
+#status {
+  white-space: pre-wrap;
+
+  &.editor-status-error {
     color: $color-red;
   }
 }


### PR DESCRIPTION
This makes error output a bit friendlier. It actually affects the ProseMirror editor too, but most of the enhancements are specific to the XML editor:

* When an error is just a string, such as the raw content of a Django 500 traceback, we just print out the whole string, rather than printing its human-unfriendly JSON representation.

* When an error is just a JS object with a single `detail` key that has a string value, we just print out that value, instead of the whole object's JSON representation.

* When an error has `_sourceline` metadata in it, we assume that the input was XML, and we provide slightly friendlier help than just printing out a big JSON blob. It's still far from ideal, but it's a start, and it's much better than just printing out a JSON blob.
