### PR TITLE
Skip JSON end-to-end test for now

### DIFF
--- a/api/document/tests/end_to_end_test.py
+++ b/api/document/tests/end_to_end_test.py
@@ -29,7 +29,10 @@ def get_cursor_for_policy(policy: Policy) -> DocCursor:
 
 @pytest.mark.parametrize("parser_class,renderer_class", [
     (AkomaNtosoParser, AkomaNtosoRenderer),
-    (JSONParser, JSONRenderer),
+    pytest.param(JSONParser, JSONRenderer, marks=pytest.mark.skip(
+        reason=("Intermittent failure; see "
+                "https://github.com/18F/omb-eregs/issues/974")
+    )),
 ])
 @pytest.mark.django_db
 def test_end_to_end(parser_class, renderer_class):


### PR DESCRIPTION
This is just a workaround for #974 for now, until we have enough time to investigate the intermittent failure more closely.