### PR TITLE
update admin.py to add URI to PolicyAdmin fields

### DIFF
--- a/api/reqs/admin.py
+++ b/api/reqs/admin.py
@@ -23,6 +23,7 @@ class PolicyAdmin(EReqsVersionAdmin):
         'issuance',
         'sunset',
         'workflow_phase',
+        'uri'
     ]
 
     def response_post_save_change(self, request, obj):


### PR DESCRIPTION
allows administrator editing file to change the destination of "see original" link for uploaded policies