### PR TITLE
[WIP] Support footnote and citation display in ProseMirror editor

### DIFF
--- a/api/document/js/create-editor-state.ts
+++ b/api/document/js/create-editor-state.ts
@@ -7,6 +7,7 @@ import fixupDoc from './fixup-doc';
 import keyboard from './keyboard';
 import menu from './menu';
 import parseDoc from './parse-doc';
+import footnoteValidator from './footnote-validator';
 
 export default function createEditorState(data, api: Api): EditorState {
   const doc = parseDoc(data);
@@ -23,6 +24,7 @@ export default function createEditorState(data, api: Api): EditorState {
       keyboard(api),
       history(),
       fixupDoc,
+      footnoteValidator,
     ],
   });
 }

--- a/api/document/js/footnote-validator.ts
+++ b/api/document/js/footnote-validator.ts
@@ -1,0 +1,47 @@
+import { Node } from 'prosemirror-model';
+import { Plugin } from 'prosemirror-state';
+
+import schema from './schema';
+
+export function validateFootnoteCitations(doc: Node): boolean {
+  const citations = new Set<string>();
+  const footnotes = new Set<string>();
+
+  doc.descendants((node, pos, parent) => {
+    node.marks.forEach((mark) => {
+      if (mark.type === schema.marks.footnoteCitation) {
+        if (!node.text) {
+          throw new Error('Nodes with footnote citations must have text!');
+        }
+        citations.add(node.text);
+      }
+    });
+
+    if (node.type === schema.nodes.footnote) {
+      if (typeof node.attrs.emblem !== 'string') {
+        throw new Error('Footnote nodes must have emblems!');
+      }
+      footnotes.add(node.attrs.emblem);
+    }
+
+    return true;
+  });
+
+  for (const citation of citations) {
+    if (!footnotes.has(citation)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export default new Plugin({
+  filterTransaction(tr): boolean {
+    if (!tr.docChanged) {
+      return true;
+    }
+
+    return validateFootnoteCitations(tr.doc);
+  },
+});

--- a/api/document/js/parse-doc.ts
+++ b/api/document/js/parse-doc.ts
@@ -25,6 +25,10 @@ export function convertContent(content, marks: Mark[]): Node[] {
 }
 
 const NODE_TYPE_CONVERTERS = {
+  footnote(node) {
+    const nested: Node[][] = (node.content || []).map(c => convertContent(c, []));
+    return factory.footnote(node.type_emblem, flatten(nested));
+  },
   heading(node) {
     // Duplicates logic in `ui`
     const depth = node.identifier
@@ -46,5 +50,6 @@ const NODE_TYPE_CONVERTERS = {
 };
 
 const CONTENT_TYPE_CONVERTERS = {
+  footnote_citation: content => factory.footnoteCitation(),
   unimplementedMark: content => factory.unimplementedMark(content),
 };

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -30,6 +30,17 @@ const schema = new Schema({
       content: 'text+',
       toDOM: () => ['p', { class: 'node-paragraph-text' }, 0],
     },
+    footnote: {
+      content: 'inline',
+      group: 'block',
+      attrs: {
+        emblem: {},
+      },
+      toDOM: node => ['div', {
+        class: 'footnote',
+        'data-emblem': node.attrs.emblem,
+      }, 0],
+    },
     heading: {
       content: 'text+',
       group: 'block',
@@ -63,6 +74,9 @@ const schema = new Schema({
     ...listSchemaNodes,
   },
   marks: {
+    footnoteCitation: {
+      toDOM: () => ['sup'],
+    },
     unimplementedMark: {
       attrs: {
         data: {}, // will hold unrendered content
@@ -73,6 +87,11 @@ const schema = new Schema({
 });
 
 export const factory = {
+  footnote: (emblem: number, textContent: string | Node[]) =>
+    schema.nodes.footnote.create({ emblem }, schema.nodes.inline.create(
+      {},
+      typeof textContent === 'string' ? schema.text(textContent) : textContent,
+    )),
   heading: (text: string, depth: number) =>
     schema.nodes.heading.create({ depth }, schema.text(text)),
   list: (children?: Node[]) =>
@@ -88,6 +107,8 @@ export const factory = {
     schema.nodes.policy.create({}, children || []),
   sec: (children?: Node[]) =>
     schema.nodes.sec.create({}, children || []),
+  footnoteCitation: () =>
+    schema.marks.footnoteCitation.create(),
   unimplementedMark: (original: any) =>
     schema.marks.unimplementedMark.create({ data: original }),
   unimplementedNode: (original: any) =>

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -75,6 +75,8 @@ const schema = new Schema({
   },
   marks: {
     footnoteCitation: {
+      inclusive: false,
+      excludes: '_',
       toDOM: () => ['sup'],
     },
     unimplementedMark: {

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -77,7 +77,7 @@ const schema = new Schema({
     footnoteCitation: {
       inclusive: false,
       excludes: '_',
-      toDOM: () => ['sup'],
+      toDOM: () => ['sup', { class: 'footnote-citation' }],
     },
     unimplementedMark: {
       attrs: {

--- a/api/document/js/serialize-doc.ts
+++ b/api/document/js/serialize-doc.ts
@@ -34,6 +34,10 @@ export const apiFactory = {
       ...(overrides || {}),
     };
   },
+  footnoteCitation: () => ({
+    content_type: 'footnote_citation',
+    inlines: [],
+  }),
   text: value => ({
     content_type: '__text__',
     inlines: [],
@@ -43,6 +47,12 @@ export const apiFactory = {
 
 
 const NODE_CONVERTERS = {
+  footnote(node) {
+    const footnote = defaultNodeConverter(node);
+    footnote.type_emblem = footnote.marker = node.attrs.emblem;
+
+    return footnote;
+  },
   heading: node => apiFactory.node(
     node.type.name,
     // Text isn't in an 'inline' block
@@ -88,6 +98,8 @@ function defaultNodeConverter(node): ApiNode {
 }
 
 const MARK_CONVERTERS = {
+  footnoteCitation: node =>
+    apiFactory.footnoteCitation(),
   unimplementedMark: node =>
     apiFactory.content(node.type.name, node.attrs.data),
 };

--- a/api/ereqs_admin/static/admin/module/_footnotes.scss
+++ b/api/ereqs_admin/static/admin/module/_footnotes.scss
@@ -21,6 +21,6 @@
   color: $color-blue;
 }
 
-.footnote-citation:before {
+.footnote-citation::before {
   content: 'Footnote ';
 }

--- a/api/ereqs_admin/static/admin/module/_footnotes.scss
+++ b/api/ereqs_admin/static/admin/module/_footnotes.scss
@@ -12,3 +12,15 @@
   padding: 1em;
   margin: 1em 0;
 }
+
+.footnote-citation {
+  font-family: sans-serif;
+  border: 1px solid $color-lt-blue;
+  padding: 2px;
+  border-radius: 2px;
+  color: $color-blue;
+}
+
+.footnote-citation:before {
+  content: 'Footnote ';
+}

--- a/api/ereqs_admin/static/admin/module/_footnotes.scss
+++ b/api/ereqs_admin/static/admin/module/_footnotes.scss
@@ -1,0 +1,14 @@
+// Note that ideally we should be leveraging common styling for footnotes
+// here, rather than forging our own from scratch.
+
+.footnote::before {
+  content: attr(data-emblem);
+  font-weight: bold;
+}
+
+.footnote {
+  border-top: 1px solid $color-blue;
+  border-bottom: 1px solid $color-blue;
+  padding: 1em;
+  margin: 1em 0;
+}

--- a/api/ereqs_admin/static/admin/override.scss
+++ b/api/ereqs_admin/static/admin/override.scss
@@ -27,15 +27,4 @@
 @import './layout/navigation';
 
 @import './module/editor';
-
-.footnote:before {
-    content: attr(data-emblem);
-    font-weight: bold;
-}
-
-.footnote {
-    border-top: 1px solid $color-blue;
-    border-bottom: 1px solid $color-blue;
-    padding: 1em;
-    margin: 1em 0;
-}
+@import './module/footnotes';

--- a/api/ereqs_admin/static/admin/override.scss
+++ b/api/ereqs_admin/static/admin/override.scss
@@ -28,3 +28,14 @@
 
 @import './module/editor';
 
+.footnote:before {
+    content: attr(data-emblem);
+    font-weight: bold;
+}
+
+.footnote {
+    border-top: 1px solid $color-blue;
+    border-bottom: 1px solid $color-blue;
+    padding: 1em;
+    margin: 1em 0;
+}


### PR DESCRIPTION
This is a work in progress! It's horrible!

I think I will probably save the actual editing and/or re-numbering of footnotes for a separate PR.

## To do

- [ ] Tests
- [ ] Delete a footnote if it is empty, and if no citation references it.
- [x] Ensure that user edits can't "break" the document
- [x] Implement (lossless) serialization
- [x] Add **temporary** styling (full styling that re-uses styles from the viewer should wait for another PR)
