### PR TITLE
Wrap docker-compose run for most common scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,58 +35,58 @@ jobs:
       - run:
           environment:
             COMPOSE_FILE: docker-compose-circle.yml
-          command: docker-compose run --rm --no-deps ui npm run lint
+          command: bin/ui-npm run lint
       - run:
           name: UI Tests
           environment:
             COMPOSE_FILE: docker-compose-circle.yml
-          command: docker-compose run --rm --no-deps ui npm test
+          command: bin/ui-npm test
       - run:
           name: Build UI
           environment:
             COMPOSE_FILE: docker-compose-circle.yml
           command: |
-            docker-compose run --rm --no-deps ui webpack
+            bin/ui-npm run build-css
             docker cp holder:/usr/src/app/ui/static/styles.css ./ui/static/styles.css
             docker cp holder:/usr/src/app/ui/static/font/. ./ui/static/font
       - run:
           name: API Unit tests
           environment:
             COMPOSE_FILE: docker-compose-circle.yml
-          command: docker-compose run --rm api py.test --cov --cov-report xml
+          command: bin/py.test --cov --cov-report xml
       - run:
           name: API Flake8
           environment:
             COMPOSE_FILE: docker-compose-circle.yml
-          command: docker-compose run --rm --no-deps api flake8
+          command: bin/flake8
       - run:
           name: API Mypy
           environment:
             COMPOSE_FILE: docker-compose-circle.yml
-          command: docker-compose run --rm --no-deps api mypy .
+          command: bin/mypy .
       - run:
           name: API Bandit
           environment:
             COMPOSE_FILE: docker-compose-circle.yml
-          command: docker-compose run --rm --no-deps api bandit -r ereqs_admin reqs omb_eregs -s B101   # skip asserts
+          command: bin/bandit -r ereqs_admin reqs omb_eregs
       - run:
           name: API TSlint
           environment:
             COMPOSE_FILE: docker-compose-circle.yml
-          command: docker-compose run --rm api-ui npm run lint
+          command: bin/api-npm run lint
       - run:
           name: API JS tests
           environment:
             COMPOSE_FILE: docker-compose-circle.yml
-          command: docker-compose run --rm api-ui npm test
+          command: bin/api-npm test
       - run:
           name: API Build and Collect Static Files
           environment:
             COMPOSE_FILE: docker-compose-circle.yml
             DEBUG: "false"
           command: |
-            docker-compose run --rm api-ui webpack
-            docker-compose run --rm api python manage.py collectstatic --noinput
+            bin/api-npm run build
+            bin/manage.py collectstatic --noinput
             docker cp holder:/usr/src/app/api/collected-static/. ./api/collected-static
 
       - run:
@@ -127,7 +127,7 @@ jobs:
               export API_URL=https://omb-eregs-api-demo.app.cloud.gov/
             fi
             export INTERNAL_API_URL=${API_URL}
-            docker-compose run --rm ui npm run build
+            bin/ui-npm run build
             docker cp holder:/usr/src/app/ui/.next ui/.next
       - deploy:
           name: Deploy

--- a/README.md
+++ b/README.md
@@ -61,15 +61,17 @@ We recommend using
 [Docker](https://www.docker.com/products/overview#install_the_platform), an
 open source container engine. If you haven't already please install Docker and
 [Docker-compose](https://docs.docker.com/compose/install/) (which is installed
-automatically with Docker on Windows and OS X).
+automatically with Docker on Windows and OS X). We'll also refer to several
+bash scripts for executing Docker-compose commands. If running Windows, you'll
+want to set up bash or run the wrapped commands directly.
 
 ### Admin/API
 
 Let's start by adding an admin user.
 
 ```bash
-docker-compose run --rm api ./manage.py migrate  # set up database
-docker-compose run --rm api ./manage.py createsuperuser
+bin/manage.py migrate # set up database
+bin/manage.py createsuperuser
 # [fill out information]
 docker-compose up
 # [Wait while it sets up]
@@ -106,13 +108,13 @@ Then run:
 
 ```bash
 # Build the UI styles
-docker-compose run --rm ui webpack
+bin/ui-npm run build-css
 # Build the UI app
-docker-compose run --rm ui run build
+bin/ui-npm run build
 # Build the API styles
-docker-compose run --rm api-ui webpack
+bin/api-npm run build
 # Collect all static files for the admin
-docker-compose run --rm api ./manage.py collectstatic
+bin/manage.py collectstatic
 docker-compose up
 ```
 
@@ -123,11 +125,11 @@ Then navigate to http://localhost:8002/.
 Let's also load example requirements, agencies, and a whole document:
 
 ```bash
-docker-compose run --rm api ./manage.py fetch_csv
-docker-compose run --rm api ./manage.py import_reqs data.csv
-docker-compose run --rm api ./manage.py sync_agencies
-docker-compose run --rm api ./manage.py import_xml_doc example_docs/m_16_19_1.xml M-16-19
-docker-compose run --rm api ./manage.py import_xml_doc example_docs/m_15_16.xml M-15-16
+bin/manage.py fetch_csv
+bin/manage.py import_reqs data.csv
+bin/manage.py sync_agencies
+bin/manage.py import_xml_doc example_docs/m_16_19_1.xml M-16-19
+bin/manage.py import_xml_doc example_docs/m_15_16.xml M-15-16
 ```
 
 This may emit some warnings for improper input. The next time you visit the
@@ -141,7 +143,7 @@ import into the policy library.
 To download some PDFs for development, you can run:
 
 ```bash
