### PR TITLE
Refactor and document pathToResolvedPos better.

### DIFF
--- a/api/document/js/__tests__/list-utils.test.ts
+++ b/api/document/js/__tests__/list-utils.test.ts
@@ -25,25 +25,31 @@ describe('deeperBullet()', () => {
   ]);
 
   it('defaults when not in a list', () => {
-    const pos = pathToResolvedPos(doc, ['para', 'inline']);
+    const pos = pathToResolvedPos(doc, 'para', 'inline');
     expect(deeperBullet(pos)).toBe('●');
   });
 
   it('selects the second level marker', () => {
-    const pos = pathToResolvedPos(doc, ['list', 'listitem', 'para', 'inline']);
+    const pos = pathToResolvedPos(doc, 'list', 'listitem', 'para', 'inline');
     expect(deeperBullet(pos)).toBe('○');
   });
 
   it('selects the third level marker', () => {
     const pos = pathToResolvedPos(
       doc,
-      ['list', new NthType(1, 'listitem'), 'list', 'listitem', 'para', 'inline'],
+      'list',
+      new NthType(1, 'listitem'),
+      'list',
+      'listitem',
+      'para',
+      'inline',
     );
     expect(deeperBullet(pos)).toBe('■');
   });
 
   it('restarts after three levels', () => {
-    const pos = pathToResolvedPos(doc, [
+    const pos = pathToResolvedPos(
+      doc,
       'list',
       new NthType(1, 'listitem'),
       'list',
@@ -52,7 +58,7 @@ describe('deeperBullet()', () => {
       'listitem',
       'para',
       'inline',
-    ]);
+    );
     expect(deeperBullet(pos)).toBe('●');
   });
 });
@@ -62,7 +68,7 @@ describe('deeperOrderedLi()', () => {
     const doc = factory.policy([factory.list('_1_', [
       factory.listitem('_1_', [factory.para(' ')]),
     ])]);
-    const pos = pathToResolvedPos(doc, ['list', 'listitem', 'para', 'inline']);
+    const pos = pathToResolvedPos(doc, 'list', 'listitem', 'para', 'inline');
     expect(deeperOrderedLi(pos)).toBe('_a_');
   });
 
@@ -79,7 +85,7 @@ describe('deeperOrderedLi()', () => {
         const doc = factory.policy([factory.list(parentMarker, [
           factory.listitem(parentMarker, [factory.para(' ')]),
         ])]);
-        const pos = pathToResolvedPos(doc, ['list', 'listitem', 'para', 'inline']);
+        const pos = pathToResolvedPos(doc, 'list', 'listitem', 'para', 'inline');
         expect(deeperOrderedLi(pos)).toBe(newMarker);
       });
     });
@@ -87,7 +93,7 @@ describe('deeperOrderedLi()', () => {
 
   it('defaults when not in a list', () => {
     const doc = factory.policy([factory.para(' ')]);
-    const pos = pathToResolvedPos(doc, ['para', 'inline']);
+    const pos = pathToResolvedPos(doc, 'para', 'inline');
     expect(deeperOrderedLi(pos)).toBe('1.');
   });
 
@@ -95,7 +101,7 @@ describe('deeperOrderedLi()', () => {
     const doc = factory.policy([factory.list('●', [
       factory.listitem('●', [factory.para(' ')]),
     ])]);
-    const pos = pathToResolvedPos(doc, ['list', 'listitem', 'para', 'inline']);
+    const pos = pathToResolvedPos(doc, 'list', 'listitem', 'para', 'inline');
     expect(deeperOrderedLi(pos)).toBe('1.');
   });
 });
@@ -110,7 +116,7 @@ describe('renumberList()', () => {
       ]),
     ]);
     const initialState = EditorState.create({ doc });
-    const pos = pathToResolvedPos(doc, ['list', 'listitem']).pos;
+    const pos = pathToResolvedPos(doc, 'list', 'listitem').pos;
     const resultTr = renumberList(initialState.tr, pos);
     const result = initialState.apply(resultTr);
     const list = result.doc.content.child(0);
