### PR TITLE
Log unfriendly Api errors in editors.

### DIFF
--- a/api/document/js/Api.ts
+++ b/api/document/js/Api.ts
@@ -14,6 +14,8 @@ export function setStatusError(e: Error) {
   const data = e['response'] && e['response']['data'];
   if (data) {
     errMsg += '\n' + makeErrorFriendly(data);
+  } else {
+    console.error(e);
   }
   setStatus(errMsg, 'editor-status-error');
 }


### PR DESCRIPTION
Currently, our `Api` class catches errors and, for ones that aren't actually related to REST API calls, just sets the current status to `An error occurred.` and does nothing else.  If the calling code doesn't re-throw the error, this is actually really unhelpful for developers, because instead of seeing useful information about an error, they just see the uninformative status message and nothing logged to the console.

There's multiple solutions to this problem. This one fixes things by just logging the error to the console if it detects that the error is an unhelpful one.
