### PR TITLE
Remove "sync_agencies" from quickstart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ Let's also load example requirements, agencies, and a whole document:
 ```bash
 bin/manage.py fetch_csv
 bin/manage.py import_reqs data.csv
-bin/manage.py sync_agencies
 bin/manage.py import_xml_doc example_docs/m_16_19_1.xml M-16-19
 bin/manage.py import_xml_doc example_docs/m_15_16.xml M-15-16
 ```


### PR DESCRIPTION
I was going through the quick-start earlier today and `sync_agencies` failed because the domain it contacts, `myit-2018.itdashboard.gov`, refused the connection.  I wasn't sure if this meant "game over" and @cmc333333 mentioned that it wasn't even used right now because we've removed agency information from the UI.

We're not removing the functionality entirely because it's likely to come back at some point, but for now it's OK to at least remove the line from the `README.md`.