### PR TITLE
Add save buttons to the editor

### DIFF
--- a/api/document/js/__tests__/Api.test.ts
+++ b/api/document/js/__tests__/Api.test.ts
@@ -12,7 +12,7 @@ function mockSetStatus() {
   const textContent = jest.fn();
   const statusEl = {};
   Object.defineProperty(statusEl, 'textContent', { set: textContent });
-  (getEl as any).mockReturnValue(statusEl);
+  (getEl as jest.Mock).mockReturnValue(statusEl);
   return textContent;
 }
 

--- a/api/document/js/__tests__/commands.test.ts
+++ b/api/document/js/__tests__/commands.test.ts
@@ -94,7 +94,7 @@ describe('appendParagraphNear()', () => {
 
 describe('makeSave()', () => {
   it('calls the save function', async () => {
-    (serializeDoc as any).mockImplementationOnce(() => ({ serialized: 'content' }));
+    (serializeDoc as jest.Mock).mockImplementationOnce(() => ({ serialized: 'content' }));
 
     const api = new Api({ contentType: '', csrfToken: '', url: '' });
     const save = makeSave(api);
@@ -107,7 +107,7 @@ describe('makeSave()', () => {
 
 describe('makeSaveThenXml()', () => {
   it('calls the save function', async () => {
-    (serializeDoc as any).mockImplementationOnce(() => ({ serialized: 'content' }));
+    (serializeDoc as jest.Mock).mockImplementationOnce(() => ({ serialized: 'content' }));
 
     const api = new Api({ contentType: '', csrfToken: '', url: '' });
     const save = makeSaveThenXml(api);
@@ -118,13 +118,14 @@ describe('makeSaveThenXml()', () => {
   });
 
   it('changes the window location', async () => {
-    (window.location.assign as any).mockClear();
+    const locationAssign = window.location.assign as jest.Mock;
+    locationAssign.mockClear();
 
     const api = new Api({ contentType: '', csrfToken: '', url: '' });
     const save = makeSaveThenXml(api);
     await save({ doc: 'stuff' });
 
-    const param = (window.location.assign as any).mock.calls[0][0];
+    const param = locationAssign.mock.calls[0][0];
     expect(param).toMatch(/akn$/);
   });
 });

--- a/api/document/js/__tests__/commands.test.ts
+++ b/api/document/js/__tests__/commands.test.ts
@@ -1,7 +1,12 @@
+jest.mock('../Api');
+jest.mock('../serialize-doc');
+
 import { EditorState, TextSelection } from 'prosemirror-state';
 
-import { appendParagraphNear } from '../commands';
+import Api from '../Api';
+import { appendParagraphNear, makeSave } from '../commands';
 import schema, { factory } from '../schema';
+import serializeDoc from '../serialize-doc';
 
 function executeTransform(initialState: EditorState, transform): EditorState {
   const dispatch = jest.fn();
@@ -83,5 +88,18 @@ describe('appendParagraphNear()', () => {
     expect(resolvedPos.parent.type).toBe(schema.nodes.inline);
     expect(resolvedPos.parent).toBe(
       modified.doc.content.child(2).content.child(0));
+  });
+});
+
+describe('makeSave()', () => {
+  it('calls the save function', async () => {
+    (serializeDoc as any).mockImplementationOnce(() => ({ serialized: 'content' }));
+
+    const api = new Api({ contentType: '', csrfToken: '', url: '' });
+    const save = makeSave(api);
+    await save({ doc: 'stuff' });
+
+    expect(serializeDoc).toBeCalledWith('stuff');
+    expect(api.write).toBeCalledWith({ serialized: 'content' });
   });
 });

--- a/api/document/js/commands.ts
+++ b/api/document/js/commands.ts
@@ -1,7 +1,9 @@
 import { Node } from 'prosemirror-model';
 import { TextSelection } from 'prosemirror-state';
 
+import Api from './Api';
 import { factory } from './schema';
+import serializeDoc from './serialize-doc';
 
 function safeDocCheck(doc: Node) {
   try {
@@ -37,4 +39,8 @@ export function appendParagraphNear(state, dispatch) {
   }
 
   return true;
+}
+
+export function makeSave(api: Api) {
+  return async state => api.write(serializeDoc(state.doc));
 }

--- a/api/document/js/commands.ts
+++ b/api/document/js/commands.ts
@@ -44,3 +44,10 @@ export function appendParagraphNear(state, dispatch) {
 export function makeSave(api: Api) {
   return async state => api.write(serializeDoc(state.doc));
 }
+
+export function makeSaveThenXml(api: Api) {
+  return async (state) => {
+    await api.write(serializeDoc(state.doc));
+    window.location.assign(`${window.location.href}/akn`);
+  };
+}

--- a/api/document/js/create-editor-state.ts
+++ b/api/document/js/create-editor-state.ts
@@ -18,7 +18,7 @@ export default function createEditorState(data, api: Api): EditorState {
   return EditorState.create({
     doc,
     plugins: [
-      menu,
+      menu(api),
       keyboard(api),
       history(),
     ],

--- a/api/document/js/keyboard.ts
+++ b/api/document/js/keyboard.ts
@@ -3,13 +3,13 @@ import { undo, redo } from 'prosemirror-history';
 import { keymap } from 'prosemirror-keymap';
 
 import Api from './Api';
-import serializeDoc from './serialize-doc';
+import { makeSave } from './commands';
 
 export default function menu(api: Api) {
   return keymap({
     ...baseKeymap,
     'Mod-z': undo,
     'Shift-Mod-z': redo,
-    'Mod-s': async state => api.write(serializeDoc(state.doc)),
+    'Mod-s': makeSave(api),
   });
 }

--- a/api/document/js/menu.ts
+++ b/api/document/js/menu.ts
@@ -4,13 +4,13 @@ import { appendParagraphNear } from './commands';
 
 
 const newParagraph = new MenuItem({
-  css: 'cursor: pointer;',
-  title: 'Add paragraph',
+  class: 'menuitem-clickable',
+  title: 'Append paragraph',
   run: appendParagraphNear,
   label: 'P',
   // These defaults are needed due to a doc issue. See
   // https://github.com/ProseMirror/prosemirror-menu/issues/15
-  class: '',
+  css: '',
   execEvent: 'mousedown',
 });
 

--- a/api/document/js/menu.ts
+++ b/api/document/js/menu.ts
@@ -1,6 +1,7 @@
 import { menuBar, undoItem, redoItem, MenuItem, MenuItemSpec } from 'prosemirror-menu';
 
-import { appendParagraphNear } from './commands';
+import Api from './Api';
+import { appendParagraphNear, makeSave } from './commands';
 
 
 const newParagraph = new MenuItem({
@@ -14,20 +15,34 @@ const newParagraph = new MenuItem({
   execEvent: 'mousedown',
 });
 
-const menu = menuBar({
-  floating: true,
-  content: [
-    [
-      // This forcible type assertion is due to what appears to
-      // be a bug in the documentation/type annotations for
-      // prosemirror-menu. For more details, see:
-      //
-      // https://github.com/ProseMirror/prosemirror-menu/issues/12
-      undoItem as any as MenuItem,
-      redoItem as any as MenuItem,
-      newParagraph,
-    ],
-  ],
-});
+function makeSaveButton(api: Api) {
+  return new MenuItem({
+    class: 'menuitem-clickable',
+    title: 'Save Document',
+    run: makeSave(api),
+    label: 'Save',
+    // These defaults are needed due to a doc issue. See
+    // https://github.com/ProseMirror/prosemirror-menu/issues/15
+    css: '',
+    execEvent: 'mousedown',
+  });
+}
 
-export default menu;
+export default function menu(api: Api) {
+  return menuBar({
+    floating: true,
+    content: [
+      [
+        // This forcible type assertion is due to what appears to
+        // be a bug in the documentation/type annotations for
+        // prosemirror-menu. For more details, see:
+        //
+        // https://github.com/ProseMirror/prosemirror-menu/issues/12
+        undoItem as any as MenuItem,
+        redoItem as any as MenuItem,
+        newParagraph,
+        makeSaveButton(api),
+      ],
+    ],
+  });
+}

--- a/api/document/js/menu.ts
+++ b/api/document/js/menu.ts
@@ -1,30 +1,16 @@
 import { menuBar, undoItem, redoItem, MenuItem, MenuItemSpec } from 'prosemirror-menu';
 
 import Api from './Api';
-import { appendParagraphNear, makeSave } from './commands';
+import { appendParagraphNear, makeSave, makeSaveThenXml } from './commands';
 
-
-const newParagraph = new MenuItem({
-  class: 'menuitem-clickable',
-  title: 'Append paragraph',
-  run: appendParagraphNear,
-  label: 'P',
-  // These defaults are needed due to a doc issue. See
-  // https://github.com/ProseMirror/prosemirror-menu/issues/15
-  css: '',
-  execEvent: 'mousedown',
-});
-
-function makeSaveButton(api: Api) {
+function makeButton(content) {
   return new MenuItem({
     class: 'menuitem-clickable',
-    title: 'Save Document',
-    run: makeSave(api),
-    label: 'Save',
     // These defaults are needed due to a doc issue. See
     // https://github.com/ProseMirror/prosemirror-menu/issues/15
     css: '',
     execEvent: 'mousedown',
+    ...content,
   });
 }
 
@@ -40,8 +26,21 @@ export default function menu(api: Api) {
         // https://github.com/ProseMirror/prosemirror-menu/issues/12
         undoItem as any as MenuItem,
         redoItem as any as MenuItem,
-        newParagraph,
-        makeSaveButton(api),
+        makeButton({
+          label: 'P',
+          run: appendParagraphNear,
+          title: 'Append paragraph',
+        }),
+        makeButton({
+          label: 'Save',
+          run: makeSave(api),
+          title: 'Save document',
+        }),
+        makeButton({
+          label: 'Save then XML',
+          title: 'Save document then edit as XML',
+          run: makeSaveThenXml(api),
+        }),
       ],
     ],
   });

--- a/api/ereqs_admin/static/admin/module/_editor.scss
+++ b/api/ereqs_admin/static/admin/module/_editor.scss
@@ -32,3 +32,23 @@ kbd {
   padding: .1em .6em;
   text-shadow: 0 1px 0 $color-white;
 }
+
+.ProseMirror-menubar {
+  padding: $space-xs;
+  border-bottom-color: $color-black;
+}
+
+.ProseMirror-menuitem {
+  border: solid 1px $color-black;
+  color: $color-black;
+  margin-left: 0;
+  margin-right: $space-xs;
+  min-width: 1rem;
+  padding-left: $space-sm;
+  padding-right: $space-sm;
+  text-align: center;
+}
+
+.menuitem-clickable {
+  cursor: pointer;
+}


### PR DESCRIPTION
Per convo with @rtwell and @austinhernandez, this adds a "save" button and adds a path to get to the XML editor.

## Looks like
<img width="573" alt="screen shot 2018-02-01 at 12 43 37 pm" src="https://user-images.githubusercontent.com/326918/35693910-a3206d0e-074d-11e8-8c20-0699a15999dd.png">
