### PR TITLE
Add very rudimentary PDF import

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,19 +14,6 @@ api: &API
   environment:
     DEBUG: "True"
     DATABASE_URL: postgres://postgres@localhost/postgres
-    VCAP_SERVICES: |
-      {"s3": [{
-         "credentials": {
-           "access_key_id": "LOCAL_ID",
-           "bucket": "pdfs",
-           "region": "irrelevant fake region",
-           "endpoint": "http://localhost:9100",
-           "secret_access_key": "LOCAL_KEY"
-         },
-         "label": "s3",
-         "name": "storage-s3"
-       }]
-      }
 admin-ui: &ADMIN_UI
   docker:
     - image: node:6

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ ui/lcov.info
 .next
 api/webpack-static/
 api/collected-static/
+api/media/
 
 # Data
 *.csv

--- a/api/reqs/forms.py
+++ b/api/reqs/forms.py
@@ -1,0 +1,77 @@
+import logging
+
+import reversion
+from django import forms
+from django.core.validators import FileExtensionValidator
+from django.db import connection, transaction
+
+from document.models import DocNode
+from ombpdf.document import OMBDocument
+from ombpdf.management.commands.migrate_documents import migrate_doc
+from ombpdf.semdb import to_db
+from reqs.models import Policy, Requirement, WorkflowPhases
+
+logger = logging.getLogger(__name__)
+
+
+def create_document(policy: Policy):
+    """Attempt to parse the PDF associated with this policy, applying document
+    migrations for misparses."""
+    try:
+        DocNode.objects.filter(policy=policy).delete()
+        parsed_pdf = OMBDocument.from_file(policy.document_source.file)
+        cursor = to_db(parsed_pdf, policy)
+        policy.workflow_phase = WorkflowPhases.cleanup.name
+        policy.save()
+        migrate_doc(cursor)
+    except:     # noqa - don't know the exceptions we'll raise
+        logger.exception('Error loading document')
+        policy.workflow_phase = WorkflowPhases.failed.name
+        policy.save()
+
+
+def create_requirements(policy: Policy):
+    """We're currently searching over *requirements* rather than policy text.
+    This is a big hack to keep the app functional as users upload new
+    documents. It creates a requirement for every doc node."""
+    Requirement.objects.filter(policy=policy).delete()
+    with connection.cursor() as cursor:
+        cursor.execute("""
+            INSERT INTO reqs_requirement
+                (policy_id, req_id, req_text, public,
+                 -- blank text fields
+                 policy_section, policy_sub_section, verb, impacted_entity,
+                 req_deadline, citation, req_status, precedent, related_reqs,
+                 omb_data_collection)
+            SELECT
+                document_docnode.policy_id,
+                 -- construct a unique req_id
+                 'pdf.' || CAST(document_docnode.id AS text),
+                 document_docnode.text, -- req_text
+                 true, -- public
+                 -- blank text fields
+                 '', '', '', '', '', '', '', '', '', ''
+            FROM document_docnode
+            WHERE document_docnode.policy_id = %s
+            AND document_docnode.text <> ''
+        """, [policy.pk])
+
+
+class DocumentUploadForm(forms.ModelForm):
+    document_source = forms.FileField(
+        required=True, validators=[FileExtensionValidator(['pdf'])])
+
+    class Meta:
+        model = Policy
+        fields = ['document_source']
+
+    @transaction.atomic
+    def save(self, commit=True):
+        if commit:
+            with reversion.create_revision():
+                policy = super().save()
+                create_document(policy)
+                create_requirements(policy)
+                return policy
+        else:
+            return super().save(False)

--- a/api/reqs/models.py
+++ b/api/reqs/models.py
@@ -158,6 +158,13 @@ class Policy(models.Model):
     def has_published_document(self):
         return self.workflow_phase == WorkflowPhases.published.name
 
+    @property
+    def has_no_document(self):
+        return self.workflow_phase in (
+            WorkflowPhases.failed.name,
+            WorkflowPhases.no_doc.name,
+        )
+
     def __str__(self):
         text = self.title_with_number
         if len(text) > 100:

--- a/api/reqs/templates/reqs/admin/document_upload.html
+++ b/api/reqs/templates/reqs/admin/document_upload.html
@@ -1,0 +1,23 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+<div id="content-main">
+  <form enctype="multipart/form-data" method="POST">
+    {% csrf_token %}
+    <div>
+      {{ form.non_field_errors }}
+      <div class="fieldWrapper">
+        {{ form.document_source.errors }}
+        <label for="{{ form.document_source.id_for_label }}">Document:</label>
+        <input
+          accept=".pdf"
+          id="{{ form.document_source.id_for_label }}"
+          name="{{ form.document_source.html_name }}"
+          type="file"
+        />
+      </div>
+      <input type="submit" value="Submit" />
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/api/reqs/tests/admin_tests.py
+++ b/api/reqs/tests/admin_tests.py
@@ -1,6 +1,10 @@
+from unittest.mock import Mock
+
+from django.core.files.uploadedfile import SimpleUploadedFile
 from model_mommy import mommy
 
 from document.tree import DocCursor
