### PR TITLE
Resolve some issues with text deletion in the editor

### DIFF
--- a/api/document/js/__tests__/fixup-doc.test.ts
+++ b/api/document/js/__tests__/fixup-doc.test.ts
@@ -1,0 +1,74 @@
+import { EditorState } from 'prosemirror-state';
+
+import { deleteEmpty } from '../fixup-doc';
+import schema, { factory } from '../schema';
+
+describe('deleteEmpty()', () => {
+  it('deletes empty paragraphs', () => {
+    const doc = factory.policy([
+      factory.para('first'),
+      schema.nodes.para.create({}, schema.nodes.inline.create()),
+    ]);
+    expect(doc.childCount).toBe(2);
+    const state = EditorState.create({ doc });
+    const transaction = deleteEmpty(state.tr);
+    const modified = state.apply(transaction);
+
+    expect(modified.doc.childCount).toBe(1);
+    expect(modified.doc.textContent).toBe('first');
+  });
+
+  it('deletes empty listitems', () => {
+    const doc = factory.policy([
+      factory.list([
+        factory.listitem('1.', [factory.para('First')]),
+        factory.listitem('2.', []),
+        factory.listitem('3.', [factory.para('Third')]),
+      ]),
+    ]);
+    expect(doc.content.child(0).childCount).toBe(3);
+    const state = EditorState.create({ doc });
+    const transaction = deleteEmpty(state.tr);
+    const modified = state.apply(transaction);
+
+    expect(modified.doc.content.child(0).childCount).toBe(2);
+    expect(modified.doc.content.child(0).textContent).toBe('FirstThird');
+  });
+
+  it('deletes empty lists', () => {
+    const doc = factory.policy([
+      factory.list([]),
+      factory.para('stuff'),
+    ]);
+    expect(doc.content.childCount).toBe(2);
+    const state = EditorState.create({ doc });
+    const transaction = deleteEmpty(state.tr);
+    const modified = state.apply(transaction);
+
+    expect(modified.doc.childCount).toBe(1);
+    expect(modified.doc.textContent).toBe('stuff');
+  });
+  it('is recursive', () => {
+    const doc = factory.policy([
+      factory.para('Something'),
+      factory.list([
+        factory.listitem('1. ', []),
+        factory.listitem('2', [
+          schema.nodes.para.create({}, schema.nodes.inline.create()),
+        ]),
+      ]),
+      factory.para('tail'),
+    ]);
+    // First pass, we'll delete the first listitem (as it has no children)
+    // Second pass, we'll delete the para
+    // Then the second list item,
+    // Then the whole list, which is now empty
+    expect(doc.content.childCount).toBe(3);
+    const state = EditorState.create({ doc });
+    const transaction = deleteEmpty(state.tr);
+    const modified = state.apply(transaction);
+
+    expect(modified.doc.childCount).toBe(2);
+    expect(modified.doc.textContent).toBe('Somethingtail');
+  });
+});

--- a/api/document/js/__tests__/schema.test.ts
+++ b/api/document/js/__tests__/schema.test.ts
@@ -32,26 +32,3 @@ describe('heading', () => {
     });
   });
 });
-
-describe('para', () => {
-  it('can be deleted', () => {
-    const doc = factory.policy([
-      factory.para('1'),
-      factory.para('2'),
-    ]);
-    expect(doc.content.childCount).toBe(2);
-    // Selected the "2"
-    const selection = new TextSelection(
-      pathToResolvedPos(doc, [new NthType(1, 'para'), 'inline']),
-      pathToResolvedPos(doc, [new NthType(1, 'para'), 'inline', 1]),
-    );
-    const state = EditorState.create({ doc, selection });
-    const dispatch = jest.fn();
-
-    deleteSelection(state, dispatch);
-    const transaction = dispatch.mock.calls[0][0];
-    const modifiedDoc = state.apply(transaction).doc;
-
-    expect(modifiedDoc.content.childCount).toBe(1);
-  });
-});

--- a/api/document/js/create-editor-state.ts
+++ b/api/document/js/create-editor-state.ts
@@ -3,6 +3,7 @@ import { EditorState } from 'prosemirror-state';
 import { history } from 'prosemirror-history';
 
 import Api, { setStatusError } from './Api';
+import fixupDoc from './fixup-doc';
 import keyboard from './keyboard';
 import menu from './menu';
 import parseDoc from './parse-doc';
@@ -21,6 +22,7 @@ export default function createEditorState(data, api: Api): EditorState {
       menu(api),
       keyboard(api),
       history(),
+      fixupDoc,
     ],
   });
 }

