### PR TITLE
Add new li when pressing enter at end of existing li

### DIFF
--- a/api/document/js/__tests__/commands.test.ts
+++ b/api/document/js/__tests__/commands.test.ts
@@ -237,13 +237,10 @@ describe('addListItem()', () => {
   it('puts the cursor in the li', () => {
     const init = makeState(['list', 'listitem', 'para', 'inline', 'aaa'.length]);
     const result = executeTransform(init, addListItem);
-    expect(result.selection.anchor).toBe(pathToResolvedPos(
-      result.doc,
-      ['list', new NthType(1, 'listitem'), 'para', 'inline'],
-    ).pos);
-    expect(result.selection.head).toBe(pathToResolvedPos(
-      result.doc,
-      ['list', new NthType(1, 'listitem'), 'para', 'inline', ' '.length],
-    ).pos);
+    const inlinePath = ['list', new NthType(1, 'listitem'), 'para', 'inline'];
+    expect(result.selection.anchor).toBe(
+      pathToResolvedPos(result.doc, inlinePath).pos);
+    expect(result.selection.head).toBe(
+      pathToResolvedPos(result.doc, [...inlinePath, ' '.length]).pos);
   });
 });

--- a/api/document/js/__tests__/commands.test.ts
+++ b/api/document/js/__tests__/commands.test.ts
@@ -30,7 +30,7 @@ function executeTransform(initialState: EditorState, transform): EditorState {
 
 describe('appendNearBlock()', () => {
   const paraTransform = (state, dispatch) =>
-    appendNearBlock(state, dispatch, factory.para(' '), ['inline']);
+    appendNearBlock(factory.para(' '), ['inline'], state, dispatch);
 
   it('adds a node after the current', () => {
     const doc = factory.policy([
@@ -178,9 +178,10 @@ describe('makeSaveThenXml()', () => {
 
     const api = new JsonApi({ csrfToken: '', url: '' });
     const save = makeSaveThenXml(api);
-    await save({ doc: 'stuff' });
+    const doc = factory.policy();
+    await save(EditorState.create({ doc }));
 
-    expect(serializeDoc).toBeCalledWith('stuff');
+    expect(serializeDoc).toBeCalledWith(doc);
     expect(api.write).toBeCalledWith({ serialized: 'content' });
   });
 
@@ -190,7 +191,7 @@ describe('makeSaveThenXml()', () => {
 
     const api = new JsonApi({ csrfToken: '', url: '' });
     const save = makeSaveThenXml(api);
-    await save({ doc: 'stuff' });
+    await save(EditorState.create({ doc: factory.policy() }));
 
     const param = locationAssign.mock.calls[0][0];
     expect(param).toMatch(/akn$/);

--- a/api/document/js/__tests__/list-utils.test.ts
+++ b/api/document/js/__tests__/list-utils.test.ts
@@ -1,4 +1,6 @@
-import { createMarkerTemplate, deeperBullet } from '../list-utils';
+import { EditorState } from 'prosemirror-state';
+
+import { collectMarkers, createMarkerTemplate, deeperBullet, renumberList } from '../list-utils';
 import pathToResolvedPos, { NthType } from '../path-to-resolved-pos';
 import { factory } from '../schema';
 
@@ -82,5 +84,69 @@ describe('createMarkerTemplate()', () => {
     expect(tpl(0)).toBe('4.c.R.i');
     expect(tpl(7)).toBe('4.c.R.viii');
     expect(tpl(100)).toBe('4.c.R.ci');
+  });
+});
+
+describe('renumberList()', () => {
+  it('uses the first li as a template', () => {
+    const doc = factory.policy([
+      factory.list([
+        factory.listitem('>a<', []),
+        factory.listitem('(b)', []),
+        factory.listitem('4444', []),
+      ]),
+    ]);
+    const initialState = EditorState.create({ doc });
+    const pos = pathToResolvedPos(doc, ['list', 'listitem']).pos;
+    const resultTr = renumberList(initialState.tr, pos);
+    const result = initialState.apply(resultTr);
+    const list = result.doc.content.child(0);
+    const markers: string[] = [];
+    list.content.forEach(li => markers.push(li.attrs.marker));
+    expect(markers).toEqual(['>a<', '>b<', '>c<']);
+  });
+
+  it('keeps sub-content', () => {
+    const doc = factory.policy([
+      factory.list([
+        factory.listitem('>a<', [factory.para('stuff')]),
+        factory.listitem('(b)', [factory.para('more'), factory.para('stuff')]),
+      ]),
+    ]);
+    expect(doc.content.child(0).content.child(0).content.childCount).toBe(1);
+    expect(doc.content.child(0).content.child(1).content.childCount).toBe(2);
+    expect(doc.textContent).toBe('stuffmorestuff');
+
+    const initialState = EditorState.create({ doc });
+    const pos = pathToResolvedPos(doc, ['list', 'listitem']).pos;
+    const resultTr = renumberList(initialState.tr, pos);
+    const list = initialState.apply(resultTr).doc.content.child(0);
+
+    expect(list.content.child(0).content.childCount).toBe(1);
+    expect(list.content.child(1).content.childCount).toBe(2);
+    expect(list.textContent).toBe('stuffmorestuff');
+  });
+
+  it('only renumbers the immediate containing elt', () => {
+    const doc = factory.policy([
+      factory.list([
+        factory.listitem('a>>', []),
+        factory.listitem('x', [factory.list([
+          factory.listitem('1*', []),
+          factory.listitem('*b*', []),
+        ])]),
+      ]),
+    ]);
+    const initialState = EditorState.create({ doc });
+    const pos = pathToResolvedPos(
+      doc,
+      ['list', new NthType(1, 'listitem'), 'list', 'listitem'],
+    ).pos;
+    const resultTr = renumberList(initialState.tr, pos);
+    const list = initialState.apply(resultTr).doc.content.child(0);
+    const subList = list.content.child(1).content.child(0);
+
+    expect(collectMarkers(list)).toEqual(['a>>', 'x']);
+    expect(collectMarkers(subList)).toEqual(['1*', '2*']);
   });
 });

--- a/api/document/js/__tests__/list-utils.test.ts
+++ b/api/document/js/__tests__/list-utils.test.ts
@@ -69,6 +69,8 @@ describe('createMarkerTemplate()', () => {
     const tpl = createMarkerTemplate('(a)');
     expect(tpl(0)).toBe('(a)');
     expect(tpl(8)).toBe('(i)');
+    expect(tpl(25)).toBe('(z)');
+    expect(tpl(26)).toBe('(aa)');
     expect(tpl(99)).toBe('(vvvv)');
   });
 

--- a/api/document/js/__tests__/list-utils.test.ts
+++ b/api/document/js/__tests__/list-utils.test.ts
@@ -1,4 +1,4 @@
-import { deeperBullet } from '../list-utils';
+import { createMarkerTemplate, deeperBullet } from '../list-utils';
 import pathToResolvedPos, { NthType } from '../path-to-resolved-pos';
 import { factory } from '../schema';
 
@@ -52,5 +52,35 @@ describe('deeperBullet()', () => {
       'inline',
     ]);
     expect(deeperBullet(pos)).toBe('●');
+  });
+});
+
+describe('createMarkerTemplate()', () => {
+  it('works with decimals', () => {
+    const tpl = createMarkerTemplate('1.');
+    expect(tpl(0)).toBe('1.');
+    expect(tpl(3)).toBe('4.');
+    expect(tpl(25)).toBe('26.');
+  });
+
+  it('works with parens', () => {
+    const tpl = createMarkerTemplate('(a)');
+    expect(tpl(0)).toBe('(a)');
+    expect(tpl(8)).toBe('(i)');
+    expect(tpl(99)).toBe('(vvvv)');
+  });
+
+  it('works when a known character is not present', () => {
+    const tpl = createMarkerTemplate('■');
+    expect(tpl(0)).toBe('■');
+    expect(tpl(7)).toBe('■');
+    expect(tpl(9999)).toBe('■');
+  });
+
+  it('selects the *last* match', () => {
+    const tpl = createMarkerTemplate('4.c.R.i');
+    expect(tpl(0)).toBe('4.c.R.i');
+    expect(tpl(7)).toBe('4.c.R.viii');
+    expect(tpl(100)).toBe('4.c.R.ci');
   });
 });

--- a/api/document/js/commands.ts
+++ b/api/document/js/commands.ts
@@ -85,12 +85,16 @@ const inLi = (pos: ResolvedPos) => (
   && pos.node(pos.depth - 2).type === schema.nodes.listitem
   && pos.node(pos.depth - 3).type === schema.nodes.list
 );
-const atEndOfLi = (pos: ResolvedPos) => (
-  pos.depth >= 2
-  && pos.pos === pos.end(pos.depth)
-  && pos.pos === pos.end(pos.depth - 1) - 1
-  && pos.pos === pos.end(pos.depth - 2) - 2
-);
+function atEndOfLi(pos: ResolvedPos) {
+  if (pos.depth < 2) return false;
+  const endOfInline = pos.end(pos.depth);
+  const endOfPara = pos.end(pos.depth - 1);
+  const endOfListItem = pos.end(pos.depth - 2);
+  const inlineAtEndOfPara = endOfInline + 1 === endOfPara;
+  const paraAtEndOfLi = endOfPara + 1 === endOfListItem;
+
+  return pos.pos === endOfInline && inlineAtEndOfPara && paraAtEndOfLi;
+}
 
 export function addListItem(state: EditorState, dispatch?: Dispatch) {
   const pos = state.selection.$head;
@@ -101,7 +105,7 @@ export function addListItem(state: EditorState, dispatch?: Dispatch) {
     return true;
   }
 
-  const endOfLi: number = pos.end(pos.depth - 2);
+  const endOfLi: number = pos.end(pos.depth - 2); // inline < para < li
   const insertPos = endOfLi + 1;
   // This marker will be replaced during the renumber step
   const liToInsert = factory.listitem('', [factory.para(' ')]);

--- a/api/document/js/keyboard.ts
+++ b/api/document/js/keyboard.ts
@@ -20,10 +20,8 @@ const del = chainCommands(deleteSelection, selectNodeForward);
 export default function menu(api: JsonApi) {
   return keymap({
     ...baseKeymap,
-    // tslint:disable-next-line object-literal-key-quotes
     'Backspace': backspace,
     'Mod-Backspace': backspace,
-    // tslint:disable-next-line object-literal-key-quotes
     'Delete': del,
     'Mod-Delete': del,
     'Mod-z': undo,

--- a/api/document/js/keyboard.ts
+++ b/api/document/js/keyboard.ts
@@ -9,13 +9,17 @@ import { undo, redo } from 'prosemirror-history';
 import { keymap } from 'prosemirror-keymap';
 
 import { JsonApi } from './Api';
-import { makeSave } from './commands';
+import { addListItem, makeSave } from './commands';
 import schema from './schema';
 
 // Removing joinBackwards/forwards from actions taken when deleting as they
 // need to be tuned a bit better to our use case.
 const backspace = chainCommands(deleteSelection, selectNodeBackward);
 const del = chainCommands(deleteSelection, selectNodeForward);
+
+// Similarly, removing the default "Enter" behavior (newlineInCode,
+// createParagraphNear, liftEmptyBlock, splitBlock) for the same reason.
+const enter = addListItem;
 
 export default function menu(api: JsonApi) {
   return keymap({
@@ -27,6 +31,7 @@ export default function menu(api: JsonApi) {
     'Mod-z': undo,
     'Shift-Mod-z': redo,
     'Mod-s': makeSave(api),
+    'Enter': enter,
     // Macs have additional keyboard combinations for deletion; we set them
     // for all OSes as a convenience
     'Ctrl-h': backspace,

--- a/api/document/js/list-utils.ts
+++ b/api/document/js/list-utils.ts
@@ -23,10 +23,11 @@ export function deeperBullet(pos: ResolvedPos): string {
 
 function makeIntToLetter(initial: string) {
   const offset = initial.charCodeAt(0);
+  const alphabetLen = 26;
 
   return (idx: number) => {
-    const count = Math.floor(idx / 26) + 1;
-    const letter = String.fromCharCode(offset + idx % 26);
+    const count = Math.floor(idx / alphabetLen) + 1;
+    const letter = String.fromCharCode(offset + idx % alphabetLen);
     return repeatString(letter, count);
   };
 }

--- a/api/document/js/list-utils.ts
+++ b/api/document/js/list-utils.ts
@@ -1,6 +1,9 @@
 import { Node, ResolvedPos } from 'prosemirror-model';
+import * as repeatString from 'repeat-string';
+import * as romanize from 'romanize';
 
-import schema from './schema';
+import schema, { factory } from './schema';
+import { walkUpUntil } from './util';
 
 const defaultBullet = '●';
 const bulletFollows = {
@@ -8,22 +11,45 @@ const bulletFollows = {
   '○': '■',
 };
 
-function parentListItem(pos: ResolvedPos): Node | void {
-  let depth = pos.depth;
-  // Walk up the document until we hit a list
-  while (depth >= 0) {
-    const node = pos.node(depth);
-    if (node.type === schema.nodes.listitem) {
-      return node;
-    }
-    depth -= 1;
-  }
-}
-
 export function deeperBullet(pos: ResolvedPos): string {
-  const parListItem = parentListItem(pos);
-  if (parListItem) {
+  const liDepth = walkUpUntil(pos, node => node.type === schema.nodes.listitem);
+  if (liDepth >= 0) {
+    const parListItem = pos.node(liDepth);
     return bulletFollows[parListItem.attrs.marker] || defaultBullet;
   }
   return defaultBullet;
+}
+
+function makeIntToLetter(initial: string) {
+  const offset = initial.charCodeAt(0);
+
+  return (idx: number) => {
+    const count = Math.floor(idx / 26) + 1;
+    const letter = String.fromCharCode(offset + idx % 26);
+    return repeatString(letter, count);
+  };
+}
+
+const firstToMapper = {
+  'a': makeIntToLetter('a'),
+  'A': makeIntToLetter('A'),
+  // our input will be zero indexed
+  '1': (idx: number) => `${idx + 1}`,
+  'i': (idx: number) => romanize(idx + 1).toLowerCase(),
+  'I': (idx: number) => romanize(idx + 1),
+};
+const lastMatch = new RegExp(/^.*([aA1iI])[^aA1iI]*$/, 'm');
+
+export function createMarkerTemplate(toImitate: string) {
+  const match = lastMatch.exec(toImitate);
+  if (match) {
+    const matchingChar = match[1];
+    const prefixEnds = toImitate.lastIndexOf(matchingChar);
+    return (idx: number) => (
+      toImitate.substr(0, prefixEnds)
+      + firstToMapper[matchingChar](idx)
+      + toImitate.substr(prefixEnds + 1)
+    );
+  }
+  return (marker: number) => toImitate;
 }

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -1,4 +1,4 @@
-import { Node, NodeSpec, Schema } from 'prosemirror-model';
+import { Fragment, Node, NodeSpec, Schema } from 'prosemirror-model';
 
 const listSchemaNodes: { [name: string]: NodeSpec } = {
   list: {
@@ -75,18 +75,18 @@ const schema = new Schema({
 export const factory = {
   heading: (text: string, depth: number) =>
     schema.nodes.heading.create({ depth }, schema.text(text)),
-  list: (children?: Node[]) =>
+  list: (children?: Node[] | Fragment) =>
     schema.nodes.list.create({}, children || []),
-  listitem: (marker: string, children?: Node[]) =>
+  listitem: (marker: string, children?: Node[] | Fragment) =>
     schema.nodes.listitem.create({ marker }, children || []),
   para: (textContent: string | Node[], children?: Node[]) =>
     schema.nodes.para.create({}, [schema.nodes.inline.create(
       {},
       typeof textContent === 'string' ? schema.text(textContent) : textContent,
     )].concat(children || [])),
-  policy: (children?: Node[]) =>
+  policy: (children?: Node[] | Fragment) =>
     schema.nodes.policy.create({}, children || []),
-  sec: (children?: Node[]) =>
+  sec: (children?: Node[] | Fragment) =>
     schema.nodes.sec.create({}, children || []),
   unimplementedMark: (original: any) =>
     schema.marks.unimplementedMark.create({ data: original }),

--- a/api/document/js/util.ts
+++ b/api/document/js/util.ts
@@ -1,3 +1,5 @@
+import { Node, ResolvedPos } from 'prosemirror-model';
+
 export function getEl(selector: string): HTMLElement {
   const el = document.querySelector(selector);
   if (!el || !(el instanceof HTMLElement))
@@ -13,4 +15,16 @@ export function getElAttr(selector: string, attr: string): string {
   }
 
   return value;
+}
+
+export function walkUpUntil(pos: ResolvedPos, predicate: (node: Node) => boolean) {
+  let depth = pos.depth;
+  while (depth >= 0) {
+    const node = pos.node(depth);
+    if (predicate(node)) {
+      break;
+    }
+    depth -= 1;
+  }
+  return depth;
 }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -6142,6 +6142,14 @@
         "inherits": "2.0.3"
       }
     },
+    "romanize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/romanize/-/romanize-1.1.1.tgz",
+      "integrity": "sha1-yVb6E4dkHINycDB3oAmc0bfXDBw=",
+      "requires": {
+        "repeat-string": "1.6.1"
+      }
+    },
     "rope-sequence": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.2.2.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -43,6 +43,8 @@
     "prosemirror-menu": "^1.0.0",
     "prosemirror-state": "^1.0.0",
     "prosemirror-view": "^1.0.5",
+    "repeat-string": "^1.6.1",
+    "romanize": "^1.1.1",
     "style-loader": "0.19.1",
     "ts-loader": "^3.2.0",
     "typescript": "^2.6.2",

--- a/api/tslint.yaml
+++ b/api/tslint.yaml
@@ -7,3 +7,5 @@ rules:
   # Deprecated in favor of no-this-assignment
   no-var-self: false
   no-this-assignment: true
+  # Removing this as we don't want to have to mix str and literal keys
+  object-literal-key-quotes: false


### PR DESCRIPTION
If the cursor's at the end of the text of an existing li (and there are no child nodes, like footnotes), pressing Enter will create a new li immediately following the current, renumber the lis, and place the cursor in the new one.

Renumbering inspects the first li and uses that as a template for all following (meaning we can have arbitrary text in the marker). It'd be a good idea to call the renumbering operating when deleting lis and changing indents, but this doesn't implement those scenarios.

## Looks Like
![add-bullet](https://user-images.githubusercontent.com/326918/36049288-3a92da9c-0db0-11e8-9c19-13a3ddaa497f.gif)
![add-ordered](https://user-images.githubusercontent.com/326918/36049294-3e9795ec-0db0-11e8-85c6-da9a84e06802.gif)
![renumbering](https://user-images.githubusercontent.com/326918/36049301-41965bc0-0db0-11e8-8e74-e25f7dd069a9.gif)