+from reqs import forms
 from reqs.models import Policy
 
 
@@ -14,7 +18,25 @@ def test_policy_edit_doc_button(admin_client):
     assert b'Save and edit document' in result.content
 
 
-def test_policy_redirect(admin_client):
+def test_policy_redirect_no_doc(admin_client):
+    policy = mommy.make(Policy, slug='some-policy')
+
+    result = admin_client.post(f'/admin/reqs/policy/{policy.pk}/change/', {
+       'title': policy.title,
+       'omb_policy_id': '',
+       'issuance': policy.issuance.isoformat(),
+       'sunset': '',
+       'public': 'on',
+       'workflow_phase': 'no_doc',
+       '_savethendoc': 'Save and edit document',
+    })
+
+    assert result.status_code == 302
+    assert result['Location'] == (f"/admin/reqs/policy/{policy.pk}/"
+                                  "document_upload")
+
+
+def test_policy_redirect_to_editor(admin_client):
     policy = mommy.make(Policy, slug='some-policy')
     root = DocCursor.new_tree('root', policy=policy)
     root.nested_set_renumber()
@@ -34,3 +56,31 @@ def test_policy_redirect(admin_client):
 
     policy.refresh_from_db()
     assert policy.title == 'Some new policy title'
+
+
+def test_document_upload_404(admin_client):
+    result = admin_client.get(f'/admin/reqs/policy/010101/document_upload')
+    assert result.status_code == 404
+
+
+def test_document_upload_get(admin_client):
+    policy = mommy.make(Policy)
+    result = admin_client.get(f'/admin/reqs/policy/{policy.pk}/'
+                              'document_upload')
+    assert b'form' in result.content
+    assert b'accept=".pdf"' in result.content
+    assert b'document_source' in result.content
+
+
+def test_document_upload_post(admin_client, monkeypatch):
+    monkeypatch.setattr(forms, 'create_document', Mock())
+
+    policy = mommy.make(Policy, slug='some-policy')
+    pdf = SimpleUploadedFile('a-file.pdf', b'contents')
+    result = admin_client.post(
+        f'/admin/reqs/policy/{policy.pk}/document_upload',
+        {'document_source': pdf},
+    )
+
+    assert result.status_code == 302
+    assert result['Location'] == '/admin/document-editor/some-policy'

--- a/api/reqs/tests/forms_tests.py
+++ b/api/reqs/tests/forms_tests.py
@@ -1,0 +1,93 @@
+from unittest.mock import Mock, call
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from model_mommy import mommy
+
+from document.tree import DocCursor
+from reqs import forms
+from reqs.models import Policy, Requirement
+
+
+@pytest.mark.django_db
+def test_document_source_is_set(monkeypatch):
+    monkeypatch.setattr(forms, 'create_document', Mock())
+    monkeypatch.setattr(forms, 'create_requirements', Mock())
+    policy = mommy.make(Policy)
+    upload = SimpleUploadedFile('a_filename.pdf', b'content here')
+
+    form = forms.DocumentUploadForm(
+        None, files={'document_source': upload}, instance=policy)
+    assert form.is_valid()
+    result = form.save()
+
+    assert result.pk == policy.pk
+    assert result.document_source.name.startswith('a_filename')
+    assert result.document_source.name.endswith('.pdf')
+    assert result.document_source.read() == b'content here'
+    assert forms.create_document.called
+    assert forms.create_requirements.called
+
+
+def test_file_validation():
+    policy = mommy.prepare(Policy)
+    upload = SimpleUploadedFile('a_jpeg.jpg', b'content here')
+
+    form = forms.DocumentUploadForm(
+        None, files={'document_source': upload}, instance=policy)
+    assert not form.is_valid()
+
+
+@pytest.mark.django_db
+def test_create_document_success(monkeypatch):
+    monkeypatch.setattr(forms, 'OMBDocument', Mock())
+    monkeypatch.setattr(forms, 'to_db', Mock())
+    monkeypatch.setattr(forms, 'migrate_doc', Mock())
+    policy = mommy.make(
+        Policy, document_source=SimpleUploadedFile('a.pdf', b'aaa'))
+    doc = DocCursor.new_tree('policy', policy=policy)
+    doc.add_child('para', text='Content')
+    doc.nested_set_renumber()
+    forms.to_db.return_value = doc
+
+    forms.create_document(policy)
+
+    assert forms.OMBDocument.from_file.call_args ==\
+        call(policy.document_source.file)
+    assert forms.to_db.called
+    assert policy.workflow_phase == 'cleanup'
+    assert forms.migrate_doc.called
+
+
+@pytest.mark.django_db
+def test_create_document_failure_pdf(monkeypatch):
+    monkeypatch.setattr(forms, 'OMBDocument', Mock())
+    forms.OMBDocument.from_file.side_effect = ValueError('oh noes')
+
+    policy = mommy.make(
+        Policy, document_source=SimpleUploadedFile('a.pdf', b'aaa'))
+    forms.create_document(policy)
+
+    assert policy.workflow_phase == 'failed'
+
+
+@pytest.mark.django_db
+def test_create_requirements():
+    policy = mommy.make(Policy)
+    mommy.make(Requirement, policy=policy, _quantity=5)
+    doc = DocCursor.new_tree('policy', policy=policy)
+    doc.add_child('para', text='First paragraph')
+    doc.add_child('sec')
+    doc['sec_1'].add_child('heading', text='A section')
+    doc['sec_1'].add_child('para', text='Second paragraph')
+    doc['sec_1'].add_child('para', text='Final paragraph')
+    doc.nested_set_renumber()
+    # These will be deleted
+    assert Requirement.objects.filter(policy=policy).count() == 5
+
+    forms.create_requirements(policy)
+
+    assert Requirement.objects.filter(policy=policy).count() == 4
+    assert set(Requirement.objects.values_list('req_text', flat=True)) == {
+        'First paragraph', 'A section', 'Second paragraph', 'Final paragraph',
+    }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,16 +4,6 @@ services:
     image: postgres:9.4
     volumes:
       - database_data:/var/lib/postgresql/data
