### PR TITLE
[WIP EXPERIMENT] Improve cursor behavior around footnotes

### DIFF
--- a/api/document/js/__tests__/parse-doc.test.ts
+++ b/api/document/js/__tests__/parse-doc.test.ts
@@ -150,7 +150,7 @@ describe('convertContent()', () => {
     expect(result[0].type.name).toBe('inlineFootnote');
     expect(result[0].attrs.emblem).toBe('5');
     expect(result[0].content.toJSON()).toEqual([{
-      text: 'Some text ',
+      text: '\u200bSome text ',
       type: 'text',
     }]);
   });

--- a/api/document/js/__tests__/serialize-doc.test.ts
+++ b/api/document/js/__tests__/serialize-doc.test.ts
@@ -58,7 +58,7 @@ describe('serializeDoc()', () => {
       schema.nodes.paraText.create({}, [
         schema.text('hello'),
         schema.nodes.inlineFootnote.create({ emblem: '2' }, [
-          schema.text('i am a footnote'),
+          schema.text('\u200bi am a footnote'),
         ]),
       ]),
     ]);

--- a/api/document/js/fixup-doc.ts
+++ b/api/document/js/fixup-doc.ts
@@ -2,7 +2,7 @@ import { Node } from 'prosemirror-model';
 import { EditorState, Plugin, Transaction } from 'prosemirror-state';
 
 import { renumberList } from './list-utils';
-import schema from './schema';
+import schema, { BEGIN_FOOTNOTE } from './schema';
 
 const shouldDeleteChecks = {
   list: (node: Node) => node.content.childCount === 0,
@@ -10,6 +10,9 @@ const shouldDeleteChecks = {
   para: (node: Node) => (
     node.content.childCount === 1 // Just the paraText
     && node.textContent === ''
+  ),
+  inlineFootnote: (node: Node) => (
+    node.textContent[0] !== BEGIN_FOOTNOTE
   ),
 };
 

--- a/api/document/js/parse-doc.ts
+++ b/api/document/js/parse-doc.ts
@@ -3,7 +3,7 @@ import { flatten } from 'lodash/array';
 import { Mark, Node } from 'prosemirror-model';
 
 import { ApiNode, ApiContent } from './Api';
-import schema, { factory } from './schema';
+import schema, { factory, BEGIN_FOOTNOTE } from './schema';
 
 export default function parseDoc(node): Node {
   const nodeType = node.node_type in NODE_TYPE_CONVERTERS ?
@@ -24,7 +24,7 @@ function convertFootnoteCitation(content: ApiContent): Node {
   const nested: Node[][] = (footnote.content || [])
     .map(c => convertContent(c, []));
   return schema.nodes.inlineFootnote.create({ emblem }, [
-    schema.text('\u200b'),
+    schema.text(BEGIN_FOOTNOTE),
   ].concat(flatten(nested)));
 }
 

--- a/api/document/js/parse-doc.ts
+++ b/api/document/js/parse-doc.ts
@@ -23,7 +23,9 @@ function convertFootnoteCitation(content: ApiContent): Node {
   }
   const nested: Node[][] = (footnote.content || [])
     .map(c => convertContent(c, []));
-  return schema.nodes.inlineFootnote.create({ emblem }, flatten(nested));
+  return schema.nodes.inlineFootnote.create({ emblem }, [
+    schema.text('\u200b'),
+  ].concat(flatten(nested)));
 }
 
 export function convertContent(content: ApiContent, marks: Mark[]): Node[] {

--- a/api/document/js/schema.ts
+++ b/api/document/js/schema.ts
@@ -3,6 +3,11 @@ import * as romanize from 'romanize';
 
 import { Fragment, Node, NodeSpec, Schema } from 'prosemirror-model';
 
+// We use a zero-width space to begin footnotes, which allows
+// editors to position the cursor at the beginning of a footnote,
+// before its first character.
+export const BEGIN_FOOTNOTE = '\u200b';
+
 const listSchemaNodes: { [name: string]: NodeSpec } = {
   list: {
     attrs: {

--- a/api/ereqs_admin/static/admin/module/_editor.scss
+++ b/api/ereqs_admin/static/admin/module/_editor.scss
@@ -12,8 +12,7 @@
   }
 
   .inline-footnote::before {
-    content: 'Footnote ' attr(data-emblem) ': ';
-    padding-left: 0.5em;
+    content: ' Footnote ' attr(data-emblem) ': ';
     @include font-san-serif-bold;
   }
 


### PR DESCRIPTION
This is an experimental PR atop #1021 that tries to make footnotes a bit easier to edit.

At the moment, the cursor can't actually be positioned at the very beginning of a footnote: it can be positioned either immediately before the footnote or after its first character, but not in between.  This PR attempts to resolve that in a kind of weird way: by placing a [zero-width space](https://en.wikipedia.org/wiki/Zero-width_space) at the beginning of each footnote when parsing the document, and stripping it out before serializing the document.

We also need to fix up the document when the user decides to press backspace at the beginning of a footnote, thereby removing the zero-width space.  Right now I'm simply deleting the entire footnote, but I'm only really doing that because it was trivial to implement: ideally I suspect the content of the footnote should be "lifted" into its surrounding paragraph, but I'm not sure (we should talk to design about this).

## Other things I tried

Before settling on the zero-width space solution, I tried creating a new node type called a `footnoteMarker` that would be placed at the beginning of a footnote, but that resulted in weird behavior from browsers (I also tried setting its `atom` to `true` and that didn't improve things).  We could revisit that solution again if there's something I missed, though.

## Future challenges

I'm realizing that there are downsides to making footnotes an inline node instead of a mark.  Most importantly, I'm not sure how to deal with the situation when the cursor is at the end of a footnote: right now, typing anything at the end of a footnote makes the new text be part of a footnote.  If the footnote were a mark type, we could simply add a button that toggled the active marks to not include the footnote mark, and users could treat footnotes just like they treat bold/italic/etc in other WYSIWYG editors.  However, because footnotes _aren't_ marks, I'm not really sure what to do.