--- a/api/document/js/fixup-doc.ts
+++ b/api/document/js/fixup-doc.ts
@@ -1,0 +1,40 @@
+import { Node } from 'prosemirror-model';
+import { EditorState, Plugin, Transaction } from 'prosemirror-state';
+
+import schema from './schema';
+
+const shouldDeleteChecks = {
+  list: (node: Node) => node.content.childCount === 0,
+  listitem: (node: Node) => node.content.childCount === 0,
+  para: (node: Node) => (
+    node.content.childCount === 1 // Just the inline
+    && node.textContent === ''
+  ),
+};
+
+export function deleteEmpty(transaction: Transaction) {
+  let newTransaction;
+  transaction.doc.descendants((node, pos) => {
+    if (newTransaction) return false;
+
+    const shouldDeleteCheck = shouldDeleteChecks[node.type.name];
+    if (shouldDeleteCheck && shouldDeleteCheck(node)) {
+      newTransaction = transaction.delete(pos, pos + node.nodeSize);
+      return false;
+    }
+    return true;
+  });
+  if (newTransaction) {
+    const subTransaction = deleteEmpty(newTransaction);
+    return subTransaction || newTransaction;
+  }
+  return newTransaction;
+}
+
+export default new Plugin({
+  appendTransaction(transactions, oldState, newState) {
+    if (oldState.doc !== newState.doc) {
+      return deleteEmpty(newState.tr);
+    }
+  },
+});

--- a/api/document/js/keyboard.ts
+++ b/api/document/js/keyboard.ts
@@ -1,4 +1,4 @@
-import { baseKeymap } from 'prosemirror-commands';
+import { baseKeymap, chainCommands, deleteSelection, selectNodeBackward, selectNodeForward } from 'prosemirror-commands';
 import { undo, redo } from 'prosemirror-history';
 import { keymap } from 'prosemirror-keymap';
 
@@ -6,11 +6,28 @@ import Api from './Api';
 import { makeSave } from './commands';
 import schema from './schema';
 
+// Removing joinBackwards/forwards from actions taken when deleting as they
+// need to be tuned a bit better to our use case.
+const backspace = chainCommands(deleteSelection, selectNodeBackward);
+const del = chainCommands(deleteSelection, selectNodeForward);
+
 export default function menu(api: Api) {
   return keymap({
     ...baseKeymap,
+    'Backspace': backspace,
+    'Mod-Backspace': backspace,
+    'Delete': del,
+    'Mod-Delete': del,
     'Mod-z': undo,
     'Shift-Mod-z': redo,
     'Mod-s': makeSave(api),
+    // Macs have additional keyboard combinations for deletion; we set them
+    // for all OSes as a convenience
+    'Ctrl-h': backspace,
+    'ALt-Backspace': backspace,
+    'Ctrl-d': del,
+    'Ctrl-Alt-Backspace': del,
+    'Alt-Delete': del,
+    'Alt-d': del,
   });
 }

--- a/api/document/js/keyboard.ts
+++ b/api/document/js/keyboard.ts
@@ -1,4 +1,10 @@
-import { baseKeymap, chainCommands, deleteSelection, selectNodeBackward, selectNodeForward } from 'prosemirror-commands';
+import {
+  baseKeymap,
+  chainCommands,
+  deleteSelection,
+  selectNodeBackward,
+  selectNodeForward,
+} from 'prosemirror-commands';
 import { undo, redo } from 'prosemirror-history';
 import { keymap } from 'prosemirror-keymap';
 
@@ -14,8 +20,10 @@ const del = chainCommands(deleteSelection, selectNodeForward);
 export default function menu(api: Api) {
   return keymap({
     ...baseKeymap,
+    // tslint:disable-next-line object-literal-key-quotes
     'Backspace': backspace,
     'Mod-Backspace': backspace,
+    // tslint:disable-next-line object-literal-key-quotes
     'Delete': del,
     'Mod-Delete': del,
     'Mod-z': undo,

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -2,7 +2,7 @@ import { Node, NodeSpec, Schema } from 'prosemirror-model';
 
 const listSchemaNodes: { [name: string]: NodeSpec } = {
   list: {
-    content: 'listitem+',
+    content: 'listitem*',
     group: 'block',
     toDOM: () => ['ol', { class: 'node-list' }, 0],
   },
@@ -10,7 +10,7 @@ const listSchemaNodes: { [name: string]: NodeSpec } = {
     attrs: {
       marker: { default: '1.' },
     },
-    content: 'block+',
+    content: 'block*',
     toDOM: node => [
       'li',
       { class: 'node-list-item' },
@@ -27,7 +27,7 @@ const schema = new Schema({
       content: 'block+',
     },
     inline: {
-      content: 'text+',
+      content: 'text*',
       toDOM: () => ['p', { class: 'node-paragraph-text' }, 0],
     },
     heading: {


### PR DESCRIPTION
Previously, we had kept our document schema relatively rigid -- all paragraphs
must have text, all lists: listitems, etc. This doesn't play well with
ProseMirror's internals, which need to be able to delete blocks, text, etc. at
a very fundamental level. The strict schema prevented some of these actions
and would give unexpected results (e.g. replacing a paragraph text with
"undefined") in an effort to maintain a valid document.

This takes a different approach by keeping the schema flexible, but using a
plugin to make a second pass on the modified document and performing fixups
around deleting empty pieces of content.

## Before
![old-delete](https://user-images.githubusercontent.com/326918/35993320-ef6fd036-0cda-11e8-8183-87b6404d0a66.gif)

## After
![new-delete](https://user-images.githubusercontent.com/326918/35993324-f2cb593a-0cda-11e8-818a-adedbcaabbeb.gif)
