### PR TITLE
Add "Save and edit document" to policy admin.

### DIFF
--- a/api/omb_eregs/urls.py
+++ b/api/omb_eregs/urls.py
@@ -22,7 +22,8 @@ from reqs.router import router
 
 urlpatterns = [
     url(r'^', include(router.urls)),
-    url(r'^admin/document-editor/(?P<policy_id>[^/]+)$', editor),
+    url(r'^admin/document-editor/(?P<policy_id>[^/]+)$', editor,
+        name='document_editor'),
     url(r'^admin/document-editor/(?P<policy_id>[^/]+)/akn$', editor_akn),
     url(r'^admin/', admin_site.urls),
     url(r'^document/', include('document.urls')),

--- a/api/reqs/admin.py
+++ b/api/reqs/admin.py
@@ -1,6 +1,8 @@
 from django import forms
 from django.contrib import admin
 from django.core.exceptions import ValidationError
+from django.http import HttpResponseRedirect
+from django.urls import reverse
 
 from ereqs_admin.revision_admin import EReqsVersionAdmin
 from reqs.models import Agency, AgencyGroup, Office, Policy, Requirement, Topic
@@ -39,6 +41,15 @@ class PolicyAdmin(EReqsVersionAdmin):
         'public',
         'workflow_phase',
     ]
+
+    def response_post_save_change(self, request, obj):
+        """Redirect to the document editor, if that's the button the user
+        clicked."""
+        if '_savethendoc' in request.POST:
+            policy_id = obj.omb_policy_id or obj.slug
+            return HttpResponseRedirect(
+                reverse('document_editor', kwargs={'policy_id': policy_id}))
+        return super().response_post_save_change(request, obj)
 
 
 @admin.register(Topic)

--- a/api/reqs/templates/admin/reqs/policy/change_form.html
+++ b/api/reqs/templates/admin/reqs/policy/change_form.html
@@ -1,0 +1,4 @@
+{% extends "admin/change_form.html" %}
+{% load policy_submit_row %}
+
+{% block submit_buttons_bottom %}{% submit_row %}{% endblock %}

--- a/api/reqs/templates/reqs/admin/submit_line.html
+++ b/api/reqs/templates/reqs/admin/submit_line.html
@@ -1,0 +1,16 @@
+{% comment %}
+Copy-pasted and then extended from /admin/submit_line.html to include a "Save
+and edit document" button
+{% endcomment %}
+{% load i18n admin_urls %}
+<div class="submit-row">
+{% if show_save %}<input type="submit" value="{% trans 'Save' %}" class="default" name="_save" />{% endif %}
+{% if show_delete_link %}
+    {% url opts|admin_urlname:'delete' original.pk|admin_urlquote as delete_url %}
+    <p class="deletelink-box"><a href="{% add_preserved_filters delete_url %}" class="deletelink">{% trans "Delete" %}</a></p>
+{% endif %}
+{% if show_save_then_doc %}<input type="submit" value="{% trans 'Save and edit document' %}" name="_savethendoc" />{% endif %}
+{% if show_save_as_new %}<input type="submit" value="{% trans 'Save as new' %}" name="_saveasnew" />{% endif %}
+{% if show_save_and_add_another %}<input type="submit" value="{% trans 'Save and add another' %}" name="_addanother" />{% endif %}
+{% if show_save_and_continue %}<input type="submit" value="{% trans 'Save and continue editing' %}" name="_continue" />{% endif %}
+</div>

--- a/api/reqs/templatetags/policy_submit_row.py
+++ b/api/reqs/templatetags/policy_submit_row.py
@@ -1,0 +1,15 @@
+from django import template
+from django.contrib.admin.templatetags.admin_modify import \
+    submit_row as original_submit_row
+
+register = template.Library()
+
+
+@register.inclusion_tag('reqs/admin/submit_line.html', takes_context=True)
+def submit_row(context):
+    """Identical to admin_modify's submit_row, save that we use a different
+    template and add an extra context value."""
+    context = original_submit_row(context)
+    # Extension point for future permissions checks, if desired
+    context['show_save_then_doc'] = True
+    return original_submit_row(context)

--- a/api/reqs/tests/admin_tests.py
+++ b/api/reqs/tests/admin_tests.py
@@ -1,0 +1,36 @@
+from model_mommy import mommy
+
+from document.tree import DocCursor
+from reqs.models import Policy
+
+
+def test_policy_edit_doc_button(admin_client):
+    policy = mommy.make(Policy, slug='some-policy')
+    root = DocCursor.new_tree('root', policy=policy)
+    root.nested_set_renumber()
+
+    result = admin_client.get(f'/admin/reqs/policy/{policy.pk}/change/')
+    assert b'_savethendoc' in result.content
+    assert b'Save and edit document' in result.content
+
+
+def test_policy_redirect(admin_client):
+    policy = mommy.make(Policy, slug='some-policy')
+    root = DocCursor.new_tree('root', policy=policy)
+    root.nested_set_renumber()
+
+    result = admin_client.post(f'/admin/reqs/policy/{policy.pk}/change/', {
+       'title': 'Some new policy title',
+       'omb_policy_id': '',
+       'issuance': policy.issuance.isoformat(),
+       'sunset': '',
+       'public': 'on',
+       'workflow_phase': 'cleanup',
+       '_savethendoc': 'Save and edit document',
+    })
+
+    assert result.status_code == 302
+    assert result['Location'] == '/admin/document-editor/some-policy'
+
+    policy.refresh_from_db()
+    assert policy.title == 'Some new policy title'


### PR DESCRIPTION
We'd like a stop-gap to get to the editor page from a policy, so we'll add a
new button at the bottom of the Policy change form. We call the Django
template tags and methods and copy-paste the minimum template to reduce
duplication.

## Looks like
![save-and-edit](https://user-images.githubusercontent.com/326918/35653993-b4d54848-06b8-11e8-99d9-131e762ab6ee.gif)
