### PR TITLE
Fix stylesheet for lists.

### DIFF
--- a/shared-styles/base/_util.scss
+++ b/shared-styles/base/_util.scss
@@ -18,6 +18,7 @@
   &::after {
     content: ' ';
     display: table;
+    white-space: normal; // Account for ProseMirror failing to collapse these
   }
 
   &::after {


### PR DESCRIPTION
ProseMirror's stylesheets alter how whitespace is collapsed by browsers.
Unfortunately, our .clearfix class (based on basscss) assumed whitespace
_would_ be collapsed.

This doesn't affect the viewer, but for the editor:

## Before
<img width="1251" alt="screen shot 2018-02-12 at 6 37 32 pm" src="https://user-images.githubusercontent.com/326918/36125925-2725d5ce-1024-11e8-80d3-ce87d050e3b6.png">


## After
<img width="1246" alt="screen shot 2018-02-12 at 6 37 56 pm" src="https://user-images.githubusercontent.com/326918/36125920-230c4234-1024-11e8-853d-385f711b415b.png">
