### PR TITLE
Add brief notes about CloudFront headers.

### DIFF
--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -16,6 +16,9 @@ applications:
     command: ./run_api.sh
     routes:
       - route: omb-eregs-api.app.cloud.gov
+      # When creating this service, be sure to configure it to pass two headers:
+      # Accept: Required to get the correct data format
+      # Referer: Required for CSRF validation
       - route: policy-api.cio.gov
     env:
       NEW_RELIC_APP_NAME: OMB Prod API/Admin


### PR DESCRIPTION
Unfortunately, the XML editor wasn't working due to CloudFront stripping the
Accept header. This is fixed in prod, but worth noting somewhere, as it only
affects one environment (and is therefore easy to miss).