### PR TITLE
Bump Python version.

### DIFF
--- a/api/runtime.txt
+++ b/api/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.2
+python-3.6.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     volumes:
       - database_data:/var/lib/postgresql/data
   python: &PYTHON     # This command is out of order to aid with config reuse
-    image: python:3.6.2
+    image: python:3.6.4
     volumes:
       - .:/usr/src/app:delegated
     working_dir: /usr/src/app/api


### PR DESCRIPTION
Our deploys have been failing today as cloud.gov no longer supports 3.6.2.