### PR TITLE
Set workflow phase to 'published' in import_xml_doc command

### DIFF
--- a/api/document/management/commands/import_xml_doc.py
+++ b/api/document/management/commands/import_xml_doc.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 
 from django.core.management.base import BaseCommand
+from django.db import transaction
 
 from document.parsers import AkomaNtosoParser
 from document.serializers.doc_cursor import DocCursorSerializer
@@ -17,6 +18,7 @@ def fetch_policy(identifier: str):
         return Policy.objects.filter(omb_policy_id=identifier).first()
 
 
+@transaction.atomic
 def import_xml_doc(policy, xmlstream):
     policy.workflow_phase = WorkflowPhases.published.name
     policy.save()

--- a/api/document/management/commands/import_xml_doc.py
+++ b/api/document/management/commands/import_xml_doc.py
@@ -5,7 +5,7 @@ from django.core.management.base import BaseCommand
 
 from document.parsers import AkomaNtosoParser
 from document.serializers.doc_cursor import DocCursorSerializer
-from reqs.models import Policy
+from reqs.models import Policy, WorkflowPhases
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +18,8 @@ def fetch_policy(identifier: str):
 
 
 def import_xml_doc(policy, xmlstream):
+    policy.workflow_phase = WorkflowPhases.published.name
+    policy.save()
     parsed_data = AkomaNtosoParser().parse(xmlstream)
     serializer = DocCursorSerializer(data=parsed_data, context={
         'policy': policy

--- a/api/document/tests/import_xml_doc_test.py
+++ b/api/document/tests/import_xml_doc_test.py
@@ -6,7 +6,7 @@ from model_mommy import mommy
 from document.management.commands import import_xml_doc
 from document.models import DocNode
 from document.tree import DocCursor
-from reqs.models import Policy
+from reqs.models import Policy, WorkflowPhases
 
 
 @pytest.mark.django_db
@@ -23,7 +23,7 @@ def test_fetch_policy_number():
 
 @pytest.mark.django_db
 def test_import_xml_doc():
-    policy = mommy.make(Policy)
+    policy = mommy.make(Policy, workflow_phase=WorkflowPhases.no_doc)
     for i in range(2):
         xml = BytesIO(f"""
         <aroot title="Root of Doc {i}\u2026">
@@ -46,3 +46,6 @@ def test_import_xml_doc():
         assert root['subchild_b'].title == ''
         assert root['subchild_2'].title == 'Second child'
         assert root['subchild_2']['subsubchild_1'].node_type == 'subsubchild'
+
+        policy.refresh_from_db()
+        assert policy.workflow_phase == WorkflowPhases.published.name


### PR DESCRIPTION
The current README instructions that instruct a user to use `manage.py import_xml_doc` to import an existing XML doc are a bit developer-unfriendly after #842 because the related policy's `workflow_phase` is still set to `no_doc`, which means that even though the document is stored in the database, it won't be linked-to in the viewer anymore.

This just fixes it so that the related policy's `workflow_phase` is set to `published`, which restores the previous developer experience (and also makes sense semantically).