### PR TITLE
Fix delete-paragraph bug

### DIFF
--- a/api/document/js/__tests__/schema.test.ts
+++ b/api/document/js/__tests__/schema.test.ts
@@ -1,4 +1,6 @@
+import { deleteSelection } from 'prosemirror-commands';
 import { DOMSerializer } from 'prosemirror-model';
+import { EditorState, TextSelection } from 'prosemirror-state';
 
 import schema, { factory } from '../schema';
 
@@ -27,5 +29,25 @@ describe('heading', () => {
       const result = serializer.serializeNode(node);
       expect(result.nodeName).toBe(hTag);
     });
+  });
+});
+
+describe('para', () => {
+  it('can be deleted', () => {
+    const doc = factory.policy([
+      factory.para('1'),
+      factory.para('2'),
+    ]);
+    expect(doc.content.childCount).toBe(2);
+    // Selected the "2"
+    const selection = new TextSelection(doc.resolve(7), doc.resolve(8));
+    const state = EditorState.create({ doc, selection });
+    const dispatch = jest.fn();
+
+    deleteSelection(state, dispatch);
+    const transaction = dispatch.mock.calls[0][0];
+    const modifiedDoc = state.apply(transaction).doc;
+
+    expect(modifiedDoc.content.childCount).toBe(1);
   });
 });

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -39,7 +39,7 @@ const schema = new Schema({
       toDOM: node => [`h${node.attrs.depth}`, { class: 'node-heading' }, 0],
     },
     para: {
-      content: 'inline? block*',
+      content: 'inline block*',
       group: 'block',
       toDOM: () => ['div', { class: 'node-paragraph' }, 0],
     },


### PR DESCRIPTION
Building on #969, this fixes a bug in which deleting a paragraph in the ProseMirror frontend wouldn't delete its entry in the ProseMirror doc. Then that doc was serialized, it'd include an empty paragraph, which led to very unintuitive problems.