### PR TITLE
Prevent list markers from being edited.

### DIFF
--- a/api/document/js/__tests__/parse-doc.test.ts
+++ b/api/document/js/__tests__/parse-doc.test.ts
@@ -84,22 +84,14 @@ describe('parseDoc()', () => {
     expect(result.content.childCount).toBe(2);
     const lis = [result.content.child(0), result.content.child(1)];
     expect(lis.map(li => li.type.name)).toEqual(['listitem', 'listitem']);
-    expect(lis.map(li => li.content.childCount)).toEqual([2, 2]);
+    expect(lis.map(li => li.attrs.marker)).toEqual(['aaa', 'bbb']);
 
-    const markers = lis.map(li => li.content.child(0));
-    expect(markers.map(m => m.type.name)).toEqual(
-      ['listitemMarker', 'listitemMarker']);
-    expect(markers.map(m => m.textContent)).toEqual(['aaa', 'bbb']);
+    expect(lis[0].content.childCount).toBe(1);
+    expect(lis[0].content.child(0).type.name).toBe('para');
 
-    const [body1, body2] = lis.map(li => li.content.child(1));
-    expect(body1.type.name).toBe('listitemBody');
-    expect(body1.content.childCount).toBe(1);
-    expect(body1.content.child(0).type.name).toBe('para');
-
-    expect(body2.type.name).toBe('listitemBody');
-    expect(body2.content.childCount).toBe(2);
-    expect(body2.content.child(0).type.name).toBe('para');
-    expect(body2.content.child(1).type.name).toBe('para');
+    expect(lis[1].content.childCount).toBe(2);
+    expect(lis[1].content.child(0).type.name).toBe('para');
+    expect(lis[1].content.child(1).type.name).toBe('para');
   });
 
   describe('unimplementedNode', () => {

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -7,16 +7,16 @@ const listSchemaNodes: { [name: string]: NodeSpec } = {
     toDOM: () => ['ol', { class: 'node-list' }, 0],
   },
   listitem: {
-    content: 'listitemMarker listitemBody',
-    toDOM: () => ['li', { class: 'node-list-item' }, 0],
-  },
-  listitemMarker: {
-    content: 'text+',
-    toDOM: () => ['span', { class: 'list-item-marker' }, 0],
-  },
-  listitemBody: {
+    attrs: {
+      marker: { default: '1.' },
+    },
     content: 'block+',
-    toDOM: () => ['div', { class: 'list-item-text' }, 0],
+    toDOM: node => [
+      'li',
+      { class: 'node-list-item' },
+      ['span', { class: 'list-item-marker' }, node.attrs.marker],
+      ['div', { class: 'list-item-text' }, 0],
+    ],
   },
 };
 
@@ -78,10 +78,7 @@ export const factory = {
   list: (children?: Node[]) =>
     schema.nodes.list.create({}, children || []),
   listitem: (marker: string, children?: Node[]) =>
-    schema.nodes.listitem.create({}, [
-      schema.nodes.listitemMarker.create({}, schema.text(marker)),
-      schema.nodes.listitemBody.create({}, children || []),
-    ]),
+    schema.nodes.listitem.create({ marker }, children || []),
   para: (textContent: string | Node[], children?: Node[]) =>
     schema.nodes.para.create({}, [schema.nodes.inline.create(
       {},

--- a/api/document/js/serialize-doc.ts
+++ b/api/document/js/serialize-doc.ts
@@ -49,13 +49,9 @@ const NODE_CONVERTERS = {
     { content: convertTexts(node.content) },
   ),
   listitem(node) {
-    // Note the existence of these two nodes is ensured by the schema
-    const markerNode = node.content.child(0);
-    const body = node.content.child(1);
-
     const children: ApiNode[] = [];
-    body.forEach(child => children.push(serializeDoc(child)));
-    const marker = markerNode.textContent;
+    node.content.forEach(child => children.push(serializeDoc(child)));
+    const marker = node.attrs.marker;
     const typeEmblem = marker.replace(/[^a-zA-Z0-9]/, '');
     return apiFactory.node(
       node.type.name,


### PR DESCRIPTION
As a first step towards allowing lists/markers to be added, this removes the ability to edit the list item marker.