### PR TITLE
Comment out minio for now

### DIFF
--- a/api/ombpdf/tests/test_management_commands_import_pdfs_from_policies.py
+++ b/api/ombpdf/tests/test_management_commands_import_pdfs_from_policies.py
@@ -42,6 +42,7 @@ def test_import_from_policy_obama_whitehouse(monkeypatch):
     ])
 
 
+@pytest.mark.skip(reason="We've temporarily removed pdf upload")
 def test_import_from_policy_attached_file(monkeypatch):
     monkeypatch.setattr(import_pdfs_from_policies, 'best_url', Mock())
     monkeypatch.setattr(import_pdfs_from_policies, 'parse_pdf', Mock())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,16 @@ services:
     image: postgres:9.4
     volumes:
       - database_data:/var/lib/postgresql/data
-  minio:
-    image: minio/minio
-    environment:
-        - MINIO_ACCESS_KEY=LOCAL_ID
-        - MINIO_SECRET_KEY=LOCAL_KEY
-    command: server --address ':9100' minio-test
-    ports:
-      - 9100:9100
+  # We've temporarily removed pdf upload, so we don't need
+  # minio (a mock S3 server) for now.
+  # minio:
+  #   image: minio/minio
+  #   environment:
+  #       - MINIO_ACCESS_KEY=LOCAL_ID
+  #       - MINIO_SECRET_KEY=LOCAL_KEY
+  #   command: server --address ':9100' minio-test
+  #   ports:
+  #     - 9100:9100
   api:
     image: python:3.6.4
     working_dir: /usr/src/app/api
@@ -53,7 +55,7 @@ services:
       - .:/usr/src/app:delegated
     depends_on:
       - persistent_db
-      - minio
+      # - minio
       - api-ui
   api-ui:
     image: node:6


### PR DESCRIPTION
Just as we're currently skipping tests related to PDF upload functionality, I think we should comment out the related Docker functionality, so developers aren't confused by its presence (and, tangentially, to make the Docker setup leaner for the time being).

Another alternative may be to simply _remove_ the code instead of commenting it out; it can always be brought back by inspecting the original commit that removed it (which we could make easy to find, e.g. by linking to it from #993).