### PR TITLE
Allow non-public documents to be edited by admins.

### DIFF
--- a/api/document/views.py
+++ b/api/document/views.py
@@ -23,7 +23,10 @@ class TreeView(GenericAPIView):
     queryset = DocNode.objects.none()   # Used to determine permissions
 
     def get_object(self, prefetch_related=True):
-        policy = policy_or_404(self.kwargs['policy_id'])
+        policy = policy_or_404(
+            self.kwargs['policy_id'],
+            only_public=not self.request.user.is_authenticated,
+        )
         # we'll pass this policy down when we serialize
         self.policy = policy
         query_args = {'policy_id': policy.pk}
@@ -38,6 +41,7 @@ class TreeView(GenericAPIView):
         root = DocCursor.load_from_model(root_doc, subtree=False)
         if prefetch_related:
             root.add_models(root_doc.descendants().prefetch_annotations())
+        self.check_object_permissions(self.request, root)
         return root
 
     def get_serializer_context(self):
@@ -70,7 +74,7 @@ class TreeView(GenericAPIView):
 def render_editor(request, policy_id, filename, title):
     # Verify that the policy is valid; 404 when not. We don't actually load
     # the document content as they'll be retrieved from the API
-    policy_or_404(policy_id)
+    policy_or_404(policy_id, only_public=False)
     return render(request, filename, {
         'document_url': reverse('document', kwargs={'policy_id': policy_id}),
         'title': title,

--- a/api/document/views.py
+++ b/api/document/views.py
@@ -23,10 +23,8 @@ class TreeView(GenericAPIView):
     queryset = DocNode.objects.none()   # Used to determine permissions
 
     def get_object(self, prefetch_related=True):
-        policy = policy_or_404(
-            self.kwargs['policy_id'],
-            only_public=not self.request.user.is_authenticated,
-        )
+        only_public = not self.request.user.is_authenticated
+        policy = policy_or_404(self.kwargs['policy_id'], only_public)
         # we'll pass this policy down when we serialize
         self.policy = policy
         query_args = {'policy_id': policy.pk}

--- a/api/reqs/views/policies.py
+++ b/api/reqs/views/policies.py
@@ -62,8 +62,10 @@ def relevant_reqs_count(params):
     return Subquery(subquery, output_field=IntegerField())
 
 
-def policy_or_404(identifier):
-    queryset = Policy.objects.filter(public=True)
+def policy_or_404(identifier, only_public=True):
+    queryset = Policy.objects.all()
+    if only_public:
+        queryset = queryset.filter(public=True)
     policy = queryset.filter(omb_policy_id=identifier).first()
     if not policy and identifier.isdigit():
         policy = queryset.filter(pk=identifier).first()


### PR DESCRIPTION
Previously, we weren't allowing documents associated with non-public policies
from being loaded into the editor (nor could they be retrieved in the API).
This should allow *logged in* users to see both.

It also adds a permissions check to the document load logic, which it looks
like we forgot. We don't really worry about different user groups anywhere
(other than logged in vs non), but it's best to lay that groundwork now.