### PR TITLE
Remove shared-styles symlink to support docker on Windows

### DIFF
--- a/ui/css/main.scss
+++ b/ui/css/main.scss
@@ -11,13 +11,13 @@ $fa-font-path: '~font-awesome/fonts';
 @import '~katex/dist/katex.css';
 @import '~system-font-css/system-font';
 
-@import 'shared-styles/base/colors';
-@import 'shared-styles/base/fonts';
-@import 'shared-styles/base/media-queries';
-@import 'shared-styles/base/spacing';
-@import 'shared-styles/base/type-size';
-@import 'shared-styles/base/util';
-@import 'shared-styles/layout/markers';
+@import '../../shared-styles/base/colors';
+@import '../../shared-styles/base/fonts';
+@import '../../shared-styles/base/media-queries';
+@import '../../shared-styles/base/spacing';
+@import '../../shared-styles/base/type-size';
+@import '../../shared-styles/base/util';
+@import '../../shared-styles/layout/markers';
 @import 'base/base';
 
 @import 'layout/typography';
@@ -40,9 +40,9 @@ $fa-font-path: '~font-awesome/fonts';
 @import 'module/tables';
 @import 'module/external-link';
 @import 'module/styleguide';
-@import 'shared-styles/module/heading';
-@import 'shared-styles/module/list';
-@import 'shared-styles/module/paragraph';
+@import '../shared-styles/module/heading';
+@import '../shared-styles/module/list';
+@import '../shared-styles/module/paragraph';
 
 @import 'state/print';
 @import 'state/ie';

--- a/ui/css/shared-styles
+++ b/ui/css/shared-styles
@@ -1,1 +1,0 @@
-../../shared-styles/


### PR DESCRIPTION
ab5bce3e343281b8dd21861cfd99c3fd5c094d75 created a symlink that made a `shared-styles` folder and linked to SCSS through it.

However, symlinks on Windows are problematic, to say the least. Out-of-the-box, the use of this symlink breaks Windows docker setups. While it may _technically_ be possible to make it work, it's likely that it'd  require the very latest versions of Windows 10 and developer tools (git and docker, at the very least), and possibly additional preference-setting gymnastics.  This could be particularly problematic for folks who may be stuck in enterprise environment, so I think we probably shouldn't rely on symlinks if at all possible.

This PR fixes things by removing the symlink and directly referring to the folder in question.