### PR TITLE
[WIP EXPERIMENT] Alternative approach to WYSIWYG footnote editing

### DIFF
--- a/api/document/js/Api.ts
+++ b/api/document/js/Api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 import { getEl } from './util';
 import { makeErrorFriendly } from './friendly-error';
+import * as footnoteMunging from './footnote-munging';
 
 function setStatus(msg: string, className: 'editor-status-error'|'' = '') {
   const status = getEl('#status');
@@ -80,6 +81,15 @@ export class JsonApi extends Api<ApiNode> {
   constructor({ csrfToken, url }) {
     super({ csrfToken, url, contentType: 'application/json' });
   }  
+
+  async fetch(): Promise<ApiNode> {
+    const result = await Api.prototype.fetch.call(this);
+    return footnoteMunging.munge(result);
+  }
+
+  async write(data: ApiNode): Promise<void> {
+    await Api.prototype.write.call(this, footnoteMunging.unmunge(data));
+  }
 }
 
 export class AknXmlApi extends Api<string> {

--- a/api/document/js/Api.ts
+++ b/api/document/js/Api.ts
@@ -33,6 +33,7 @@ export interface ApiContent {
   content_type: string;
   inlines: ApiContent[];
   text: string;
+  footnote_number?: string;
 }
 
 export class Api<T> {

--- a/api/document/js/footnote-munging.ts
+++ b/api/document/js/footnote-munging.ts
@@ -6,8 +6,8 @@ interface FootnoteMap {
   [typeEmblem: string]: ApiNode;
 }
 
-function mungeApiContent(content: ApiContent,
-                         footnotes: FootnoteMap): ApiContent {
+function mungeContent(content: ApiContent,
+                      footnotes: FootnoteMap): ApiContent {
   if (content.content_type === 'footnote_citation') {
     const footnoteNum = content.text;
     const footnote = footnotes[footnoteNum];
@@ -24,7 +24,7 @@ function mungeApiContent(content: ApiContent,
   }
 
   const inlines = content.inlines.map(content =>
-    mungeApiContent(content, footnotes));
+    mungeContent(content, footnotes));
   return { ...content, inlines };
 }
 
@@ -44,18 +44,18 @@ function removeFootnotes(node: ApiNode, footnotes: FootnoteMap): ApiNode {
 
 function inlineFootnotes(node: ApiNode, footnotes: FootnoteMap): ApiNode {
   const content = node.content.map(content =>
-    mungeApiContent(content, footnotes));
+    mungeContent(content, footnotes));
   const children = node.children.map(child =>
     inlineFootnotes(child, footnotes));
   return { ...node, children, content };
 }
 
-export function mungeApiNode(node: ApiNode): ApiNode {
+export function munge(node: ApiNode): ApiNode {
   const footnotes: FootnoteMap = {};
   const withoutFootnotes = removeFootnotes(node, footnotes);
   return inlineFootnotes(withoutFootnotes, footnotes);
 }
 
-export function mungeNode(node: Node): Node {
-  throw new Error('Implement this!');
+export function unmunge(node: ApiNode): ApiNode {
+  throw new Error('Implement footnoteMunging.unmunge()!');
 }

--- a/api/document/js/footnote-munging.ts
+++ b/api/document/js/footnote-munging.ts
@@ -1,0 +1,61 @@
+import { Mark, Node } from 'prosemirror-model';
+
+import { ApiNode, ApiContent } from './Api';
+
+interface FootnoteMap {
+  [typeEmblem: string]: ApiNode;
+}
+
+function mungeApiContent(content: ApiContent,
+                         footnotes: FootnoteMap): ApiContent {
+  if (content.content_type === 'footnote_citation') {
+    const footnoteNum = content.text;
+    const footnote = footnotes[footnoteNum];
+    if (!footnote) {
+      throw new Error(`Footnote ${footnoteNum} not found!`);
+    }
+    const inlines = footnote.content;
+    return {
+      ...content,
+      inlines,
+      footnote_number: footnoteNum,
+      content_type: 'munged_footnote',
+    };
+  }
+
+  const inlines = content.inlines.map(content =>
+    mungeApiContent(content, footnotes));
+  return { ...content, inlines };
+}
+
+function removeFootnotes(node: ApiNode, footnotes: FootnoteMap): ApiNode {
+  const children = node.children.filter((child) => {
+    if (child.node_type === 'footnote') {
+      if (!child.type_emblem)
+        throw new Error('footnotes must have emblems!');
+      footnotes[child.type_emblem] = child;
+      return false;
+    }
+    return true;
+  }).map(child =>
+    removeFootnotes(child, footnotes));
+  return { ...node, children };
+}
+
+function inlineFootnotes(node: ApiNode, footnotes: FootnoteMap): ApiNode {
+  const content = node.content.map(content =>
+    mungeApiContent(content, footnotes));
+  const children = node.children.map(child =>
+    inlineFootnotes(child, footnotes));
+  return { ...node, children, content };
+}
+
+export function mungeApiNode(node: ApiNode): ApiNode {
+  const footnotes: FootnoteMap = {};
+  const withoutFootnotes = removeFootnotes(node, footnotes);
+  return inlineFootnotes(withoutFootnotes, footnotes);
+}
+
+export function mungeNode(node: Node): Node {
+  throw new Error('Implement this!');
+}

--- a/api/document/js/main.ts
+++ b/api/document/js/main.ts
@@ -3,7 +3,6 @@ import { EditorView } from 'prosemirror-view';
 import { JsonApi } from './Api';
 import createEditorState from './create-editor-state';
 import { getEl, getElAttr } from './util';
-import * as footnoteMunging from './footnote-munging';
 
 const EDITOR_SEL = '#editor';
 const DOC_URL_ATTR = 'data-document-url';
@@ -15,8 +14,7 @@ window.addEventListener('load', () => {
   });
 
   api.fetch().then((data) => {
-    const mungedData = footnoteMunging.mungeApiNode(data);
-    const state = createEditorState(mungedData, api);
+    const state = createEditorState(data, api);
     new EditorView(getEl(EDITOR_SEL), { state });
   });
 });

--- a/api/document/js/main.ts
+++ b/api/document/js/main.ts
@@ -3,6 +3,7 @@ import { EditorView } from 'prosemirror-view';
 import { JsonApi } from './Api';
 import createEditorState from './create-editor-state';
 import { getEl, getElAttr } from './util';
+import * as footnoteMunging from './footnote-munging';
 
 const EDITOR_SEL = '#editor';
 const DOC_URL_ATTR = 'data-document-url';
@@ -14,7 +15,8 @@ window.addEventListener('load', () => {
   });
 
   api.fetch().then((data) => {
-    const state = createEditorState(data, api);
+    const mungedData = footnoteMunging.mungeApiNode(data);
+    const state = createEditorState(mungedData, api);
     new EditorView(getEl(EDITOR_SEL), { state });
   });
 });


### PR DESCRIPTION
This takes an alternative approach to footnote editing by assuming the API is providing the editor with a different document structure than it actually (currently) provides it with.  It also assumes the API can take in this different document structure in PUT requests.

For now we'll call this different document structure the "inlined footnotes structure", because that's what it does: it just inlines footnotes at their citation.

In reality, a "munging" layer exists between the API and the rest of the code that modifies the document structure as needed.

The idea is that we'd eventually modify the actual API (and the viewer) to accept this alternative document structure; as discussed in Slack and proposed by @thebestsophist, this is likely what we'll need to do anyways in order to conform to AKN, and it seems to make sense regardless since there is a one-to-one correspondence between footnotes and their citations. I've implemented the munging layer for now instead of doing things "properly" partly because it will likely be a _lot_ of work to modify the rest of our architecture.

However, I'm also taking the munging approach because regardless of the rest of our architecture, the inlined footnotes structure is _much_ easier for us to deal with at the ProseMirror level, particularly given Austin's mockups (see #1010), which represent footnotes inline.
