### PR TITLE
Improve API typings

### DIFF
--- a/api/document/js/Api.ts
+++ b/api/document/js/Api.ts
@@ -35,43 +35,32 @@ export interface ApiContent {
   text: string;
 }
 
-interface ApiTypeMap {
-  'json': ApiNode;
-  'akn+xml': string;
-}
-
-interface ApiOptions<T extends keyof ApiTypeMap> {
-  contentType: T;
-  csrfToken: string;
-  url: string;
-}
-
-export default class Api<T extends keyof ApiTypeMap> {
+export class Api<T> {
   url: string;
   contentType: string;
   csrfToken: string;
 
-  constructor(options: ApiOptions<T>) {
-    this.url = options.url;
-    this.contentType = `application/${options.contentType}`;
-    this.csrfToken = options.csrfToken;
+  constructor({ contentType, csrfToken, url }) {
+    this.url = url;
+    this.contentType = contentType;
+    this.csrfToken = csrfToken;
   }
 
-  async fetch(): Promise<ApiTypeMap[T]> {
+  async fetch(): Promise<T> {
     try {
       setStatus('Loading document...');
       const response = await axios.get(this.url, { headers: {
         Accept: this.contentType,
       } });
       setStatus('Document loaded.');
-      return response.data as ApiTypeMap[T];
+      return response.data as T;
     } catch (e) {
       setStatusError(e);
       throw e;
     }
   }
 
-  async write(data: ApiTypeMap[T]): Promise<void> {
+  async write(data: T): Promise<void> {
     try {
       setStatus('Saving...');
       await axios.put(this.url, data, { headers: {
@@ -83,5 +72,17 @@ export default class Api<T extends keyof ApiTypeMap> {
       setStatusError(e);
       throw e;
     }
+  }
+}
+
+export class JsonApi extends Api<ApiNode> {
+  constructor({ csrfToken, url }) {
+    super({ csrfToken, url, contentType: 'application/json' });
+  }  
+}
+
+export class AknXmlApi extends Api<string> {
+  constructor({ csrfToken, url }) {
+    super({ csrfToken, url, contentType: 'application/akn+xml' });
   }
 }

--- a/api/document/js/__tests__/Api.test.ts
+++ b/api/document/js/__tests__/Api.test.ts
@@ -5,7 +5,7 @@ jest.mock('../util', () => ({
 
 import axios from 'axios';
 
-import Api from '../Api';
+import { Api } from '../Api';
 import { getEl } from '../util';
 
 function mockSetStatus() {
@@ -16,8 +16,8 @@ function mockSetStatus() {
   return textContent;
 }
 
-const api = new Api({
-  contentType: 'akn+xml',
+const api = new Api<string>({
+  contentType: 'c-type',
   csrfToken: 'some-token',
   url: 'http://example.com/path',
 });
@@ -26,9 +26,7 @@ describe('fetch()', () => {
   it('passes the correct args', () => {
     api.fetch();
     expect(axios.get).toHaveBeenCalledWith(
-      'http://example.com/path', { headers: {
-        Accept: 'application/akn+xml',
-      } });
+      'http://example.com/path', { headers: { Accept: 'c-type' } });
   });
 
   it('loads the data', async () => {
@@ -68,10 +66,7 @@ describe('write()', () => {
     expect(axios.put).toHaveBeenCalledWith(
       'http://example.com/path',
       'some data here',
-      { headers: {
-        'Content-Type': 'application/akn+xml',
-        'X-CSRFToken': 'some-token',
-      } },
+      { headers: { 'Content-Type': 'c-type', 'X-CSRFToken': 'some-token' } },
     );
   });
 

--- a/api/document/js/__tests__/Api.test.ts
+++ b/api/document/js/__tests__/Api.test.ts
@@ -17,7 +17,7 @@ function mockSetStatus() {
 }
 
 const api = new Api({
-  contentType: 'c-type',
+  contentType: 'akn+xml',
   csrfToken: 'some-token',
   url: 'http://example.com/path',
 });
@@ -26,7 +26,9 @@ describe('fetch()', () => {
   it('passes the correct args', () => {
     api.fetch();
     expect(axios.get).toHaveBeenCalledWith(
-      'http://example.com/path', { headers: { Accept: 'c-type' } });
+      'http://example.com/path', { headers: {
+        Accept: 'application/akn+xml',
+      } });
   });
 
   it('loads the data', async () => {
@@ -51,7 +53,7 @@ describe('fetch()', () => {
     error.response = { data: { oh: 'noes', and: 6 } };
     axios.get = jest.fn(() => { throw error; });
 
-    await api.fetch();
+    try { await api.fetch(); } catch (_) {}
 
     expect(textContent).toHaveBeenCalledTimes(2);
     const message = textContent.mock.calls[1][0];
@@ -66,7 +68,10 @@ describe('write()', () => {
     expect(axios.put).toHaveBeenCalledWith(
       'http://example.com/path',
       'some data here',
-      { headers: { 'Content-Type': 'c-type', 'X-CSRFToken': 'some-token' } },
+      { headers: {
+        'Content-Type': 'application/akn+xml',
+        'X-CSRFToken': 'some-token',
+      } },
     );
   });
 
@@ -85,7 +90,7 @@ describe('write()', () => {
     error.response = { data: { some: 'warning' } };
     axios.get = jest.fn(() => { throw error; });
 
-    await api.fetch();
+    try { await api.fetch(); } catch (_) {}
 
     expect(textContent).toHaveBeenCalledTimes(2);
     const message = textContent.mock.calls[1][0];

--- a/api/document/js/__tests__/Api.test.ts
+++ b/api/document/js/__tests__/Api.test.ts
@@ -51,7 +51,7 @@ describe('fetch()', () => {
     error.response = { data: { oh: 'noes', and: 6 } };
     axios.get = jest.fn(() => { throw error; });
 
-    try { await api.fetch(); } catch (_) {}
+    await expect(api.fetch()).rejects.toBeInstanceOf(Error);
 
     expect(textContent).toHaveBeenCalledTimes(2);
     const message = textContent.mock.calls[1][0];
@@ -85,7 +85,7 @@ describe('write()', () => {
     error.response = { data: { some: 'warning' } };
     axios.get = jest.fn(() => { throw error; });
 
-    try { await api.fetch(); } catch (_) {}
+    await expect(api.fetch()).rejects.toBeInstanceOf(Error);
 
     expect(textContent).toHaveBeenCalledTimes(2);
     const message = textContent.mock.calls[1][0];

--- a/api/document/js/__tests__/commands.test.ts
+++ b/api/document/js/__tests__/commands.test.ts
@@ -4,7 +4,7 @@ window.location.assign = jest.fn();
 
 import { EditorState, TextSelection } from 'prosemirror-state';
 
-import Api from '../Api';
+import { JsonApi } from '../Api';
 import {
   appendBulletListNear,
   appendNearBlock,
@@ -160,7 +160,7 @@ describe('makeSave()', () => {
   it('calls the save function', async () => {
     (serializeDoc as jest.Mock).mockImplementationOnce(() => ({ serialized: 'content' }));
 
-    const api = new Api({ contentType: 'json', csrfToken: '', url: '' });
+    const api = new JsonApi({ csrfToken: '', url: '' });
     const save = makeSave(api);
     await save({ doc: 'stuff' });
 
@@ -173,7 +173,7 @@ describe('makeSaveThenXml()', () => {
   it('calls the save function', async () => {
     (serializeDoc as jest.Mock).mockImplementationOnce(() => ({ serialized: 'content' }));
 
-    const api = new Api({ contentType: 'json', csrfToken: '', url: '' });
+    const api = new JsonApi({ csrfToken: '', url: '' });
     const save = makeSaveThenXml(api);
     await save({ doc: 'stuff' });
 
@@ -185,7 +185,7 @@ describe('makeSaveThenXml()', () => {
     const locationAssign = window.location.assign as jest.Mock;
     locationAssign.mockClear();
 
-    const api = new Api({ contentType: 'json', csrfToken: '', url: '' });
+    const api = new JsonApi({ csrfToken: '', url: '' });
     const save = makeSaveThenXml(api);
     await save({ doc: 'stuff' });
 

--- a/api/document/js/__tests__/commands.test.ts
+++ b/api/document/js/__tests__/commands.test.ts
@@ -160,7 +160,7 @@ describe('makeSave()', () => {
   it('calls the save function', async () => {
     (serializeDoc as jest.Mock).mockImplementationOnce(() => ({ serialized: 'content' }));
 
-    const api = new Api({ contentType: '', csrfToken: '', url: '' });
+    const api = new Api({ contentType: 'json', csrfToken: '', url: '' });
     const save = makeSave(api);
     await save({ doc: 'stuff' });
 
@@ -173,7 +173,7 @@ describe('makeSaveThenXml()', () => {
   it('calls the save function', async () => {
     (serializeDoc as jest.Mock).mockImplementationOnce(() => ({ serialized: 'content' }));
 
-    const api = new Api({ contentType: '', csrfToken: '', url: '' });
+    const api = new Api({ contentType: 'json', csrfToken: '', url: '' });
     const save = makeSaveThenXml(api);
     await save({ doc: 'stuff' });
 
@@ -185,7 +185,7 @@ describe('makeSaveThenXml()', () => {
     const locationAssign = window.location.assign as jest.Mock;
     locationAssign.mockClear();
 
-    const api = new Api({ contentType: '', csrfToken: '', url: '' });
+    const api = new Api({ contentType: 'json', csrfToken: '', url: '' });
     const save = makeSaveThenXml(api);
     await save({ doc: 'stuff' });
 

--- a/api/document/js/__tests__/create-editor-state.test.ts
+++ b/api/document/js/__tests__/create-editor-state.test.ts
@@ -15,7 +15,11 @@ describe('createEditorState()', () => {
       schema.nodes.heading.create({ depth: 1 }, factory.sec()),
     ]));
 
-    createEditorState('', new Api({ contentType: '', csrfToken: '', url: '' }));
+    createEditorState('', new Api({
+      contentType: 'json',
+      csrfToken: '',
+      url: '',
+    }));
 
     expect(setStatusError).toHaveBeenCalled();
   });

--- a/api/document/js/__tests__/create-editor-state.test.ts
+++ b/api/document/js/__tests__/create-editor-state.test.ts
@@ -1,7 +1,7 @@
 jest.mock('../Api');
 jest.mock('../parse-doc');
 
-import Api, { setStatusError } from '../Api';
+import { JsonApi, setStatusError } from '../Api';
 import createEditorState from '../create-editor-state';
 import parseDoc from '../parse-doc';
 import schema, { factory } from '../schema';
@@ -15,8 +15,7 @@ describe('createEditorState()', () => {
       schema.nodes.heading.create({ depth: 1 }, factory.sec()),
     ]));
 
-    createEditorState('', new Api({
-      contentType: 'json',
+    createEditorState('', new JsonApi({
       csrfToken: '',
       url: '',
     }));

--- a/api/document/js/akn/main.ts
+++ b/api/document/js/akn/main.ts
@@ -10,9 +10,8 @@ import { getEl, getElAttr } from '../util';
 
 const EDITOR_SEL = '#editor';
 const DOC_URL_ATTR = 'data-document-url';
-const AKN_CONTENT_TYPE = 'application/akn+xml';
 
-function createEditor(value: string, api: Api) {
+function createEditor(value: string, api: Api<'akn+xml'>) {
   const cm = CodeMirror(getEl(EDITOR_SEL), {
     value,
     lineNumbers: true,
@@ -25,7 +24,7 @@ function createEditor(value: string, api: Api) {
 
 window.addEventListener('load', () => {
   const api = new Api({
-    contentType: AKN_CONTENT_TYPE,
+    contentType: 'akn+xml',
     csrfToken: getElAttr('[name=csrfmiddlewaretoken]', 'value'),
     url: getElAttr(EDITOR_SEL, DOC_URL_ATTR),
   });

--- a/api/document/js/akn/main.ts
+++ b/api/document/js/akn/main.ts
@@ -5,13 +5,13 @@ import 'codemirror/addon/search/search.js';
 import 'codemirror/addon/search/searchcursor.js';
 import 'codemirror/addon/dialog/dialog.js';
 
-import Api from '../Api';
+import { AknXmlApi } from '../Api';
 import { getEl, getElAttr } from '../util';
 
 const EDITOR_SEL = '#editor';
 const DOC_URL_ATTR = 'data-document-url';
 
-function createEditor(value: string, api: Api<'akn+xml'>) {
+function createEditor(value: string, api: AknXmlApi) {
   const cm = CodeMirror(getEl(EDITOR_SEL), {
     value,
     lineNumbers: true,
@@ -23,8 +23,7 @@ function createEditor(value: string, api: Api<'akn+xml'>) {
 }
 
 window.addEventListener('load', () => {
-  const api = new Api({
-    contentType: 'akn+xml',
+  const api = new AknXmlApi({
     csrfToken: getElAttr('[name=csrfmiddlewaretoken]', 'value'),
     url: getElAttr(EDITOR_SEL, DOC_URL_ATTR),
   });

--- a/api/document/js/commands.ts
+++ b/api/document/js/commands.ts
@@ -59,11 +59,11 @@ export function appendBulletListNear(state, dispatch) {
   return appendNearBlock(state, dispatch, element, ['listitem', 'para', 'inline']);
 }
 
-export function makeSave(api: Api) {
+export function makeSave(api: Api<'json'>) {
   return async state => api.write(serializeDoc(state.doc));
 }
 
-export function makeSaveThenXml(api: Api) {
+export function makeSaveThenXml(api: Api<'json'>) {
   return async (state) => {
     await api.write(serializeDoc(state.doc));
     window.location.assign(`${window.location.href}/akn`);

--- a/api/document/js/commands.ts
+++ b/api/document/js/commands.ts
@@ -1,7 +1,7 @@
 import { Node } from 'prosemirror-model';
 import { TextSelection } from 'prosemirror-state';
 
-import Api from './Api';
+import { JsonApi } from './Api';
 import { deeperBullet } from './list-utils';
 import pathToResolvedPos, { SelectionPath } from './path-to-resolved-pos';
 import { factory } from './schema';
@@ -59,11 +59,11 @@ export function appendBulletListNear(state, dispatch) {
   return appendNearBlock(state, dispatch, element, ['listitem', 'para', 'inline']);
 }
 
-export function makeSave(api: Api<'json'>) {
+export function makeSave(api: JsonApi) {
   return async state => api.write(serializeDoc(state.doc));
 }
 
-export function makeSaveThenXml(api: Api<'json'>) {
+export function makeSaveThenXml(api: JsonApi) {
   return async (state) => {
     await api.write(serializeDoc(state.doc));
     window.location.assign(`${window.location.href}/akn`);

--- a/api/document/js/create-editor-state.ts
+++ b/api/document/js/create-editor-state.ts
@@ -2,13 +2,13 @@ import { Node } from 'prosemirror-model';
 import { EditorState } from 'prosemirror-state';
 import { history } from 'prosemirror-history';
 
-import Api, { setStatusError } from './Api';
+import { JsonApi, setStatusError } from './Api';
 import fixupDoc from './fixup-doc';
 import keyboard from './keyboard';
 import menu from './menu';
 import parseDoc from './parse-doc';
 
-export default function createEditorState(data, api: Api<'json'>): EditorState {
+export default function createEditorState(data, api: JsonApi): EditorState {
   const doc = parseDoc(data);
   try {
     doc.check();

--- a/api/document/js/create-editor-state.ts
+++ b/api/document/js/create-editor-state.ts
@@ -8,7 +8,7 @@ import keyboard from './keyboard';
 import menu from './menu';
 import parseDoc from './parse-doc';
 
-export default function createEditorState(data, api: Api): EditorState {
+export default function createEditorState(data, api: Api<'json'>): EditorState {
   const doc = parseDoc(data);
   try {
     doc.check();

--- a/api/document/js/keyboard.ts
+++ b/api/document/js/keyboard.ts
@@ -8,7 +8,7 @@ import {
 import { undo, redo } from 'prosemirror-history';
 import { keymap } from 'prosemirror-keymap';
 
-import Api from './Api';
+import { JsonApi } from './Api';
 import { makeSave } from './commands';
 import schema from './schema';
 
@@ -17,7 +17,7 @@ import schema from './schema';
 const backspace = chainCommands(deleteSelection, selectNodeBackward);
 const del = chainCommands(deleteSelection, selectNodeForward);
 
-export default function menu(api: Api<'json'>) {
+export default function menu(api: JsonApi) {
   return keymap({
     ...baseKeymap,
     // tslint:disable-next-line object-literal-key-quotes

--- a/api/document/js/keyboard.ts
+++ b/api/document/js/keyboard.ts
@@ -17,7 +17,7 @@ import schema from './schema';
 const backspace = chainCommands(deleteSelection, selectNodeBackward);
 const del = chainCommands(deleteSelection, selectNodeForward);
 
-export default function menu(api: Api) {
+export default function menu(api: Api<'json'>) {
   return keymap({
     ...baseKeymap,
     // tslint:disable-next-line object-literal-key-quotes

--- a/api/document/js/main.ts
+++ b/api/document/js/main.ts
@@ -1,6 +1,6 @@
 import { EditorView } from 'prosemirror-view';
 
-import Api from './Api';
+import { JsonApi } from './Api';
 import createEditorState from './create-editor-state';
 import { getEl, getElAttr } from './util';
 
@@ -8,8 +8,7 @@ const EDITOR_SEL = '#editor';
 const DOC_URL_ATTR = 'data-document-url';
 
 window.addEventListener('load', () => {
-  const api = new Api({
-    contentType: 'json',
+  const api = new JsonApi({
     csrfToken: getElAttr('[name=csrfmiddlewaretoken]', 'value'),
     url: getElAttr(EDITOR_SEL, DOC_URL_ATTR),
   });

--- a/api/document/js/main.ts
+++ b/api/document/js/main.ts
@@ -9,7 +9,7 @@ const DOC_URL_ATTR = 'data-document-url';
 
 window.addEventListener('load', () => {
   const api = new Api({
-    contentType: 'application/json',
+    contentType: 'json',
     csrfToken: getElAttr('[name=csrfmiddlewaretoken]', 'value'),
     url: getElAttr(EDITOR_SEL, DOC_URL_ATTR),
   });

--- a/api/document/js/menu.ts
+++ b/api/document/js/menu.ts
@@ -1,6 +1,6 @@
 import { menuBar, undoItem, redoItem, MenuItem, MenuItemSpec } from 'prosemirror-menu';
 
-import Api from './Api';
+import { JsonApi } from './Api';
 import { appendBulletListNear, appendParagraphNear, makeSave, makeSaveThenXml } from './commands';
 import icons from './icons';
 
@@ -15,7 +15,7 @@ function makeButton(content) {
   });
 }
 
-export default function menu(api: Api<'json'>) {
+export default function menu(api: JsonApi) {
   return menuBar({
     floating: true,
     content: [

--- a/api/document/js/menu.ts
+++ b/api/document/js/menu.ts
@@ -15,7 +15,7 @@ function makeButton(content) {
   });
 }
 
-export default function menu(api: Api) {
+export default function menu(api: Api<'json'>) {
   return menuBar({
     floating: true,
     content: [

--- a/api/document/js/parse-doc.ts
+++ b/api/document/js/parse-doc.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { flatten } from 'lodash/array';
 import { Mark, Node } from 'prosemirror-model';
 
+import { ApiNode, ApiContent } from './Api';
 import schema, { factory } from './schema';
 
 export default function parseDoc(node): Node {
@@ -24,8 +25,16 @@ export function convertContent(content, marks: Mark[]): Node[] {
   return flatten(nestedChildNodes);
 }
 
-const NODE_TYPE_CONVERTERS = {
+
+type NodeConverterMap = {
+  [nodeName: string]: (node: ApiNode) => Node,
+};
+
+const NODE_TYPE_CONVERTERS: NodeConverterMap = {
   heading(node) {
+    if (!node.identifier)
+      throw new Error('Assertion failure, node needs identifier');
+
     // Duplicates logic in `ui`
     const depth = node.identifier
       .split('_')
@@ -35,7 +44,11 @@ const NODE_TYPE_CONVERTERS = {
     return factory.heading(text, depth);
   },
   list: node => factory.list((node.children || []).map(parseDoc)),
-  listitem: node => factory.listitem(node.marker, (node.children || []).map(parseDoc)),
+  listitem(node) {
+    if (!node.marker)
+      throw new Error('Assertion failure, list items must have markers');
+    return factory.listitem(node.marker, (node.children || []).map(parseDoc));
+  },
   para(node) {
     const nested: Node[][] = (node.content || []).map(c => convertContent(c, []));
     return factory.para(flatten(nested), (node.children || []).map(parseDoc));

--- a/api/document/js/serialize-doc.ts
+++ b/api/document/js/serialize-doc.ts
@@ -1,21 +1,7 @@
 import { Fragment, Mark, Node } from 'prosemirror-model';
 
+import { ApiNode, ApiContent } from './Api';
 import schema from './schema';
-
-interface ApiNode {
-  children: ApiNode[];
-  content: ApiContent[];
-  marker?: string;
-  node_type: string;
-  type_emblem?: string;
-  title?: string;
-}
-
-interface ApiContent {
-  content_type: string;
-  inlines: ApiContent[];
-  text: string;
-}
 
 export const apiFactory = {
   node(nodeType, overrides): ApiNode {
@@ -41,8 +27,11 @@ export const apiFactory = {
   }),
 };
 
+type NodeConverterMap = {
+  [nodeName: string]: (node: Node) => ApiNode,
+};
 
-const NODE_CONVERTERS = {
+const NODE_CONVERTERS: NodeConverterMap = {
   heading: node => apiFactory.node(
     node.type.name,
     // Text isn't in an 'inline' block
@@ -71,7 +60,7 @@ const NODE_CONVERTERS = {
   unimplementedNode: node => node.attrs.data,
 };
 
-function defaultNodeConverter(node): ApiNode {
+function defaultNodeConverter(node: Node): ApiNode {
   const children: ApiNode[] = [];
   let content: ApiContent[] = [];
   node.content.forEach((child) => {


### PR DESCRIPTION
When I was working on #1003, I realized that I was frequently getting confused about what kind of object was a "Django app document node" vs. what kind of object was a ProseMirror node.  At first I started creating my own typing for the former, until I noticed that it already existed in `serialize-doc.ts`!  So I just moved the related typings from there to `Api.ts`, since that seemed like a more appropriate location for types called `ApiNode` and `ApiContent`.

I also changed `Api` to be parameterized based on whether the caller wants to use it for JSON or AKN+XML, since that alters the return type of the object.
