### PR TITLE
Weird Windows fixes.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,8 @@ services:
     working_dir: /usr/src/app/styleguide
     entrypoint: .docker/deps_ok_then .docker/modify_path_then
     command: .docker/build_run_styleguide
+    environment:
+      USE_POLLING: ${USE_POLLING:-false}
     ports:
       - 3000:3000
     volumes:

--- a/styleguide/.docker/build_run_styleguide
+++ b/styleguide/.docker/build_run_styleguide
@@ -2,5 +2,5 @@
 
 set -e
 
-webpack --watch &
-fractal start --sync
+node node_modules/webpack/bin/webpack.js --watch &
+./node_modules/@frctl/fractal/bin/fractal start --sync

--- a/styleguide/.docker/deps_ok_then
+++ b/styleguide/.docker/deps_ok_then
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-if [ ! -x node_modules/.bin/deps-ok ]; then
+export DEPS_OK=./node_modules/deps-ok/bin/deps-ok.js
+
+if [ ! -x $DEPS_OK ]; then
   echo "Installing deps-ok"
   npm install --save-dev deps-ok
 fi
 
-./node_modules/.bin/deps-ok &> /dev/null
+$DEPS_OK &> /dev/null
 if [ $? -ne 0 ]; then
   echo "Installing Node dependencies"
   npm install


### PR DESCRIPTION
Strangely, the binary symlinks installed in the node environments of `ui` and `api-ui` work okay, but I'm frequently running into https://github.com/docker/for-win/issues/137 for the node environment of `styleguide`, whereby the container's processes think that the symlinks in `node_modules/.bin` are files rather than symlinks.

This works around the bizarre problem by passing a direct path to the relevant scripts.

It also exposes `USE_POLLING` to the `styleguide` container, so that polling works for webpack.
