### PR TITLE
Bump redeployer version

### DIFF
--- a/redeployer/runtime.txt
+++ b/redeployer/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.2
+python-3.6.4


### PR DESCRIPTION
Prior to removing the deployer (#988) we need to keep it up to date. Fortunately, the redeployer is the last of our apps to deploy, so we're effectively deploying everything now (despite the builds being marked as failures).