@@ -131,7 +137,7 @@ describe('renumberList()', () => {
     expect(doc.textContent).toBe('stuffmorestuff');
 
     const initialState = EditorState.create({ doc });
-    const pos = pathToResolvedPos(doc, ['list', 'listitem']).pos;
+    const pos = pathToResolvedPos(doc, 'list', 'listitem').pos;
     const resultTr = renumberList(initialState.tr, pos);
     const list = initialState.apply(resultTr).doc.content.child(0);
 
@@ -153,7 +159,10 @@ describe('renumberList()', () => {
     const initialState = EditorState.create({ doc });
     const pos = pathToResolvedPos(
       doc,
-      ['list', new NthType(1, 'listitem'), 'list', 'listitem'],
+      'list',
+      new NthType(1, 'listitem'),
+      'list',
+      'listitem',
     ).pos;
     const resultTr = renumberList(initialState.tr, pos);
     const list = initialState.apply(resultTr).doc.content.child(0);

--- a/api/document/js/__tests__/schema.test.ts
+++ b/api/document/js/__tests__/schema.test.ts
@@ -2,7 +2,6 @@ import { deleteSelection } from 'prosemirror-commands';
 import { DOMSerializer } from 'prosemirror-model';
 import { EditorState, TextSelection } from 'prosemirror-state';
 
-import pathToResolvedPos, { NthType } from '../path-to-resolved-pos';
 import schema, { factory, listAttrs } from '../schema';
 
 const serializer = DOMSerializer.fromSchema(schema);

--- a/api/document/js/commands.ts
+++ b/api/document/js/commands.ts
@@ -3,7 +3,7 @@ import { EditorState, TextSelection, Transaction } from 'prosemirror-state';
 
 import { JsonApi } from './Api';
 import { deeperBullet, deeperOrderedLi, renumberList } from './list-utils';
-import pathToResolvedPos, { SelectionPath } from './path-to-resolved-pos';
+import pathToResolvedPos, { Selector } from './path-to-resolved-pos';
 import schema, { factory } from './schema';
 import serializeDoc from './serialize-doc';
 import { walkUpUntil } from './util';
@@ -23,7 +23,7 @@ function safeDocCheck(doc: Node) {
 // that element.
 export function appendNearBlock(
   element: Node,
-  selectionPath: SelectionPath,
+  selectionPath: Selector[],
   state: EditorState,
   dispatch?: Dispatch,
 ) {
@@ -40,7 +40,7 @@ export function appendNearBlock(
     let tr = state.tr.insert(insertPos, element);
     const eltStart = pathToResolvedPos(
       tr.doc.resolve(insertPos + 1),
-      selectionPath,
+      ...selectionPath,
     );
     const eltEnd = eltStart.pos + eltStart.parent.nodeSize - 1; // inclusive
     tr = tr.setSelection(TextSelection.create(
@@ -124,7 +124,8 @@ export function addListItem(state: EditorState, dispatch?: Dispatch) {
   tr = renumberList(tr, insertPos);
   const cursorStart = pathToResolvedPos(
     tr.doc.resolve(insertPos + 1),
-    ['para', 'inline'],
+    'para',
+    'inline',
   ).pos;
   tr = tr.setSelection(TextSelection.create(
     tr.doc,

--- a/api/document/js/path-to-resolved-pos.ts
+++ b/api/document/js/path-to-resolved-pos.ts
@@ -1,7 +1,9 @@
+// Exports a function to make generating ResolvedPos easier
 import { Node, NodeType, ResolvedPos } from 'prosemirror-model';
 
 import schema from './schema';
 
+// Represents a query for the nth element of some type
 export class NthType {
   nth: number;
   nodeType: NodeType;
@@ -10,41 +12,45 @@ export class NthType {
     this.nth = nth;
     this.nodeType = nodeType instanceof NodeType ? nodeType : schema.nodes[nodeType];
   }
-}
 
-export type Selector = string | number | NthType;
-export type SelectionPath = Selector[];
-
-// Position of the nth child with of type nodeType
-function getNodeTypeChildPos(initial: ResolvedPos, selector: NthType): ResolvedPos {
-  let remainingInstances = selector.nth;
-  let updatedPos: number = initial.start(initial.depth);
-  for (let idx = 0; idx < initial.parent.content.childCount; idx += 1) {
-    const child = initial.parent.content.child(idx);
-    if (child.type === selector.nodeType && remainingInstances > 0) {
-      remainingInstances -= 1;
-    } else if (child.type === selector.nodeType) {
-      return initial.doc.resolve(updatedPos + 1); // now inside that el
+  // find the nth node of the right type, return the position within that node
+  fromStart(initial: ResolvedPos): ResolvedPos {
+    let remainingInstances = this.nth;
+    let updatedPos: number = initial.start(initial.depth);
+    for (let idx = 0; idx < initial.parent.childCount; idx += 1) {
+      const child = initial.parent.content.child(idx);
+      if (child.type === this.nodeType && remainingInstances > 0) {
+        remainingInstances -= 1;
+      } else if (child.type === this.nodeType) {
+        return initial.doc.resolve(updatedPos + 1); // now inside that el
+      }
+      updatedPos += child.nodeSize;
     }
-    updatedPos += child.nodeSize;
+    throw new Error(`Could not find ${this.nodeType.name} ${this.nth}`);
   }
-  throw new Error(`Could not find ${selector.nodeType.name} ${selector.nth}`);
 }
+
+// string: select the first child with that node type
+// number: increment the position this much
+// NthType: select the nth child with that node type
+export type Selector = string | number | NthType;
 
 
 function getChildPos(initial: ResolvedPos, selector: Selector): ResolvedPos {
   if (typeof selector === 'string') {
-    return getNodeTypeChildPos(initial, new NthType(0, selector));
+    return new NthType(0, selector).fromStart(initial);
   }
   if (typeof selector === 'number') {
     return initial.doc.resolve(initial.pos + selector);
   }
-  return getNodeTypeChildPos(initial, selector);
+  return selector.fromStart(initial);
 }
 
+// Create a new ResolvedPos by digging into the children of the first
+// argument.
 export default function pathToResolvedPos(
   initial: (ResolvedPos | Node),
-  path: SelectionPath,
+  ...path: Selector[],
 ) {
   const initialPos = initial instanceof Node ? initial.resolve(0) : initial;
   return path.reduce(getChildPos, initialPos);


### PR DESCRIPTION
Stemming from @toolness's suggestion in #1006, this adds more docs to pathToResolvedPos.
It also switches the calling syntax to variadic arguments rather than an array and shuffles some non-surfaced logic around.

What do you think?