-  # We've temporarily removed pdf upload, so we don't need
-  # minio (a mock S3 server) for now.
-  # minio:
-  #   image: minio/minio
-  #   environment:
-  #       - MINIO_ACCESS_KEY=LOCAL_ID
-  #       - MINIO_SECRET_KEY=LOCAL_KEY
-  #   command: server --address ':9100' minio-test
-  #   ports:
-  #     - 9100:9100
   api:
     image: python:3.6.4
     working_dir: /usr/src/app/api
@@ -36,26 +26,13 @@ services:
       VCAP_APPLICATION: >
         {"uris": ["localhost", "0.0.0.0", "127.0.0.1", "api"]}
       VCAP_SERVICES: >
-        {"config": [{"credentials": {"DJANGO_SECRET_KEY": "NotASecret"}}],
-         "s3": [{
-           "credentials": {
-             "access_key_id": "LOCAL_ID",
-             "bucket": "pdfs",
-             "region": "irrelevant fake region",
-             "endpoint": "http://minio:9100",
-             "secret_access_key": "LOCAL_KEY"
-           },
-           "label": "s3",
-           "name": "storage-s3"
-         }]
-        }
+        {"config": [{"credentials": {"DJANGO_SECRET_KEY": "NotASecret"}}]}
     ports:
       - 8001:8001
     volumes:
       - .:/usr/src/app:delegated
     depends_on:
       - persistent_db
-      # - minio
       - api-ui
   api-ui:
     image: node:8

--- a/ui/components/policies/policy-view.js
+++ b/ui/components/policies/policy-view.js
@@ -4,13 +4,8 @@ import React from 'react';
 import Policy from '../../util/policy';
 import Link from '../link';
 
-export default function PolicyView({ policy, topicsIds }) {
-  const linkParams = {
-    policy__id__in: policy.id,
-    topics__id__in: topicsIds,
-  };
-  const relevantReqCount = policy.relevantReqs >= 100 ? '99+' : policy.relevantReqs;
-  const countClass = relevantReqCount === '99+' ? 'ninety-nine-plus' : '';
+export default function PolicyView({ policy }) {
+  const percentMatch = (100 * (policy.relevantReqs / policy.totalReqs)).toFixed();
   let policyTitle = policy.titleWithNumber;
 
   if (policy.hasPublishedDocument) {
@@ -27,18 +22,7 @@ export default function PolicyView({ policy, topicsIds }) {
         <h2 className="mt0 mb3">{policyTitle}</h2>
         <div className="clearfix">
           <div className="requirements-links mb1 sm-col sm-col-12 md-col-8">
-            <div className="circle-bg border gray-border center p1">
-              <Link
-                route="requirements"
-                params={linkParams}
-                aria-label="Relevant requirements"
-                className={countClass}
-              >
-                {relevantReqCount}
-              </Link>
-            </div> of&nbsp;
-            {policy.totalReqs} requirements
-             match your search
+            {percentMatch}% match
           </div>
           <div className="sm-col sm-col-12 md-col-4 right-align">
             <Link href={policy.originalUrl}>


### PR DESCRIPTION
If the policy is marked as having no document (or having a failed import), selecting the "Save and Edit Document" button will redirect to a pdf uploader page. The user can then upload a pdf, which will be processed **in the same thread**. Processing involves:
* Converting the pdf to our internal DocStructs
* Running the document migrations on the result (these'll eventually be part of the import process)
* Creating a "Requirement" for every text node (hacky work-around for our current search)

If the pdf is too large, the request will die and the user will be (understandably) confused. Alas.

This also modifies the UI to stop linking to the requirements listing pages. This uses a percentage of *requirements* that match. Again, this will likely be confusing, but we don't have time to rework search yet.
<img width="745" alt="screen shot 2018-03-19 at 10 43 16 am" src="https://user-images.githubusercontent.com/326918/37602120-1c72d47a-2b62-11e8-8262-3144e7e64731.png">