-docker-compose run --rm api ./manage.py download_pdfs
+bin/manage.py download_pdfs
 ```
 
 You can then access a variety of development and debugging-related
@@ -155,26 +157,24 @@ after running the commands; alternatively, you can run
 
 The following commands pertain to the API and/or its database:
 
-* `docker-compose run api bandit`
-* `docker-compose run api flake8`
-* `docker-compose run api ./manage.py`
-* `docker-compose run api mypy`
-* `docker-compose run api pip-compile`
-* `docker-compose run api .docker/watch_tests.sh`
-* `docker-compose run api pytest`
-* `docker-compose run persistent_db psql -h persistent_db -U postgres`
+* `bin/bandit`
+* `bin/flake8`
+* `bin/manage.py`
+* `bin/mypy`
+* `bin/pip-compile`
+* `bin/ptw`
+* `bin/py.test`
+* `bin/psql`
 
 The following commands pertain to the API UI, which is the user interface that
 staff and administrators use:
 
-* `docker-compose run api-ui npm`
-* `docker-compose run api-ui webpack`
+* `bin/api-npm`
 
 The following commands pertain to the UI, which is the user interface that
 the general public uses:
 
-* `docker-compose run ui npm`
-* `docker-compose run ui webpack`
+* `bin/ui-npm`
 
 ### Resolving common container issues
 
@@ -282,18 +282,17 @@ We have unit tests for the API/admin (Python) and for the React-based frontend
 
 For Python unit tests, run:
 ```sh
-docker-compose run --rm api flake8              # linting
-docker-compose run --rm api mypy .              # type checking
-docker-compose run --rm api py.test             # run tests once
-docker-compose run api .docker/watch_tests.sh   # watch command to run tests whenever
-                                                # a file changes
+bin/flake8              # linting
+bin/mypy .              # type checking
+bin/py.test             # run tests once
+bin/ptw                 # watch command to run tests whenever a file changes
 ```
 
 For JS unit tests, run:
 ```sh
-docker-compose run --rm ui npm run lint        # linting
-docker-compose run --rm ui npm test            # run tests once
-docker-compose run --rm ui npm run test:watch  # watch command to run tests whenever a file changes
+bin/ui-npm run lint        # linting
+bin/ui-npm test            # run tests once
+bin/ui-npm run test:watch  # watch command to run tests whenever a file changes
 ```
 
 In the above commands, you can replace `ui` with `api-ui` to run the tests for
@@ -324,7 +323,7 @@ line tool and an associated plugin:
 Then, make sure you've built the frontend:
 
 ```sh
-docker-compose run --rm ui webpack
+bin/ui-npm run build-css
 ```
 
 And deploy!

--- a/api/.docker/watch_tests.sh
+++ b/api/.docker/watch_tests.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-ptw document ereqs_admin omb_eregs ombpdf reqs "$@"

--- a/api/package.json
+++ b/api/package.json
@@ -7,6 +7,7 @@
     "test": "tests"
   },
   "scripts": {
+    "build": "webpack",
     "lint": "tslint 'document/**/*.ts'",
     "test": "NODE_ENV=test jest --coverage",
     "test:watch": "NODE_ENV=test jest --watch"

--- a/bin/api-npm
+++ b/bin/api-npm
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+docker-compose run api-ui npm "$@"

--- a/bin/bandit
+++ b/bin/bandit
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+docker-compose run\
+  --rm\
+  --entrypoint .docker/activate_then\
+  --no-deps\
+  api bandit -s B101 "$@" # skip asserts

--- a/bin/flake8
+++ b/bin/flake8
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+docker-compose run\
+  --rm\
+  --entrypoint .docker/activate_then\
+  --no-deps\
+  api flake8 "$@"

--- a/bin/manage.py
+++ b/bin/manage.py
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+docker-compose run --rm api python manage.py "$@"

--- a/bin/mypy
+++ b/bin/mypy
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+docker-compose run\
+  --rm\
+  --entrypoint .docker/activate_then\
+  --no-deps\
+  api mypy "$@"

--- a/bin/pip-compile
+++ b/bin/pip-compile
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+docker-compose run\
+  --rm\
+  --entrypoint .docker/activate_then\
+  --no-deps\
+  api pip-compile "$@"

--- a/bin/psql
+++ b/bin/psql
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+docker-compose run --rm persistent_db psql -h persistent_db -U postgres

--- a/bin/ptw
+++ b/bin/ptw
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+docker-compose run\
+  --rm\
+  api ptw document ereqs_admin omb_eregs ombpdf reqs -- -x --ff "$@" # run last fail first, fail fast

--- a/bin/py.test
+++ b/bin/py.test
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+docker-compose run --rm api py.test "$@"
+

--- a/bin/python
+++ b/bin/python
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+docker-compose run --rm api python "$@"

--- a/bin/ui-npm
+++ b/bin/ui-npm
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# this doesn't check for "start" in $@, which _does_ need deps
+docker-compose run\
+  --rm\
+  --no-deps\
+  ui npm "$@"

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "next build",
+    "build-css": "webpack",
     "lint": "eslint '**/*.js'",
     "start": "node server/index.js",
     "test": "NODE_ENV=test jest --coverage",


### PR DESCRIPTION
Having a `bin` directory of common scripts had worked really well on personal projects. It gives us an avenue for docker optimization and documents our expected entry points. We can still do `docker-compose run xxx yyy` for edge-case tools (though it's super cheap to add another shell script, too).